### PR TITLE
Fix issue #13 JWT tokens expire during long-running TOC generation workflow

### DIFF
--- a/frontend/src/app/dashboard/books/[bookId]/edit-toc/page.tsx
+++ b/frontend/src/app/dashboard/books/[bookId]/edit-toc/page.tsx
@@ -150,12 +150,9 @@ export default function EditTOCPage({ params }: { params: Promise<{ bookId: stri
   useEffect(() => {
     const fetchTOC = async () => {
       try {
-        // Set up auth token for the API client
-        const token = await getToken();
-        if (token) {
-          bookClient.setAuthToken(token);
-        }
-        
+        // Set up token provider for automatic token refresh
+        bookClient.setTokenProvider(getToken);
+
         // Fetch TOC from the backend API
         const response = await bookClient.getToc(bookId);
         
@@ -410,14 +407,11 @@ export default function EditTOCPage({ params }: { params: Promise<{ bookId: stri
   };  const handleSaveTOC = async () => {
     setIsLoading(true);
     setError('');
-    
+
     try {
-      // Set up auth token for the API client
-      const token = await getToken();
-      if (token) {
-        bookClient.setAuthToken(token);
-      }
-      
+      // Set up token provider for automatic token refresh
+      bookClient.setTokenProvider(getToken);
+
       // Convert local Chapter format to API TocData format
       const tocData = convertChaptersToTocData(toc);
       console.log('TOC to save:', tocData);

--- a/frontend/src/app/dashboard/books/[bookId]/export/page.tsx
+++ b/frontend/src/app/dashboard/books/[bookId]/export/page.tsx
@@ -59,12 +59,9 @@ export default function ExportBookPage({ params }: { params: Promise<{ bookId: s
   useEffect(() => {
     const fetchBookDetails = async () => {
       try {
-        // Get auth token
-        const token = await getToken();
-        if (token) {
-          bookClient.setAuthToken(token);
-        }
-        
+        // Set up token provider for automatic token refresh
+        bookClient.setTokenProvider(getToken);
+
         // Fetch book details
         const bookData = await bookClient.getBook(bookId);
         setBook(bookData);

--- a/frontend/src/app/dashboard/books/[bookId]/page.tsx
+++ b/frontend/src/app/dashboard/books/[bookId]/page.tsx
@@ -101,11 +101,8 @@ export default function BookPage({ params }: { params: Promise<{ bookId: string 
     const fetchBookData = async () => {
       setIsLoading(true);
       try {
-        // Set up auth token
-        const token = await getToken();
-        if (token) {
-          bookClient.setAuthToken(token);
-        }
+        // Set up token provider for automatic token refresh
+        bookClient.setTokenProvider(getToken);
 
         // Fetch book details
         const bookData: BookProject = await bookClient.getBook(bookId);

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -29,11 +29,8 @@ export default function Dashboard() {
 
     setIsLoading(true);
     try {
-      // Get Clerk session token for API authentication
-      const token = await getToken();
-      if (token) {
-        bookClient.setAuthToken(token);
-      }
+      // Set up token provider for automatic token refresh
+      bookClient.setTokenProvider(getToken);
       const books = await bookClient.getUserBooks();
       setProjects(books);
       setError(null);
@@ -80,12 +77,9 @@ export default function Dashboard() {
   
   const handleDeleteBook = async (bookId: string) => {
     try {
-      // Get Clerk session token for API authentication
-      const token = await getToken();
-      if (token) {
-        bookClient.setAuthToken(token);
-      }
-      
+      // Set up token provider for automatic token refresh
+      bookClient.setTokenProvider(getToken);
+
       await bookClient.deleteBook(bookId);
       toast.success('Book deleted successfully');
       

--- a/frontend/src/components/toc/ClarifyingQuestions.tsx
+++ b/frontend/src/components/toc/ClarifyingQuestions.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useAuth } from '@clerk/nextjs';
 import { QuestionResponse } from '@/types/toc';
 import { bookClient } from '@/lib/api/bookClient';
 
@@ -10,10 +11,16 @@ interface ClarifyingQuestionsProps {
 }
 
 export default function ClarifyingQuestions({ questions, onSubmit, isLoading, bookId }: ClarifyingQuestionsProps) {
+  const { getToken } = useAuth();
   const [responses, setResponses] = useState<Record<string, string>>({});
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [isSaving, setIsSaving] = useState(false);
   const [lastSaved, setLastSaved] = useState<string | null>(null);
+
+  // Set up token provider for automatic token refresh
+  useEffect(() => {
+    bookClient.setTokenProvider(getToken);
+  }, [getToken]);
 
   // Load existing responses when component mounts
   useEffect(() => {

--- a/frontend/src/components/toc/TocGenerationWizard.tsx
+++ b/frontend/src/components/toc/TocGenerationWizard.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
+import { useAuth } from '@clerk/nextjs';
 import bookClient from '@/lib/api/bookClient';
 import {
   WizardStep,
@@ -22,12 +23,18 @@ interface TocGenerationWizardProps {
 
 export default function TocGenerationWizard({ bookId }: TocGenerationWizardProps) {
   const router = useRouter();
+  const { getToken } = useAuth();
   const { trackOperation } = usePerformanceTracking();
   const [wizardState, setWizardState] = useState<WizardState>({
     step: WizardStep.CHECKING_READINESS,
     questionResponses: [],
     isLoading: true
   });
+
+  // Set up token provider for automatic token refresh
+  useEffect(() => {
+    bookClient.setTokenProvider(getToken);
+  }, [getToken]);
 
   const generateQuestions = useCallback(async () => {
     try {


### PR DESCRIPTION
…token refresh

This commit resolves issue #13 where JWT tokens expire during long-running TOC generation workflows, causing 401 authentication errors.

Changes:
- Added token provider support to BookClient class
  - New private property: tokenProvider
  - New method: setTokenProvider() for setting token provider function
  - New private method: getAuthToken() that fetches fresh tokens
  - Made getHeaders() async to support token fetching
  - Updated all API methods to await getHeaders()

- Updated TocGenerationWizard component
  - Added useAuth hook to get getToken function
  - Set up token provider on mount with useEffect

- Updated ClarifyingQuestions component
  - Added useAuth hook to get getToken function
  - Set up token provider on mount with useEffect

- Updated Dashboard page
  - Replaced manual token fetching with setTokenProvider in fetchBooks
  - Replaced manual token fetching with setTokenProvider in handleDeleteBook

- Updated Book Details page
  - Replaced manual token fetching with setTokenProvider in fetchBookData

- Updated Edit TOC page
  - Replaced manual token fetching with setTokenProvider in fetchTOC
  - Replaced manual token fetching with setTokenProvider in handleSaveTOC

- Updated Export page
  - Replaced manual token fetching with setTokenProvider in fetchBookDetails

Benefits:
- Automatic token refresh before each API call prevents expiration errors
- Backward compatible: existing setAuthToken() method still works
- Solves token expiration in multi-step workflows (analyze-summary → toc-readiness → generate-questions → generate-toc)
- No changes needed to workflow logic, only authentication setup

Root Cause:
BookClient was caching JWT tokens via setAuthToken() and reusing them for all subsequent API calls. In TOC generation, when analyze-summary takes 11+ seconds, the token expires before toc-readiness is called, resulting in 401 errors.

Solution:
The token provider pattern allows BookClient to fetch fresh tokens from Clerk before each API call, ensuring tokens never expire during long-running operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated authentication token handling system across dashboard pages and components to use an automatic token provider mechanism instead of manual token setting on each API call.
  * Enhanced API client to support dynamic token resolution and streamlined token lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->