### PR TITLE
fix(test): valid 32+ char BETTER_AUTH_SECRET to green backend CI (#102)

### DIFF
--- a/backend/run_unit_tests.py
+++ b/backend/run_unit_tests.py
@@ -11,7 +11,7 @@ import os
 os.environ['DATABASE_URL'] = 'mongodb://localhost:27017'
 os.environ['DATABASE_NAME'] = 'auto_author_test'
 os.environ['OPENAI_AUTOAUTHOR_API_KEY'] = 'test-key'
-os.environ['BETTER_AUTH_SECRET'] = 'test-secret-key-for-better-auth'
+os.environ['BETTER_AUTH_SECRET'] = 'test-secret-for-ci-minimum-32-characters-long-safe-for-testing'
 os.environ['BETTER_AUTH_URL'] = 'http://localhost:3000'
 os.environ['BETTER_AUTH_ISSUER'] = 'better-auth'
 

--- a/backend/tests/test_services_isolated.py
+++ b/backend/tests/test_services_isolated.py
@@ -15,7 +15,7 @@ from app.core.config import settings
 
 # Set environment variables for testing
 os.environ['OPENAI_AUTOAUTHOR_API_KEY'] = 'test-key'
-os.environ['BETTER_AUTH_SECRET'] = 'test-secret-key-for-better-auth'
+os.environ['BETTER_AUTH_SECRET'] = 'test-secret-for-ci-minimum-32-characters-long-safe-for-testing'
 
 async def test_ai_service():
     """Test AI service draft generation"""

--- a/backend/tests/test_services_summary.py
+++ b/backend/tests/test_services_summary.py
@@ -10,7 +10,7 @@ import sys
 os.environ['DATABASE_URL'] = 'mongodb://localhost:27017'
 os.environ['DATABASE_NAME'] = 'auto_author_test'
 os.environ['OPENAI_AUTOAUTHOR_API_KEY'] = 'test-key'
-os.environ['BETTER_AUTH_SECRET'] = 'test-secret-key-for-better-auth'
+os.environ['BETTER_AUTH_SECRET'] = 'test-secret-for-ci-minimum-32-characters-long-safe-for-testing'
 os.environ['BETTER_AUTH_URL'] = 'http://localhost:3000'
 os.environ['BETTER_AUTH_ISSUER'] = 'better-auth'
 


### PR DESCRIPTION
## Summary
Fixes #102. The **Backend Tests** CI job was red because four `TestProductionSecurityValidation` tests failed at `Settings()` construction with `BETTER_AUTH_SECRET String should have at least 32 characters`.

## Root cause
Three test modules assigned the **31-char** value `test-secret-key-for-better-auth` to `os.environ['BETTER_AUTH_SECRET']` at **module import time**:
- `backend/run_unit_tests.py`
- `backend/tests/test_services_summary.py`
- `backend/tests/test_services_isolated.py`

During `pytest tests/` collection, importing those modules pollutes the global environment for the whole session. The four `test_bypass_auth_allowed_*` tests build `Settings()` *without* overriding the secret via monkeypatch, so they inherited the too-short value and raised `ValidationError` (`min_length=32`). (The `production` tests pass because they set a valid secret explicitly.)

## Fix
Replace the 31-char value with the canonical CI secret already used by the `config.py` default, `tests.yml`, and `test_config.py`:
`test-secret-for-ci-minimum-32-characters-long-safe-for-testing`. Test-only, 3-line change.

## Verification (evidence)
Reproduced RED (no local `.env`, mirroring CI):
```
4 failed ... test_bypass_auth_allowed_in_{development,test,staging} + _when_env_not_set
  BETTER_AUTH_SECRET String should have at least 32 characters
```
After fix:
- `pytest tests/ -k bypass_auth` → **9 passed**
- `pytest tests/test_core/test_security.py` → **22 passed**
- Full suite `pytest tests/` → **415 passed, 17 skipped, 0 failed**
- `grep -rn 'test-secret-key-for-better-auth'` → **no occurrences remain**

## Acceptance criteria
- [x] `pytest tests/test_core/test_security.py` passes locally (and will in CI)
- [x] Backend Tests job green (coverage gate excluded — `continue-on-error`)
- [x] No 31-char `BETTER_AUTH_SECRET` remains in test fixtures or CI env

## Known limitations / out of scope
- Backend coverage (~49% vs 85%) is pre-existing and tracked separately (#93); the coverage step is `continue-on-error` and unaffected here.
- Pre-existing ruff lint warnings in the touched files (unused imports, f-strings without placeholders) are unrelated to this one-line value change and left as-is to keep the diff minimal; the Backend Tests CI job runs pytest only, no ruff step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test environment configuration for CI/CD compatibility and security requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->