### PR TITLE
test(security): cover auth/session error branches to 100% (#116)

### DIFF
--- a/backend/tests/test_core/test_security.py
+++ b/backend/tests/test_core/test_security.py
@@ -6,7 +6,7 @@ JWT-based authentication has been removed - all auth is now cookie/session-based
 """
 
 import pytest
-from unittest.mock import Mock, patch, AsyncMock, PropertyMock
+from unittest.mock import Mock, patch, PropertyMock
 from fastapi import HTTPException, Request
 
 from app.core.security import (
@@ -219,6 +219,88 @@ class TestGetCurrentUserFromSession:
 
         assert result == created_user
         mock_create_user.assert_called_once()
+
+    @patch("app.core.security.validate_better_auth_session")
+    @patch("app.core.security.get_better_auth_user")
+    @patch("app.db.user.get_user_by_auth_id")
+    @patch("app.core.config.settings")
+    async def test_get_current_user_from_session_db_error(
+        self, mock_settings, mock_get_user, mock_get_auth_user, mock_validate
+    ):
+        """DB error while fetching the application user surfaces as a 500."""
+        mock_settings.BYPASS_AUTH = False
+        mock_validate.return_value = {"userId": "user_123"}
+        mock_get_auth_user.return_value = {"id": "user_123", "email": "test@example.com"}
+        mock_get_user.side_effect = Exception("connection lost")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user_from_session(Mock(spec=Request))
+
+        assert exc_info.value.status_code == 500
+        assert "Error fetching user" in exc_info.value.detail
+
+    @patch("app.core.security.validate_better_auth_session")
+    @patch("app.core.security.get_better_auth_user")
+    @patch("app.db.user.get_user_by_auth_id")
+    @patch("app.core.config.settings")
+    async def test_get_current_user_from_session_unknown_user(
+        self, mock_settings, mock_get_user, mock_get_auth_user, mock_validate
+    ):
+        """Valid session but user missing from both backend and better-auth -> 401."""
+        mock_settings.BYPASS_AUTH = False
+        mock_validate.return_value = {"userId": "user_123"}
+        mock_get_user.return_value = None
+        mock_get_auth_user.return_value = None
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user_from_session(Mock(spec=Request))
+
+        assert exc_info.value.status_code == 401
+        assert "User not found" in exc_info.value.detail
+
+    @patch("app.core.security.validate_better_auth_session")
+    @patch("app.core.security.get_better_auth_user")
+    @patch("app.db.user.get_user_by_auth_id")
+    @patch("app.core.config.settings")
+    async def test_get_current_user_from_session_auto_create_missing_email(
+        self, mock_settings, mock_get_user, mock_get_auth_user, mock_validate
+    ):
+        """Auto-create aborts with 400 when better-auth user has no email."""
+        mock_settings.BYPASS_AUTH = False
+        mock_validate.return_value = {"userId": "user_123"}
+        mock_get_user.return_value = None
+        mock_get_auth_user.return_value = {"id": "user_123", "name": "No Email"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user_from_session(Mock(spec=Request))
+
+        assert exc_info.value.status_code == 400
+        assert "missing email" in exc_info.value.detail
+
+    @patch("app.core.security.validate_better_auth_session")
+    @patch("app.core.security.get_better_auth_user")
+    @patch("app.db.user.get_user_by_auth_id")
+    @patch("app.db.user.create_user")
+    @patch("app.core.config.settings")
+    async def test_get_current_user_from_session_auto_create_failure(
+        self, mock_settings, mock_create_user, mock_get_user, mock_get_auth_user, mock_validate
+    ):
+        """A failure during auto-create surfaces as a 500."""
+        mock_settings.BYPASS_AUTH = False
+        mock_validate.return_value = {"userId": "user_123"}
+        mock_get_user.return_value = None
+        mock_get_auth_user.return_value = {
+            "id": "user_123",
+            "email": "test@example.com",
+            "name": "Test User",
+        }
+        mock_create_user.side_effect = Exception("insert failed")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user_from_session(Mock(spec=Request))
+
+        assert exc_info.value.status_code == 500
+        assert "Failed to create user account" in exc_info.value.detail
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Closes #116. Adds focused tests for the auth/session module `app/core/security.py`, raising its line coverage from **84% → 100%**. Tests only — no production behavior changes.

## What changed
Four new tests in `tests/test_core/test_security.py` covering the previously-uncovered error/denial branches of `get_current_user_from_session`:

| Branch | Scenario | Expected |
|--------|----------|----------|
| `138-140` | DB error while fetching application user | 500 "Error fetching user" |
| `148-149` | Valid session, user absent from both backend **and** better-auth | 401 "User not found" |
| `168-169` | Auto-create with better-auth user missing email | 400 "missing email" |
| `195-199` | Auto-create raises during `create_user` | 500 "Failed to create user account" |

Also removed a pre-existing unused `AsyncMock` import in the same file (clean lint).

## Acceptance criteria
- [x] `app/core/security.py` line coverage ≥ 85% (now **100%**, verified via `--cov-report=term-missing`)
- [x] Both success and failure/denial branches covered for session auth and role checks
- [x] No production code changes (tests only)
- [x] All backend tests pass: `435 passed, 17 skipped`
- [x] Follows the file's established pattern (mock-based injection for error branches that can't be triggered with real services)

## Verification
```
app/core/security.py   74   0   100%
28 passed   # security tests
435 passed, 17 skipped   # full backend suite
```

## Known limitations
- This PR does **not** by itself make the repo-wide `backend-coverage` (≥85%) pre-commit gate green — backend remains ~41% overall. This is one input toward that capstone; the commit uses the documented `--no-verify` workflow described in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)