### PR TITLE
fix(toc): generate-toc reads question responses from request body (#105)

### DIFF
--- a/backend/app/api/endpoints/books.py
+++ b/backend/app/api/endpoints/books.py
@@ -1196,9 +1196,15 @@ async def generate_table_of_contents(
             status_code=400, detail="Book summary is required for TOC generation"
         )
 
-    # Check if question responses exist
-    question_responses = book.get("question_responses", {})
-    responses = question_responses.get("responses", [])
+    # Question responses come from the clarifying-questions wizard, which sends
+    # them in the request body ({"question_responses": [{question, answer}, ...]}).
+    # Fall back to any responses persisted on the book. Previously this only read
+    # the persisted field, but the wizard never persists them, so TOC generation
+    # always failed with "Question responses are required".
+    responses = data.get("question_responses") or []
+    if not responses:
+        persisted = book.get("question_responses", {})
+        responses = persisted.get("responses", [])
     if not responses:
         raise HTTPException(
             status_code=400, detail="Question responses are required for TOC generation"

--- a/backend/tests/test_api/test_routes/test_toc_generation.py
+++ b/backend/tests/test_api/test_routes/test_toc_generation.py
@@ -87,6 +87,54 @@ async def test_generate_toc_endpoint(mock_generate_toc, async_client_factory):
 
 @pytest.mark.asyncio
 @patch("app.services.ai_service.AIService.generate_toc_from_summary_and_responses")
+async def test_generate_toc_accepts_responses_from_request_body(
+    mock_generate_toc, async_client_factory
+):
+    """The clarifying-questions wizard sends responses in the request body and
+    never persists them. generate-toc must read the body payload, not only the
+    persisted book field (regression: it always 400'd 'responses required')."""
+    mock_generate_toc.return_value = MOCK_TOC_RESPONSE
+
+    client = await async_client_factory()
+    create_resp = await client.post(
+        "/api/v1/books/",
+        json={
+            "title": "Body Responses Book",
+            "description": "Testing body-supplied question responses.",
+            "genre": "Test",
+            "target_audience": "Developers",
+        },
+    )
+    assert create_resp.status_code == 201
+    book_id = create_resp.json()["id"]
+
+    summary_resp = await client.patch(
+        f"/api/v1/books/{book_id}/summary",
+        json={"summary": "A sufficiently long summary for TOC generation testing."},
+    )
+    assert summary_resp.status_code == 200
+
+    # No PUT /question-responses — responses are provided in the body only,
+    # exactly as the ClarifyingQuestions wizard does.
+    toc_resp = await client.post(
+        f"/api/v1/books/{book_id}/generate-toc",
+        json={
+            "question_responses": [
+                {"question": "Q1", "answer": "Answer 1"},
+                {"question": "Q2", "answer": "Answer 2"},
+            ]
+        },
+    )
+    assert toc_resp.status_code == 200, toc_resp.text
+    assert toc_resp.json()["success"] is True
+    assert mock_generate_toc.called
+    assert len(mock_generate_toc.call_args[0][1]) == 2  # body responses used
+
+    await client.delete(f"/api/v1/books/{book_id}")
+
+
+@pytest.mark.asyncio
+@patch("app.services.ai_service.AIService.generate_toc_from_summary_and_responses")
 async def test_toc_generation_workflow_e2e(mock_generate_toc, async_client_factory):
     # Configure the mock to return our test TOC
     mock_generate_toc.return_value = MOCK_TOC_RESPONSE

--- a/frontend/tests/e2e/staging/complete-user-journey.spec.ts
+++ b/frontend/tests/e2e/staging/complete-user-journey.spec.ts
@@ -6,6 +6,7 @@ import {
   openChapterEditor,
   answerFirstChapterQuestion,
   readFirstChapterAnswer,
+  READY_SUMMARY,
 } from './fixtures/journey.helpers';
 
 /**
@@ -35,13 +36,7 @@ test.describe('Complete Authoring Journey', () => {
     expect(bookId).toMatch(/^[a-f0-9]+$/);
 
     // 2. Add a summary and advance to the TOC wizard.
-    await addSummary(
-      page,
-      bookId,
-      'A complete-journey test book about building reliable web applications. It walks readers ' +
-        'from project setup through testing, deployment, and observability, with concrete examples ' +
-        'in each chapter so the table of contents has plenty of structure to generate from.'
-    );
+    await addSummary(page, bookId, READY_SUMMARY);
 
     // 3. Generate and accept a table of contents.
     await completeTocWizard(page);

--- a/frontend/tests/e2e/staging/fixtures/journey.helpers.ts
+++ b/frontend/tests/e2e/staging/fixtures/journey.helpers.ts
@@ -19,6 +19,24 @@ const BOOK_DETAIL_RE = /\/dashboard\/books\/[a-f0-9]+(?:[/?#]|$)/;
 const AI_TIMEOUT = 90_000;
 
 /**
+ * A detailed, well-structured summary that the AI readiness analyzer reliably
+ * judges ready (meets_minimum_requirements=true): clear topic + scope, explicit
+ * part/chapter structure, named audience, and a basic→advanced progression.
+ * A thin summary gets a (successful) "not ready" verdict and stalls the wizard.
+ */
+export const READY_SUMMARY =
+  'This is a practical, hands-on guide to machine learning for working software engineers who ' +
+  'already know how to code but have no formal ML background. The book progresses from ' +
+  'fundamentals to production. Part 1 introduces core concepts: what machine learning is, ' +
+  'supervised versus unsupervised learning, and the typical model lifecycle. Part 2 covers data ' +
+  'preparation, feature engineering, and how to split and validate datasets. Part 3 walks through ' +
+  'building and evaluating models — linear models, decision trees, and neural networks — with ' +
+  'worked Python examples in each chapter. Part 4 focuses on getting models into production: ' +
+  'packaging, serving them behind an API, monitoring for drift, and retraining. Each chapter ends ' +
+  'with exercises and a runnable example so readers can apply the material immediately. By the end, ' +
+  'an engineer can take a business problem, build a model, evaluate it honestly, and ship it.';
+
+/**
  * Create a book through the dashboard modal and return its id.
  *
  * The dashboard closes the modal and navigates to the book detail page after a

--- a/frontend/tests/e2e/staging/regressions.spec.ts
+++ b/frontend/tests/e2e/staging/regressions.spec.ts
@@ -6,6 +6,7 @@ import {
   openChapterEditor,
   answerFirstChapterQuestion,
   readFirstChapterAnswer,
+  READY_SUMMARY,
 } from './fixtures/journey.helpers';
 
 /**
@@ -115,13 +116,7 @@ test.describe('Issue #83 regressions', () => {
 
     const answer = `Persistence check ${Date.now()}`;
     const bookId = await createBook(page, `E2E #54 Book ${Date.now()}`);
-    await addSummary(
-      page,
-      bookId,
-      'A regression test book about practical machine learning for working software engineers. ' +
-        'It covers supervised and unsupervised learning, model evaluation, and shipping models to production, ' +
-        'with hands-on examples in Python so readers can follow along chapter by chapter.'
-    );
+    await addSummary(page, bookId, READY_SUMMARY);
     await completeTocWizard(page);
     await openChapterEditor(page, bookId);
     await answerFirstChapterQuestion(page, answer);


### PR DESCRIPTION
Follow-up to #134. Fixes the next blocker found while verifying the staging journey.

**Real bug:** the clarifying-questions wizard sends responses in the POST body and
never persists them, but `generate-toc` only read the persisted
`book.question_responses` field — so every wizard-driven TOC generation returned
`400 "Question responses are required"`. This is why the TOC wizard was untestable.

- `generate-toc`: prefer body `question_responses`, fall back to persisted. +1 regression test (body-only path).
- staging E2E: shared `READY_SUMMARY` the AI readiness analyzer reliably judges ready.

Verified: backend toc-generation tests pass (3/3). Staging journey re-run after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)