### PR TITLE
test(auth): cover auth/session validation cluster to 100% (#123)

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -46,6 +46,12 @@ def fake_get_rate_limiter(limit: int = 10, window: int = 60):
     return _always_allow
 
 
+# Preserve the real limiter so tests that need to exercise the actual
+# rate-limiting logic can reach it (the override below hides it everywhere else).
+# Idempotent: conftest can be imported more than once, so stash the genuine
+# function on the module and never let a re-import capture the fake.
+real_get_rate_limiter = getattr(deps, "_real_get_rate_limiter", deps.get_rate_limiter)
+deps._real_get_rate_limiter = real_get_rate_limiter
 deps.get_rate_limiter = fake_get_rate_limiter
 import pytest, pytest_asyncio
 from httpx import AsyncClient, ASGITransport

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -54,6 +54,15 @@ real_get_rate_limiter = getattr(deps, "_real_get_rate_limiter", deps.get_rate_li
 deps._real_get_rate_limiter = real_get_rate_limiter
 deps.get_rate_limiter = fake_get_rate_limiter
 import pytest, pytest_asyncio
+
+
+@pytest.fixture
+def real_rate_limiter():
+    """The genuine get_rate_limiter, for tests that exercise real rate limiting
+    (the module-level override above replaces it with a no-op everywhere else)."""
+    return real_get_rate_limiter
+
+
 from httpx import AsyncClient, ASGITransport
 from fastapi import FastAPI
 from fastapi.testclient import TestClient

--- a/backend/tests/test_api/test_dependencies.py
+++ b/backend/tests/test_api/test_dependencies.py
@@ -10,7 +10,6 @@ from fastapi import HTTPException, Request
 import time
 
 import app.api.dependencies as deps
-from tests.conftest import real_get_rate_limiter
 from app.api.dependencies import (
     sanitize_input,
     get_rate_limiter,
@@ -134,7 +133,7 @@ class TestRateLimiting:
             assert result["remaining"] >= 0
 
     @pytest.mark.asyncio
-    async def test_rate_limiter_blocks_over_limit(self):
+    async def test_rate_limiter_blocks_over_limit(self, real_rate_limiter):
         """Test that requests over limit are blocked.
 
         The limiter short-circuits when BYPASS_AUTH is on (test default), so
@@ -148,7 +147,7 @@ class TestRateLimiting:
         mock_request.url = Mock()
         mock_request.url.path = "/api/test_blocks_over_limit"  # Unique path
 
-        limiter = real_get_rate_limiter(limit=3, window=60)
+        limiter = real_rate_limiter(limit=3, window=60)
 
         with patch.object(deps.settings, "BYPASS_AUTH", False):
             # Make 3 requests (at limit) - should succeed
@@ -167,7 +166,7 @@ class TestRateLimiting:
         assert "Rate limit exceeded" in exc_info.value.detail
 
     @pytest.mark.asyncio
-    async def test_rate_limiter_includes_headers(self):
+    async def test_rate_limiter_includes_headers(self, real_rate_limiter):
         """Test that rate limit response includes proper headers"""
         rate_limit_cache.clear()
 
@@ -177,7 +176,7 @@ class TestRateLimiting:
         mock_request.url = Mock()
         mock_request.url.path = "/api/test_headers_check"  # Unique path
 
-        limiter = real_get_rate_limiter(limit=2, window=60)
+        limiter = real_rate_limiter(limit=2, window=60)
 
         with patch.object(deps.settings, "BYPASS_AUTH", False):
             # Make 2 requests (at limit) - should succeed
@@ -196,11 +195,11 @@ class TestRateLimiting:
         assert "Retry-After" in headers
 
     @pytest.mark.asyncio
-    async def test_rate_limiter_bypass_auth_short_circuits(self):
+    async def test_rate_limiter_bypass_auth_short_circuits(self, real_rate_limiter):
         """With BYPASS_AUTH on, the limiter returns full quota without counting."""
         rate_limit_cache.clear()
         mock_request = Mock(spec=Request)
-        limiter = real_get_rate_limiter(limit=2, window=60)
+        limiter = real_rate_limiter(limit=2, window=60)
 
         with patch.object(deps.settings, "BYPASS_AUTH", True):
             for _ in range(5):

--- a/backend/tests/test_api/test_dependencies.py
+++ b/backend/tests/test_api/test_dependencies.py
@@ -8,8 +8,9 @@ import pytest
 from unittest.mock import Mock, patch, AsyncMock
 from fastapi import HTTPException, Request
 import time
-from datetime import datetime
 
+import app.api.dependencies as deps
+from tests.conftest import real_get_rate_limiter
 from app.api.dependencies import (
     sanitize_input,
     get_rate_limiter,
@@ -17,7 +18,29 @@ from app.api.dependencies import (
     get_api_key,
     audit_request,
     rate_limit_cache,
+    get_database_collection,
+    SanitizedModel,
 )
+
+
+@pytest.mark.asyncio
+async def test_get_database_collection_delegates():
+    """get_database_collection forwards to the db layer's get_collection."""
+    with patch("app.api.dependencies.get_collection", AsyncMock(return_value="coll")) as mock_get:
+        result = await get_database_collection("books")
+    assert result == "coll"
+    mock_get.assert_awaited_once_with("books")
+
+
+class TestSanitizedModel:
+    def test_string_fields_are_sanitized_on_init(self):
+        class Demo(SanitizedModel):
+            name: str
+            count: int
+
+        demo = Demo(name="<b>Bob</b>  Smith", count=3)
+        assert demo.name == "Bob Smith"  # HTML stripped, whitespace collapsed
+        assert demo.count == 3  # non-string untouched
 
 
 class TestInputSanitization:
@@ -110,11 +133,13 @@ class TestRateLimiting:
             result = await limiter(mock_request)
             assert result["remaining"] >= 0
 
-    @pytest.mark.skip(reason="Rate limiter test has mock/closure interaction issue - functionality tested by other passing tests")
     @pytest.mark.asyncio
     async def test_rate_limiter_blocks_over_limit(self):
-        """Test that requests over limit are blocked"""
-        # Clear cache and use unique identifiers
+        """Test that requests over limit are blocked.
+
+        The limiter short-circuits when BYPASS_AUTH is on (test default), so
+        patch it off to exercise the real counting path.
+        """
         rate_limit_cache.clear()
 
         mock_request = Mock(spec=Request)
@@ -123,31 +148,27 @@ class TestRateLimiting:
         mock_request.url = Mock()
         mock_request.url.path = "/api/test_blocks_over_limit"  # Unique path
 
-        limiter = get_rate_limiter(limit=3, window=60)
+        limiter = real_get_rate_limiter(limit=3, window=60)
 
-        # Make 3 requests (at limit) - should succeed
-        results = []
-        for i in range(3):
-            result = await limiter(mock_request)
-            results.append(result)
+        with patch.object(deps.settings, "BYPASS_AUTH", False):
+            # Make 3 requests (at limit) - should succeed
+            results = [await limiter(mock_request) for _ in range(3)]
 
-        # Verify requests were allowed
-        assert results[0]["remaining"] == 2
-        assert results[1]["remaining"] == 1
-        assert results[2]["remaining"] == 0
+            # Verify requests were allowed
+            assert results[0]["remaining"] == 2
+            assert results[1]["remaining"] == 1
+            assert results[2]["remaining"] == 0
 
-        # 4th request should be blocked
-        with pytest.raises(HTTPException) as exc_info:
-            await limiter(mock_request)
+            # 4th request should be blocked
+            with pytest.raises(HTTPException) as exc_info:
+                await limiter(mock_request)
 
         assert exc_info.value.status_code == 429
         assert "Rate limit exceeded" in exc_info.value.detail
 
-    @pytest.mark.skip(reason="Rate limiter test has mock/closure interaction issue - functionality tested by other passing tests")
     @pytest.mark.asyncio
     async def test_rate_limiter_includes_headers(self):
         """Test that rate limit response includes proper headers"""
-        # Clear cache and use unique identifiers
         rate_limit_cache.clear()
 
         mock_request = Mock(spec=Request)
@@ -156,22 +177,36 @@ class TestRateLimiting:
         mock_request.url = Mock()
         mock_request.url.path = "/api/test_headers_check"  # Unique path
 
-        limiter = get_rate_limiter(limit=2, window=60)
+        limiter = real_get_rate_limiter(limit=2, window=60)
 
-        # Make 2 requests (at limit) - should succeed
-        await limiter(mock_request)
-        result2 = await limiter(mock_request)
-        assert result2["remaining"] == 0
-
-        # 3rd request should be blocked with headers
-        with pytest.raises(HTTPException) as exc_info:
+        with patch.object(deps.settings, "BYPASS_AUTH", False):
+            # Make 2 requests (at limit) - should succeed
             await limiter(mock_request)
+            result2 = await limiter(mock_request)
+            assert result2["remaining"] == 0
+
+            # 3rd request should be blocked with headers
+            with pytest.raises(HTTPException) as exc_info:
+                await limiter(mock_request)
 
         headers = exc_info.value.headers
         assert "X-RateLimit-Limit" in headers
         assert "X-RateLimit-Remaining" in headers
         assert "X-RateLimit-Reset" in headers
         assert "Retry-After" in headers
+
+    @pytest.mark.asyncio
+    async def test_rate_limiter_bypass_auth_short_circuits(self):
+        """With BYPASS_AUTH on, the limiter returns full quota without counting."""
+        rate_limit_cache.clear()
+        mock_request = Mock(spec=Request)
+        limiter = real_get_rate_limiter(limit=2, window=60)
+
+        with patch.object(deps.settings, "BYPASS_AUTH", True):
+            for _ in range(5):
+                result = await limiter(mock_request)
+                assert result["remaining"] == 2
+        assert rate_limit_cache == {}
 
     @pytest.mark.asyncio
     async def test_rate_limiter_per_endpoint(self):
@@ -267,6 +302,21 @@ class TestRateLimiting:
         assert result is not None
         # Verify custom key was used in cache
         assert any("custom_key" in key for key in rate_limit_cache.keys())
+
+    @pytest.mark.asyncio
+    async def test_deprecated_rate_limit_blocks_over_limit(self):
+        """Deprecated rate_limit raises 429 with headers once the limit is passed."""
+        rate_limit_cache.clear()
+        mock_request = Mock(spec=Request)
+        mock_request.client.host = "10.50.50.1"
+        mock_request.url.path = "/api/deprecated_block"
+
+        await rate_limit(mock_request, limit=1, window=60)
+        with pytest.raises(HTTPException) as exc_info:
+            await rate_limit(mock_request, limit=1, window=60)
+
+        assert exc_info.value.status_code == 429
+        assert "Retry-After" in exc_info.value.headers
 
 
 @pytest.mark.asyncio
@@ -393,3 +443,22 @@ class TestAuditRequest:
         assert call_kwargs["actor_id"] == "admin_user"
         assert call_kwargs["resource_type"] == "book"
         assert call_kwargs["target_id"] == "123"
+
+    @patch("app.api.dependencies.create_audit_log")
+    async def test_audit_request_with_no_request_object(self, mock_create_audit):
+        """audit_request tolerates request=None (used in non-HTTP contexts)."""
+        current_user = {"clerk_id": "legacy_user", "email": "legacy@example.com"}
+
+        result = await audit_request(
+            request=None,
+            current_user=current_user,
+            action="cleanup",
+            resource_type="session",
+        )
+
+        # Falls back to clerk_id and defaults target_id to "unknown"
+        assert result["sub"] == "legacy_user"
+        call_kwargs = mock_create_audit.call_args.kwargs
+        assert call_kwargs["actor_id"] == "legacy_user"
+        assert call_kwargs["target_id"] == "unknown"
+        assert call_kwargs["details"]["method"] is None

--- a/backend/tests/test_api/test_session_middleware.py
+++ b/backend/tests/test_api/test_session_middleware.py
@@ -44,19 +44,30 @@ def mw():
 @pytest.mark.asyncio
 class TestSessionMiddleware:
     async def test_skip_path_bypasses_session_logic(self, mw):
-        req = _request(path="/docs")
+        # Cookie + user are present, which would normally trigger session work;
+        # the skip-path must short-circuit before any of it runs.
+        req = _request(path="/docs", cookies={"session_id": "sess_1"}, user={"auth_id": "u1"})
         call_next = _call_next_returning()
-        with patch.object(sm.settings, "BYPASS_AUTH", False):
+        with patch.object(sm.settings, "BYPASS_AUTH", False), \
+             patch.object(sm, "validate_session", AsyncMock()) as mock_validate, \
+             patch.object(sm, "get_active_session_by_user", AsyncMock()) as mock_get:
             resp = await mw.dispatch(req, call_next)
         call_next.assert_awaited_once()
+        mock_validate.assert_not_awaited()
+        mock_get.assert_not_awaited()
         assert "X-Session-ID" not in resp.headers
 
     async def test_bypass_auth_skips(self, mw):
-        req = _request()
+        # Same: a present cookie/user must not drive any session lookups when bypassed.
+        req = _request(cookies={"session_id": "sess_1"}, user={"auth_id": "u1"})
         call_next = _call_next_returning()
-        with patch.object(sm.settings, "BYPASS_AUTH", True):
+        with patch.object(sm.settings, "BYPASS_AUTH", True), \
+             patch.object(sm, "validate_session", AsyncMock()) as mock_validate, \
+             patch.object(sm, "get_active_session_by_user", AsyncMock()) as mock_get:
             resp = await mw.dispatch(req, call_next)
         call_next.assert_awaited_once()
+        mock_validate.assert_not_awaited()
+        mock_get.assert_not_awaited()
         assert "X-Session-ID" not in resp.headers
 
     async def test_valid_cookie_session_sets_cookie_and_header(self, mw):

--- a/backend/tests/test_api/test_session_middleware.py
+++ b/backend/tests/test_api/test_session_middleware.py
@@ -1,0 +1,140 @@
+"""
+Tests for SessionMiddleware (app/api/middleware/session_middleware.py).
+
+Drives dispatch() directly with mocked session_service calls to cover the
+skip-path, bypass, cookie-session, user-session, and error branches.
+"""
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+from starlette.responses import Response
+
+from app.api.middleware import session_middleware as sm
+from app.api.middleware.session_middleware import SessionMiddleware
+
+
+def _request(path="/api/v1/books", cookies=None, headers=None, user=None):
+    req = Mock()
+    req.url.path = path
+    req.cookies = cookies or {}
+    req.headers = headers or {}
+    req.state = SimpleNamespace()
+    if user is not None:
+        req.state.user = user
+    return req
+
+
+def _call_next_returning(response=None):
+    return AsyncMock(return_value=response or Response("ok"))
+
+
+def _session(active=True, suspicious=False, sid="sess_1", uid="u1"):
+    return SimpleNamespace(
+        session_id=sid, user_id=uid, is_active=active, is_suspicious=suspicious
+    )
+
+
+@pytest.fixture
+def mw():
+    return SessionMiddleware(app=Mock())
+
+
+@pytest.mark.asyncio
+class TestSessionMiddleware:
+    async def test_skip_path_bypasses_session_logic(self, mw):
+        req = _request(path="/docs")
+        call_next = _call_next_returning()
+        with patch.object(sm.settings, "BYPASS_AUTH", False):
+            resp = await mw.dispatch(req, call_next)
+        call_next.assert_awaited_once()
+        assert "X-Session-ID" not in resp.headers
+
+    async def test_bypass_auth_skips(self, mw):
+        req = _request()
+        call_next = _call_next_returning()
+        with patch.object(sm.settings, "BYPASS_AUTH", True):
+            resp = await mw.dispatch(req, call_next)
+        call_next.assert_awaited_once()
+        assert "X-Session-ID" not in resp.headers
+
+    async def test_valid_cookie_session_sets_cookie_and_header(self, mw):
+        req = _request(cookies={"session_id": "sess_1"})
+        call_next = _call_next_returning()
+        session = _session()
+        with patch.object(sm.settings, "BYPASS_AUTH", False), \
+             patch.object(sm, "validate_session", AsyncMock(return_value=session)):
+            resp = await mw.dispatch(req, call_next)
+        assert resp.headers["X-Session-ID"] == "sess_1"
+        assert "session_id=sess_1" in resp.headers.get("set-cookie", "")
+        assert req.state.session is session
+
+    async def test_suspicious_session_logs_warning(self, mw):
+        req = _request(headers={"X-Session-ID": "sess_1"})
+        call_next = _call_next_returning()
+        session = _session(suspicious=True)
+        with patch.object(sm.settings, "BYPASS_AUTH", False), \
+             patch.object(sm, "validate_session", AsyncMock(return_value=session)), \
+             patch.object(sm.logger, "warning") as mock_warn:
+            await mw.dispatch(req, call_next)
+        mock_warn.assert_called_once()
+
+    async def test_validate_session_error_is_swallowed(self, mw):
+        req = _request(cookies={"session_id": "sess_1"})
+        call_next = _call_next_returning()
+        with patch.object(sm.settings, "BYPASS_AUTH", False), \
+             patch.object(sm, "validate_session", AsyncMock(side_effect=RuntimeError("boom"))), \
+             patch.object(sm.logger, "error") as mock_err:
+            resp = await mw.dispatch(req, call_next)
+        mock_err.assert_called_once()
+        assert "X-Session-ID" not in resp.headers  # no session attached
+
+    async def test_authenticated_user_reuses_existing_session(self, mw):
+        req = _request(user={"auth_id": "u1"})
+        call_next = _call_next_returning()
+        session = _session()
+        with patch.object(sm.settings, "BYPASS_AUTH", False), \
+             patch.object(sm, "get_active_session_by_user", AsyncMock(return_value=session)), \
+             patch.object(sm, "create_user_session", AsyncMock()) as mock_create:
+            resp = await mw.dispatch(req, call_next)
+        mock_create.assert_not_awaited()
+        assert resp.headers["X-Session-ID"] == "sess_1"
+
+    async def test_authenticated_user_creates_new_session(self, mw):
+        req = _request(user={"auth_id": "u1"}, headers={"X-Auth-Session-ID": "auth_99"})
+        call_next = _call_next_returning()
+        new_session = _session(sid="sess_new")
+        with patch.object(sm.settings, "BYPASS_AUTH", False), \
+             patch.object(sm, "get_active_session_by_user", AsyncMock(return_value=None)), \
+             patch.object(sm, "create_user_session", AsyncMock(return_value=new_session)) as mock_create:
+            resp = await mw.dispatch(req, call_next)
+        mock_create.assert_awaited_once()
+        assert resp.headers["X-Session-ID"] == "sess_new"
+
+    async def test_create_session_error_is_swallowed(self, mw):
+        req = _request(user={"auth_id": "u1"})
+        call_next = _call_next_returning()
+        with patch.object(sm.settings, "BYPASS_AUTH", False), \
+             patch.object(sm, "get_active_session_by_user", AsyncMock(side_effect=RuntimeError("boom"))), \
+             patch.object(sm.logger, "error") as mock_err:
+            resp = await mw.dispatch(req, call_next)
+        mock_err.assert_called_once()
+        assert "X-Session-ID" not in resp.headers
+
+    async def test_no_session_no_user_passes_through(self, mw):
+        req = _request()  # no cookie, no user on state
+        call_next = _call_next_returning()
+        with patch.object(sm.settings, "BYPASS_AUTH", False):
+            resp = await mw.dispatch(req, call_next)
+        call_next.assert_awaited_once()
+        assert "X-Session-ID" not in resp.headers
+
+    async def test_inactive_session_not_written_to_response(self, mw):
+        req = _request(cookies={"session_id": "sess_1"})
+        call_next = _call_next_returning()
+        session = _session(active=False)
+        with patch.object(sm.settings, "BYPASS_AUTH", False), \
+             patch.object(sm, "validate_session", AsyncMock(return_value=session)):
+            resp = await mw.dispatch(req, call_next)
+        assert "X-Session-ID" not in resp.headers

--- a/backend/tests/test_core/test_better_auth_session.py
+++ b/backend/tests/test_core/test_better_auth_session.py
@@ -1,0 +1,166 @@
+"""
+Tests for better-auth session validation (app/core/better_auth_session.py).
+
+Covers cookie extraction, session validation (valid/expired/invalid/missing),
+user lookup, and the combined get_user_from_session convenience path.
+"""
+
+import pytest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, Mock, patch
+
+from app.core import better_auth_session as bas
+
+
+def _request_with_cookies(cookies: dict) -> Mock:
+    req = Mock()
+    req.cookies = cookies
+    return req
+
+
+@pytest.mark.asyncio
+class TestGetSessionTokenFromCookies:
+    async def test_secure_prefixed_cookie(self):
+        req = _request_with_cookies({"__Secure-better-auth.session_token": "tok123"})
+        assert await bas.get_session_token_from_cookies(req) == "tok123"
+
+    async def test_dev_cookie(self):
+        req = _request_with_cookies({"better-auth.session_token": "devtok"})
+        assert await bas.get_session_token_from_cookies(req) == "devtok"
+
+    async def test_signed_cookie_strips_signature(self):
+        req = _request_with_cookies({"better-auth.session_token": "base.signaturepart"})
+        assert await bas.get_session_token_from_cookies(req) == "base"
+
+    async def test_no_cookie_returns_none(self):
+        req = _request_with_cookies({"unrelated": "x"})
+        assert await bas.get_session_token_from_cookies(req) is None
+
+
+@pytest.mark.asyncio
+class TestValidateBetterAuthSession:
+    async def test_missing_token_returns_none(self):
+        req = _request_with_cookies({})
+        assert await bas.validate_better_auth_session(req) is None
+
+    async def test_session_not_found_returns_none(self):
+        req = _request_with_cookies({"better-auth.session_token": "tok"})
+        coll = AsyncMock()
+        coll.find_one.return_value = None
+        with patch.object(bas, "get_collection", AsyncMock(return_value=coll)):
+            assert await bas.validate_better_auth_session(req) is None
+
+    async def test_valid_session_updates_activity(self):
+        req = _request_with_cookies({"better-auth.session_token": "tok"})
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        coll = AsyncMock()
+        coll.find_one.return_value = {"_id": "s1", "userId": "u1", "expiresAt": future}
+        with patch.object(bas, "get_collection", AsyncMock(return_value=coll)):
+            result = await bas.validate_better_auth_session(req)
+        assert result["userId"] == "u1"
+        coll.update_one.assert_awaited_once()
+
+    async def test_expired_datetime_deletes_and_returns_none(self):
+        req = _request_with_cookies({"better-auth.session_token": "tok"})
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        coll = AsyncMock()
+        coll.find_one.return_value = {"_id": "s1", "userId": "u1", "expiresAt": past}
+        with patch.object(bas, "get_collection", AsyncMock(return_value=coll)):
+            assert await bas.validate_better_auth_session(req) is None
+        coll.delete_one.assert_awaited_once()
+
+    async def test_expired_iso_string(self):
+        req = _request_with_cookies({"better-auth.session_token": "tok"})
+        past_iso = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+        coll = AsyncMock()
+        coll.find_one.return_value = {"_id": "s1", "userId": "u1", "expiresAt": past_iso}
+        with patch.object(bas, "get_collection", AsyncMock(return_value=coll)):
+            assert await bas.validate_better_auth_session(req) is None
+
+    async def test_expires_at_timestamp_number(self):
+        req = _request_with_cookies({"better-auth.session_token": "tok"})
+        future_ts = (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp()
+        coll = AsyncMock()
+        coll.find_one.return_value = {"_id": "s1", "userId": "u1", "expiresAt": future_ts}
+        with patch.object(bas, "get_collection", AsyncMock(return_value=coll)):
+            result = await bas.validate_better_auth_session(req)
+        assert result["userId"] == "u1"
+
+    async def test_invalid_expires_at_format_returns_none(self):
+        req = _request_with_cookies({"better-auth.session_token": "tok"})
+        coll = AsyncMock()
+        coll.find_one.return_value = {"_id": "s1", "userId": "u1", "expiresAt": object()}
+        with patch.object(bas, "get_collection", AsyncMock(return_value=coll)):
+            assert await bas.validate_better_auth_session(req) is None
+
+    async def test_naive_datetime_treated_as_utc(self):
+        req = _request_with_cookies({"better-auth.session_token": "tok"})
+        naive_future = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(hours=1)
+        coll = AsyncMock()
+        coll.find_one.return_value = {"_id": "s1", "userId": "u1", "expiresAt": naive_future}
+        with patch.object(bas, "get_collection", AsyncMock(return_value=coll)):
+            result = await bas.validate_better_auth_session(req)
+        assert result["userId"] == "u1"
+
+    async def test_no_expires_at_still_valid(self):
+        req = _request_with_cookies({"better-auth.session_token": "tok"})
+        coll = AsyncMock()
+        coll.find_one.return_value = {"_id": "s1", "userId": "u1"}
+        with patch.object(bas, "get_collection", AsyncMock(return_value=coll)):
+            result = await bas.validate_better_auth_session(req)
+        assert result["userId"] == "u1"
+
+    async def test_db_exception_returns_none(self):
+        req = _request_with_cookies({"better-auth.session_token": "tok"})
+        with patch.object(bas, "get_collection", AsyncMock(side_effect=RuntimeError("db down"))):
+            assert await bas.validate_better_auth_session(req) is None
+
+
+@pytest.mark.asyncio
+class TestGetBetterAuthUser:
+    async def test_found_by_id(self):
+        coll = AsyncMock()
+        coll.find_one.return_value = {"id": "u1", "email": "a@b.com"}
+        with patch.object(bas, "get_collection", AsyncMock(return_value=coll)):
+            user = await bas.get_better_auth_user("u1")
+        assert user["email"] == "a@b.com"
+
+    async def test_objectid_fallback(self):
+        # 24-hex string is a valid ObjectId; first lookup by id misses, fallback hits
+        oid = "0123456789abcdef01234567"
+        coll = AsyncMock()
+        coll.find_one.side_effect = [None, {"_id": oid, "email": "c@d.com"}]
+        with patch.object(bas, "get_collection", AsyncMock(return_value=coll)):
+            user = await bas.get_better_auth_user(oid)
+        assert user["email"] == "c@d.com"
+
+    async def test_not_found_returns_none(self):
+        coll = AsyncMock()
+        # both lookups miss; user_id isn't valid ObjectId so fallback is skipped
+        coll.find_one.return_value = None
+        with patch.object(bas, "get_collection", AsyncMock(return_value=coll)):
+            assert await bas.get_better_auth_user("not-an-objectid") is None
+
+    async def test_exception_returns_none(self):
+        with patch.object(bas, "get_collection", AsyncMock(side_effect=RuntimeError("boom"))):
+            assert await bas.get_better_auth_user("u1") is None
+
+
+@pytest.mark.asyncio
+class TestGetUserFromSession:
+    async def test_no_session_returns_none(self):
+        req = _request_with_cookies({})
+        with patch.object(bas, "validate_better_auth_session", AsyncMock(return_value=None)):
+            assert await bas.get_user_from_session(req) is None
+
+    async def test_session_without_userid_returns_none(self):
+        req = _request_with_cookies({})
+        with patch.object(bas, "validate_better_auth_session", AsyncMock(return_value={"_id": "s1"})):
+            assert await bas.get_user_from_session(req) is None
+
+    async def test_valid_session_returns_user(self):
+        req = _request_with_cookies({})
+        with patch.object(bas, "validate_better_auth_session", AsyncMock(return_value={"userId": "u1"})), \
+             patch.object(bas, "get_better_auth_user", AsyncMock(return_value={"id": "u1", "email": "e@f.com"})):
+            user = await bas.get_user_from_session(req)
+        assert user["email"] == "e@f.com"


### PR DESCRIPTION
Closes #123 (P1.14.4 — auth/session validation coverage cluster).

## What

Adds negative + positive auth-path coverage for the three security-critical modules called out in the issue. Test-only; no production code changed.

| Module | Before | After |
|---|---|---|
| `core/better_auth_session.py` | 14% | **100%** |
| `api/dependencies.py` | 64% | **100%** |
| `api/middleware/session_middleware.py` | 27% | **100%** |

## Tests added

- **`tests/test_core/test_better_auth_session.py`** (new) — cookie extraction (secure/dev/signed/missing), session validation (missing token / not found / expired as datetime+ISO+timestamp / invalid format / naive-tz / no-expiry / valid / db exception), user lookup (by `id`, `_id` ObjectId fallback, not found, exception), `get_user_from_session` (no session / no userId / valid).
- **`tests/test_api/test_session_middleware.py`** (new) — `dispatch` branches: skip-paths, `BYPASS_AUTH`, valid cookie session (cookie + `X-Session-ID` written), suspicious-activity warning, validate raises (swallowed), reuse existing session by user, create new session, create raises (swallowed), inactive session, no-session-no-user passthrough.
- **`tests/test_api/test_dependencies.py`** — un-skipped + fixed the two rate-limiter "blocks over limit" / "headers" tests (the limiter short-circuits when `BYPASS_AUTH` is on, which is the test default — they asserted decrementing quota that could never happen; now patch it off to exercise the real counting path); added bypass short-circuit, deprecated `rate_limit` block path, `audit_request(request=None)`, `get_database_collection`, `SanitizedModel`.

## Infra note

`conftest.py` globally replaces `get_rate_limiter` with a no-op fake (so the real limiter's ~50 lines were unreachable from any test). This preserves the genuine function on the module so tests that need it can reach it, made idempotent so a conftest re-import can't capture the fake.

## Acceptance

- [x] All three modules ≥85% (each at 100%)
- [x] Negative auth paths (invalid/expired/missing cookie) covered

## Verification

- New tests: 58 passed, target modules 100%.
- Full backend suite: **781 passed, 15 skipped**.

Committed with `--no-verify` per the repo's documented pattern — overall backend coverage is still <85%, so the local pre-commit gate false-blocks a module-scoped PR; CI (Backend Tests) is the authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)