### PR TITLE
feat(voice): AI cleanup for voice-dictated chapter text (#56)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,15 @@
 
 ## Recent Changes
 
+### 2026-06-29
+- **AI voice-input enhancement / dictation cleanup (#56, P2.6)**: built by **mirroring the #57 enhance-text pattern** end to end (no new deps, no transcription-router changes)
+  - **Backend**: `app/services/transcription_enhancement.py` (single `TRANSCRIPTION_CLEANUP_GUIDANCE` + `get_transcription_enhancement_prompt(content)` — fact-preserving). `ai_service.enhance_transcription(content)` (temp **0.3**, conservative; rejects length-truncated output so a long dictation can't be silently shortened; structured `{success, enhanced, metadata}`). New `POST /books/{id}/chapters/{cid}/enhance-transcription` (session auth, ownership 403, **chapter-existence 404**, 10/h rate limit, 400 empty-content, 503 on AI failure). **Preview-only, no persistence.**
+  - **Single "cleanup" mode** (one pass: filler removal + paragraph breaks at natural pauses + grammar/punctuation) rather than the Traycer plan's 3 boolean toggles — the AC lists all three as expected *outcomes*, not user options; "toggle raw vs enhanced" = the side-by-side preview + revert.
+  - **Frontend**: `VoiceEnhancer.tsx` dialog (intro→enhancing→preview; DOMPurify-sanitized raw-vs-cleaned side-by-side; mirrors `ContentEnhancer`); `bookClient.enhanceVoiceTranscription()`. `ChapterEditor` toolbar **Clean up dictation** button — **reuses** the existing `getEnhanceContent` + `handleApplyEnhancement` + **"Revert enhancement"** snapshot/revert (no new editor state).
+  - **Tests**: backend `test_transcription_enhancement` + `test_ai_service_transcription` + `test_transcription_enhancement_endpoint` (success/400/404-book/404-chapter/403/503); frontend `VoiceEnhancer.test.tsx`; route-mocked E2E `voice-enhancement.spec.ts` (raw dictation→clean up→preview→apply→revert). Backend **957 passed, 92.36% cov** (`transcription_enhancement.py` 100%); frontend **1878 passed**, gates green (85/85/75/85).
+  - **NB**: the unmounted `/transcribe` router and the Traycer plan's references to the deleted `chapter_error_handler`/`chapter_cache_service` (gone in #120) are intentionally untouched. E2E route-mocks the endpoint — browser SpeechRecognition is native/non-deterministic and unavailable headless (webkit/Mobile-Safari editor-load fails pre-existingly in this env; same as the #57 spec).
+  - **Status**: ✅ Complete
+
 ### 2026-06-28
 - **EPUB export format (#60, P2.3)**: PR #147 — third export format alongside PDF/DOCX
   - **Backend**: `ExportService.generate_epub()` via `ebooklib==0.20` (async worker thread, same pattern as PDF/DOCX). Title page + per-chapter `EpubHtml`, `EpubNcx` (EPUB2 nav) **and** `EpubNav` (EPUB3 nav) for max ereader compat, ordered spine. Reuses the shared HTML→formatted-text pipeline (`_extract_text_formatting`) so chapter content renders as **well-formed XHTML** — raw TipTap HTML isn't always XML-valid and would break ereaders/lxml. **Gotcha fixed**: no `<?xml … encoding …?>` prolog on `EpubHtml.content` — ebooklib parses it as a `str` during nav generation and lxml rejects a unicode string carrying an encoding decl (silently empties the body → `ParserError: Document is empty`). ebooklib writes its own prolog.

--- a/backend/app/api/endpoints/books.py
+++ b/backend/app/api/endpoints/books.py
@@ -3290,6 +3290,80 @@ async def enhance_chapter_text(
 
 
 @router.post(
+    "/{book_id}/chapters/{chapter_id}/enhance-transcription", response_model=dict
+)
+async def enhance_chapter_transcription(
+    book_id: str,
+    chapter_id: str,
+    data: dict = Body(default={}),
+    current_user: Dict = Depends(get_current_user_from_session),
+    rate_limit_info: Dict = Depends(
+        get_rate_limiter(limit=10, window=3600)
+    ),  # 10 per hour
+):
+    """
+    Clean up raw voice-dictated text into readable prose (issue #56).
+
+    Preview-only: returns the cleaned-up text (filler removal, paragraph breaks,
+    grammar/punctuation) without persisting. The caller applies it and can revert
+    by restoring the snapshot it held before applying. Single cleanup mode.
+    """
+    # Verify book ownership.
+    book = await get_book_by_id(book_id)
+    if not book:
+        raise HTTPException(status_code=404, detail="Book not found")
+    if book.get("owner_id") != current_user.get("auth_id"):
+        raise HTTPException(
+            status_code=403,
+            detail="Not authorized to enhance content for this book",
+        )
+
+    # Verify the chapter exists (matches the other chapter content endpoints),
+    # so a stale/mistyped id can't consume the cleanup quota.
+    chapters = book.get("table_of_contents", {}).get("chapters", [])
+
+    def find_chapter(chapter_list):
+        for chapter in chapter_list:
+            if chapter.get("id") == chapter_id:
+                return chapter
+            if chapter.get("subchapters"):
+                found = find_chapter(chapter["subchapters"])
+                if found:
+                    return found
+        return None
+
+    if not find_chapter(chapters):
+        raise HTTPException(status_code=404, detail="Chapter not found")
+
+    content = data.get("content", "")
+    if not content or not content.strip():
+        raise HTTPException(
+            status_code=400,
+            detail="Transcription is required for cleanup.",
+        )
+
+    result = await ai_service.enhance_transcription(content=content)
+
+    if not result.get("success"):
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Failed to clean up transcription: "
+                f"{result.get('error', 'Unknown error')}"
+            ),
+        )
+
+    return {
+        "success": True,
+        "book_id": book_id,
+        "chapter_id": chapter_id,
+        "enhanced": result["enhanced"],
+        "metadata": result["metadata"],
+        "message": "Transcription cleaned up successfully",
+    }
+
+
+@router.post(
     "/{book_id}/chapters/{chapter_id}/questions/responses/batch",
     response_model=Dict[str, Any]
 )

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -24,6 +24,10 @@ from app.services.content_enhancement import (
     ENHANCEMENT_LABELS,
     get_enhancement_prompt,
 )
+from app.services.transcription_enhancement import (
+    TRANSCRIPTION_ENHANCEMENT_LABEL,
+    get_transcription_enhancement_prompt,
+)
 from app.services.ai_cache_service import (
     AICacheService,
     get_toc_generation_cache,
@@ -1137,6 +1141,85 @@ Ensure the TOC is comprehensive, logically ordered, and matches the book's scope
 
         except Exception as e:
             logger.error(f"Failed to enhance text: {str(e)}")
+            return {
+                "success": False,
+                "error": str(e),
+                "enhanced": "",
+                "metadata": {},
+            }
+
+    async def enhance_transcription(self, content: str) -> Dict[str, Any]:
+        """
+        Clean up a raw voice transcription into readable prose (issue #56).
+
+        Preview-only: returns the cleaned-up text and metadata without
+        persisting. A single conservative pass removes filler words, breaks
+        paragraphs at natural pauses, and fixes grammar/punctuation while
+        preserving what was said. Mirrors enhance_text (#57) with temp 0.3.
+
+        Args:
+            content: The raw voice transcription to clean up.
+
+        Returns:
+            Dict with success flag, enhanced text, and metadata.
+        """
+        if not content or not content.strip():
+            return {
+                "success": False,
+                "error": "Transcription is required for cleanup.",
+                "enhanced": "",
+                "metadata": {},
+            }
+
+        try:
+            prompt = get_transcription_enhancement_prompt(content)
+            messages = [
+                {
+                    "role": "system",
+                    "content": (
+                        "You are an expert editor cleaning up dictated speech. "
+                        "Turn raw transcriptions into readable prose while "
+                        "preserving the speaker's words and meaning exactly."
+                    ),
+                },
+                {"role": "user", "content": prompt},
+            ]
+
+            # Conservative, like enhance_text: cleanup must not invent content.
+            response = await self._make_openai_request(
+                messages, temperature=0.3, max_tokens=4000
+            )
+
+            choice = response.choices[0]
+            # Refuse a truncated result: the caller would overwrite the chapter
+            # with shortened text, silently losing content (mirrors #57).
+            if getattr(choice, "finish_reason", None) == "length":
+                return {
+                    "success": False,
+                    "error": (
+                        "This transcription is too long to clean up in one pass. "
+                        "Try cleaning up a shorter section."
+                    ),
+                    "enhanced": "",
+                    "metadata": {},
+                }
+
+            enhanced = choice.message.content
+            return {
+                "success": True,
+                "enhanced": enhanced,
+                "metadata": {
+                    "enhancement_type": "transcription",
+                    "enhancement_label": TRANSCRIPTION_ENHANCEMENT_LABEL,
+                    "original_word_count": len(content.split()),
+                    "enhanced_word_count": len(enhanced.split()),
+                    "model_used": self.model,
+                    "generated_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+                },
+            }
+
+        except Exception as e:
+            logger.error(f"Failed to enhance transcription: {str(e)}")
             return {
                 "success": False,
                 "error": str(e),

--- a/backend/app/services/transcription_enhancement.py
+++ b/backend/app/services/transcription_enhancement.py
@@ -1,0 +1,43 @@
+"""
+Voice-transcription cleanup template (issue #56).
+
+Raw speech-to-text from voice input is verbatim: filler words, run-on
+sentences, no paragraph breaks, missing punctuation. This single "cleanup"
+pass turns that into readable prose — removing fillers, breaking paragraphs at
+natural pauses, and fixing grammar/punctuation — WITHOUT changing what was said.
+
+Single mode (unlike the multi-dimension content_enhancement.py, #57): the issue
+treats filler removal, paragraphing, and grammar as one expected outcome, not a
+menu of user choices.
+"""
+
+TRANSCRIPTION_ENHANCEMENT_LABEL = "Dictation Cleanup"
+
+TRANSCRIPTION_CLEANUP_GUIDANCE = (
+    "Clean up this raw voice transcription into readable written prose:\n"
+    "- Remove filler words and verbal tics (\"um\", \"uh\", \"er\", \"like\", "
+    "\"you know\", \"sort of\", \"kind of\", \"I mean\", \"basically\", "
+    "\"actually\", repeated false starts).\n"
+    "- Break the text into paragraphs at natural topic shifts and pauses.\n"
+    "- Add correct punctuation and capitalization; fix grammar, tense, and "
+    "subject-verb agreement.\n"
+    "- Keep the speaker's wording, voice, and intent — do not paraphrase, "
+    "summarize, or add ideas that were not spoken."
+)
+
+
+def get_transcription_enhancement_prompt(content: str) -> str:
+    """Build the prompt that cleans up a raw voice transcription."""
+    return f"""Clean up the following voice transcription.
+
+{TRANSCRIPTION_CLEANUP_GUIDANCE}
+
+Critical requirements:
+- Preserve ALL facts, names, numbers, and the original meaning exactly.
+- Do not add new information or remove any substantive point — only remove
+  fillers and disfluencies.
+- Return only the cleaned-up text, with no preamble or commentary.
+
+Voice transcription to clean up:
+{content}
+"""

--- a/backend/tests/test_api/test_transcription_enhancement_endpoint.py
+++ b/backend/tests/test_api/test_transcription_enhancement_endpoint.py
@@ -1,0 +1,94 @@
+"""Integration tests for the voice-transcription cleanup endpoint (issue #56)."""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+MOCK_BOOK = {
+    "_id": "test_book_id",
+    "owner_id": "test-auth-id-123",
+    "title": "Test Book",
+    "table_of_contents": {"chapters": [{"id": "ch1", "title": "Chapter 1"}]},
+}
+
+URL = "/api/v1/books/test_book_id/chapters/ch1/enhance-transcription"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_success(auth_client_factory):
+    client = await auth_client_factory()
+    mock_result = {
+        "success": True,
+        "enhanced": "The cat sat on the mat.",
+        "metadata": {
+            "enhancement_type": "transcription",
+            "enhancement_label": "Dictation Cleanup",
+            "original_word_count": 9,
+            "enhanced_word_count": 6,
+            "model_used": "gpt-4",
+            "generated_at": "2026-06-29 10:00:00",
+        },
+    }
+    with patch("app.api.endpoints.books.get_book_by_id", AsyncMock(return_value=MOCK_BOOK)):
+        with patch("app.api.endpoints.books.ai_service.enhance_transcription",
+                   AsyncMock(return_value=mock_result)):
+            response = await client.post(
+                URL, json={"content": "um so the cat you know sat on the mat"}
+            )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is True
+    assert body["enhanced"] == "The cat sat on the mat."
+    assert body["metadata"]["enhancement_label"] == "Dictation Cleanup"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_requires_content(auth_client_factory):
+    client = await auth_client_factory()
+    with patch("app.api.endpoints.books.get_book_by_id", AsyncMock(return_value=MOCK_BOOK)):
+        with patch("app.api.endpoints.books.ai_service.enhance_transcription",
+                   AsyncMock()) as enhance:
+            response = await client.post(URL, json={"content": "   "})
+    assert response.status_code == 400
+    assert "required" in response.json()["detail"].lower()
+    enhance.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_book_not_found_returns_404(auth_client_factory):
+    client = await auth_client_factory()
+    with patch("app.api.endpoints.books.get_book_by_id", AsyncMock(return_value=None)):
+        response = await client.post(URL, json={"content": "um hello there"})
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_cleanup_chapter_not_found_returns_404(auth_client_factory):
+    """An owned book but a missing chapter id 404s before calling the AI."""
+    client = await auth_client_factory()
+    bad_url = "/api/v1/books/test_book_id/chapters/nope/enhance-transcription"
+    with patch("app.api.endpoints.books.get_book_by_id", AsyncMock(return_value=MOCK_BOOK)):
+        with patch("app.api.endpoints.books.ai_service.enhance_transcription",
+                   AsyncMock()) as enhance:
+            response = await client.post(bad_url, json={"content": "um hello there"})
+    assert response.status_code == 404
+    enhance.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_ai_failure_returns_503(auth_client_factory):
+    client = await auth_client_factory()
+    mock_result = {"success": False, "error": "AI service unavailable", "enhanced": "", "metadata": {}}
+    with patch("app.api.endpoints.books.get_book_by_id", AsyncMock(return_value=MOCK_BOOK)):
+        with patch("app.api.endpoints.books.ai_service.enhance_transcription",
+                   AsyncMock(return_value=mock_result)):
+            response = await client.post(URL, json={"content": "um hello there"})
+    assert response.status_code == 503
+    assert "Failed to clean up" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_rejects_other_users_book(auth_client_factory):
+    client = await auth_client_factory()
+    other_book = {**MOCK_BOOK, "owner_id": "someone-else"}
+    with patch("app.api.endpoints.books.get_book_by_id", AsyncMock(return_value=other_book)):
+        response = await client.post(URL, json={"content": "um hello there"})
+    assert response.status_code == 403

--- a/backend/tests/test_services/test_ai_service_transcription.py
+++ b/backend/tests/test_services/test_ai_service_transcription.py
@@ -1,0 +1,67 @@
+"""Tests for AIService.enhance_transcription (issue #56)."""
+import pytest
+from unittest.mock import Mock, patch
+from app.services.ai_service import AIService
+from openai import OpenAI
+
+
+class TestAIServiceTranscriptionEnhancement:
+    @pytest.fixture
+    def mock_openai_client(self):
+        mock_client = Mock(spec=OpenAI)
+        mock_completion = Mock()
+        mock_completion.choices = [
+            Mock(
+                message=Mock(content="The cat sat on the mat."),
+                finish_reason="stop",
+            )
+        ]
+        mock_client.chat.completions.create.return_value = mock_completion
+        return mock_client
+
+    @pytest.fixture
+    def ai_service(self, mock_openai_client):
+        with patch("app.services.ai_service.OpenAI", return_value=mock_openai_client):
+            service = AIService()
+            service.client = mock_openai_client
+            return service
+
+    @pytest.mark.asyncio
+    async def test_cleanup_success(self, ai_service):
+        result = await ai_service.enhance_transcription(
+            content="um so the cat you know sat on the mat"
+        )
+        assert result["success"] is True
+        assert result["enhanced"] == "The cat sat on the mat."
+        assert result["metadata"]["enhancement_type"] == "transcription"
+        assert result["metadata"]["enhancement_label"] == "Dictation Cleanup"
+        assert result["metadata"]["original_word_count"] == 10
+        assert result["metadata"]["enhanced_word_count"] > 0
+
+        # Conservative temperature — cleanup must not invent content.
+        call_args = ai_service.client.chat.completions.create.call_args
+        assert call_args[1]["temperature"] == 0.3
+
+    @pytest.mark.asyncio
+    async def test_empty_content_rejected_without_calling_openai(self, ai_service):
+        result = await ai_service.enhance_transcription(content="   ")
+        assert result["success"] is False
+        assert "required" in result["error"].lower()
+        ai_service.client.chat.completions.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_openai_error_handled(self, ai_service):
+        ai_service.client.chat.completions.create.side_effect = Exception("OpenAI down")
+        result = await ai_service.enhance_transcription(content="um hello")
+        assert result["success"] is False
+        assert "OpenAI down" in result["error"]
+        assert result["enhanced"] == ""
+
+    @pytest.mark.asyncio
+    async def test_truncated_output_is_rejected_not_saved(self, ai_service):
+        """A length-truncated cleanup must fail, not silently overwrite the chapter."""
+        ai_service.client.chat.completions.create.return_value.choices[0].finish_reason = "length"
+        result = await ai_service.enhance_transcription(content="a very long dictation ...")
+        assert result["success"] is False
+        assert "too long" in result["error"].lower()
+        assert result["enhanced"] == ""

--- a/backend/tests/test_services/test_transcription_enhancement.py
+++ b/backend/tests/test_services/test_transcription_enhancement.py
@@ -1,0 +1,27 @@
+"""Tests for the voice-transcription cleanup template (issue #56)."""
+from app.services.transcription_enhancement import (
+    TRANSCRIPTION_ENHANCEMENT_LABEL,
+    get_transcription_enhancement_prompt,
+)
+
+
+def test_label_defined():
+    assert TRANSCRIPTION_ENHANCEMENT_LABEL == "Dictation Cleanup"
+
+
+def test_prompt_includes_content_and_cleanup_guidance():
+    content = "um so the cat you know sat on the mat"
+    prompt = get_transcription_enhancement_prompt(content)
+    assert content in prompt
+    # Covers the three AC outcomes: fillers, paragraphs, grammar/punctuation.
+    lowered = prompt.lower()
+    assert "filler" in lowered
+    assert "paragraph" in lowered
+    assert "punctuation" in lowered
+
+
+def test_prompt_preserves_facts_instruction():
+    prompt = get_transcription_enhancement_prompt("some text")
+    assert "Preserve ALL facts" in prompt
+    # Must not invent or paraphrase content.
+    assert "do not paraphrase" in prompt.lower()

--- a/frontend/src/__tests__/VoiceEnhancer.test.tsx
+++ b/frontend/src/__tests__/VoiceEnhancer.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { VoiceEnhancer } from '@/components/chapters/VoiceEnhancer';
+import { bookClient } from '@/lib/api/bookClient';
+
+jest.mock('@/lib/api/bookClient', () => ({
+  __esModule: true,
+  bookClient: {
+    enhanceVoiceTranscription: jest.fn(),
+  },
+  default: { enhanceVoiceTranscription: jest.fn() },
+}));
+
+jest.mock('@/lib/toast', () => ({
+  toast: Object.assign(jest.fn(), {
+    success: jest.fn(),
+    error: jest.fn(),
+    warning: jest.fn(),
+    info: jest.fn(),
+  }),
+}));
+
+const mockCleanup = bookClient.enhanceVoiceTranscription as jest.Mock;
+
+function setup(content = '<p>um so the cat you know sat on the mat</p>') {
+  const onApply = jest.fn();
+  render(
+    <VoiceEnhancer
+      bookId="b1"
+      chapterId="c1"
+      getCurrentContent={() => content}
+      onApply={onApply}
+    />
+  );
+  return { onApply };
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+it('renders the clean-up button', () => {
+  setup();
+  expect(screen.getByRole('button', { name: /clean up dictation/i })).toBeInTheDocument();
+});
+
+it('cleans up, previews raw vs cleaned, and applies to the editor', async () => {
+  const user = userEvent.setup();
+  mockCleanup.mockResolvedValueOnce({
+    success: true,
+    enhanced: '<p>The cat sat on the mat.</p>',
+    metadata: { enhancement_label: 'Dictation Cleanup' },
+  });
+  const { onApply } = setup();
+
+  await user.click(screen.getByRole('button', { name: /clean up dictation/i }));
+  await user.click(screen.getByRole('button', { name: /^clean up$/i }));
+
+  await waitFor(() => {
+    expect(screen.getByText(/um so the cat/i)).toBeInTheDocument();
+    expect(screen.getByText(/^The cat sat on the mat\.$/i)).toBeInTheDocument();
+  });
+
+  expect(mockCleanup).toHaveBeenCalledWith('b1', 'c1', {
+    content: '<p>um so the cat you know sat on the mat</p>',
+  });
+
+  await user.click(screen.getByRole('button', { name: /apply to chapter/i }));
+  expect(onApply).toHaveBeenCalledWith('<p>The cat sat on the mat.</p>');
+});
+
+it('blocks cleanup of empty content without calling the API', async () => {
+  const user = userEvent.setup();
+  setup('<p></p>');
+
+  await user.click(screen.getByRole('button', { name: /clean up dictation/i }));
+  await user.click(screen.getByRole('button', { name: /^clean up$/i }));
+
+  expect(await screen.findByText(/dictate or add some text/i)).toBeInTheDocument();
+  expect(mockCleanup).not.toHaveBeenCalled();
+});
+
+it('shows an error and returns to intro when cleanup fails', async () => {
+  const user = userEvent.setup();
+  mockCleanup.mockRejectedValueOnce(new Error('AI service unavailable'));
+  setup();
+
+  await user.click(screen.getByRole('button', { name: /clean up dictation/i }));
+  await user.click(screen.getByRole('button', { name: /^clean up$/i }));
+
+  expect(await screen.findByText(/AI service unavailable/i)).toBeInTheDocument();
+  // Back on the intro step: the footer "Clean up" submit button is visible again.
+  expect(screen.getByRole('button', { name: /^clean up$/i })).toBeInTheDocument();
+});

--- a/frontend/src/components/chapters/ChapterEditor.tsx
+++ b/frontend/src/components/chapters/ChapterEditor.tsx
@@ -51,6 +51,7 @@ import { usePerformanceTracking } from '@/hooks/usePerformanceTracking';
 import { DraftGenerator } from './DraftGenerator';
 import { StyleTransformer } from './StyleTransformer';
 import { ContentEnhancer } from './ContentEnhancer';
+import { VoiceEnhancer } from './VoiceEnhancer';
 import QuestionContainer from './questions/QuestionContainer';
 import { useRouter } from 'next/navigation';
 import {
@@ -697,6 +698,14 @@ export function ChapterEditor({
 
         {/* AI Content Enhancer (#57) */}
         <ContentEnhancer
+          bookId={bookId}
+          chapterId={chapterId}
+          getCurrentContent={getEnhanceContent}
+          onApply={handleApplyEnhancement}
+        />
+
+        {/* AI Voice/Dictation cleanup (#56) — shares the enhancement snapshot/revert. */}
+        <VoiceEnhancer
           bookId={bookId}
           chapterId={chapterId}
           getCurrentContent={getEnhanceContent}

--- a/frontend/src/components/chapters/VoiceEnhancer.tsx
+++ b/frontend/src/components/chapters/VoiceEnhancer.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { SparklesIcon, ArrowRight01Icon } from '@hugeicons/core-free-icons';
+import { toast } from '@/lib/toast';
+import { bookClient } from '@/lib/api/bookClient';
+import { LoadingStateManager } from '@/components/loading';
+import DOMPurify from 'dompurify';
+import { cn } from '@/lib/utils';
+
+const SANITIZE_OPTS = {
+  ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'u', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul', 'ol', 'li', 'blockquote'],
+  ALLOWED_ATTR: ['class'],
+};
+
+interface VoiceEnhancerProps {
+  bookId: string;
+  chapterId: string;
+  /** Returns the text to clean up — the selection if any, else the whole chapter. */
+  getCurrentContent: () => string;
+  /** Apply the cleaned-up text to the editor (caller snapshots for revert). */
+  onApply: (enhanced: string) => void;
+  className?: string;
+}
+
+/**
+ * Voice/dictation cleanup dialog (issue #56). Turns raw transcription into
+ * readable prose — filler removal, paragraph breaks, grammar/punctuation —
+ * with a side-by-side raw-vs-cleaned preview before applying. Single mode,
+ * preview-only; mirrors ContentEnhancer (#57).
+ */
+export function VoiceEnhancer({
+  bookId,
+  chapterId,
+  getCurrentContent,
+  onApply,
+  className,
+}: VoiceEnhancerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [step, setStep] = useState<'intro' | 'enhancing' | 'preview'>('intro');
+  const [original, setOriginal] = useState('');
+  const [enhanced, setEnhanced] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  // Guard against SSR (DOMPurify needs a DOM) and skip work until there's content.
+  const sanitizedOriginal = useMemo(
+    () => (original ? DOMPurify.sanitize(original, SANITIZE_OPTS) : ''),
+    [original]
+  );
+  const sanitizedEnhanced = useMemo(
+    () => (enhanced ? DOMPurify.sanitize(enhanced, SANITIZE_OPTS) : ''),
+    [enhanced]
+  );
+
+  const openDialog = () => {
+    setIsOpen(true);
+    setStep('intro');
+    setError(null);
+    setEnhanced('');
+  };
+
+  const handleCleanup = async () => {
+    const content = getCurrentContent();
+    // TipTap renders an empty doc as "<p></p>"; treat that as empty.
+    if (!content || !content.replace(/<[^>]*>/g, '').trim()) {
+      setError('Dictate or add some text before cleaning it up.');
+      return;
+    }
+
+    setOriginal(content);
+    setError(null);
+    setStep('enhancing');
+
+    try {
+      const result = await bookClient.enhanceVoiceTranscription(bookId, chapterId, {
+        content,
+      });
+      setEnhanced(result.enhanced);
+      setStep('preview');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to clean up transcription');
+      setStep('intro');
+      toast({
+        title: 'Cleanup Failed',
+        description: err instanceof Error ? err.message : 'Failed to clean up transcription',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleApply = () => {
+    onApply(enhanced);
+    setIsOpen(false);
+    toast({
+      title: 'Cleanup Applied',
+      description: 'Dictation cleaned up. Use "Revert enhancement" to undo.',
+    });
+  };
+
+  return (
+    <>
+      <Button
+        onClick={openDialog}
+        variant="outline"
+        size="sm"
+        className={cn('gap-2', className)}
+        data-slot="voice-enhancer"
+      >
+        <HugeiconsIcon icon={SparklesIcon} size={16} />
+        Clean up dictation
+      </Button>
+
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Clean Up Dictation</DialogTitle>
+            <DialogDescription>
+              {step === 'intro' && 'Remove filler words, add paragraph breaks, and fix grammar and punctuation in your dictated text. Facts and meaning are preserved.'}
+              {step === 'enhancing' && 'Cleaning up your dictation...'}
+              {step === 'preview' && 'Compare your raw dictation with the cleaned-up version before applying.'}
+            </DialogDescription>
+          </DialogHeader>
+
+          {step === 'intro' && error && (
+            <div className="py-4">
+              <div className="bg-destructive/10 border border-destructive/20 text-destructive p-3 rounded-md text-sm">
+                {error}
+              </div>
+            </div>
+          )}
+
+          {step === 'enhancing' && (
+            <div className="py-12">
+              <LoadingStateManager
+                isLoading={true}
+                operation="Cleaning Up Dictation"
+                message="Removing fillers and formatting your text..."
+                inline
+              />
+            </div>
+          )}
+
+          {step === 'preview' && (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 py-4">
+              <div className="space-y-2">
+                <Label className="text-muted-foreground">Raw dictation</Label>
+                <div
+                  className="border rounded-lg p-4 max-h-80 overflow-y-auto bg-muted/30 text-sm prose prose-sm max-w-none dark:prose-invert"
+                  dangerouslySetInnerHTML={{ __html: sanitizedOriginal }}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label className="flex items-center gap-1">
+                  Cleaned up
+                  <HugeiconsIcon icon={ArrowRight01Icon} size={14} />
+                </Label>
+                <div
+                  className="border rounded-lg p-4 max-h-80 overflow-y-auto bg-muted/30 text-sm prose prose-sm max-w-none dark:prose-invert"
+                  dangerouslySetInnerHTML={{ __html: sanitizedEnhanced }}
+                />
+              </div>
+            </div>
+          )}
+
+          <DialogFooter>
+            {step === 'intro' && (
+              <>
+                <Button variant="outline" onClick={() => setIsOpen(false)}>Cancel</Button>
+                <Button onClick={handleCleanup}>
+                  <HugeiconsIcon icon={SparklesIcon} size={16} className="mr-2" />
+                  Clean up
+                </Button>
+              </>
+            )}
+            {step === 'preview' && (
+              <>
+                <Button variant="outline" onClick={() => setIsOpen(false)}>Cancel</Button>
+                <Button onClick={handleApply}>Apply to Chapter</Button>
+              </>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+export default VoiceEnhancer;

--- a/frontend/src/e2e/voice-enhancement.spec.ts
+++ b/frontend/src/e2e/voice-enhancement.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * Voice/Dictation Enhancement E2E (issue #56)
+ *
+ * Covers the voice-to-enhanced workflow from the chapter editor:
+ *   raw dictated text in the editor → Clean up dictation (mocked) → raw/cleaned
+ *   side-by-side preview → Apply (replaces editor content) → Revert (restores raw).
+ *
+ * Deterministic: chapter-content load and the enhance-transcription call are
+ * mocked via page.route(); no real backend / OpenAI / browser SpeechRecognition
+ * (which is native and non-deterministic, unavailable headless). Runs with
+ * BYPASS_AUTH=true. Mirrors the #57 content-enhancement spec.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BOOK_ID = 'e2e-voice-book';
+const CHAPTER_ID = 'e2e-voice-chapter';
+// Raw dictation as it would arrive from speech-to-text: fillers, no punctuation.
+const RAW = 'um so the cat you know sat on the mat';
+const CLEANED = '<p>The cat sat on the mat.</p>';
+
+test.describe('Voice enhancement (issue #56)', () => {
+  test('cleans up dictation, previews raw/cleaned, applies, and reverts', async ({ page }) => {
+    await page.addInitScript(() => {
+      const original = window.setTimeout.bind(window);
+      // @ts-expect-error - test shim narrows the overload deliberately
+      window.setTimeout = (handler: TimerHandler, timeout?: number, ...args: unknown[]) =>
+        timeout === 2000 ? 0 : original(handler, timeout as number, ...args);
+    });
+
+    // Chapter loads with the raw dictated content already in the editor.
+    await page.route('**/books/*/chapters/*/content*', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          content: `<p>${RAW}</p>`,
+          chapter_id: CHAPTER_ID,
+          book_id: BOOK_ID,
+          metadata: { word_count: 10, last_modified: '2026-06-29T00:00:00Z', status: 'draft', estimated_reading_time: 1 },
+        }),
+      })
+    );
+
+    // Saves (auto-save / apply) succeed.
+    await page.route('**/books/*/chapters/*/content', (route) => {
+      if (route.request().method() === 'PATCH' || route.request().method() === 'PUT') {
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true }) });
+      }
+      return route.fallback();
+    });
+
+    // Voice/dictation cleanup.
+    await page.route('**/books/*/chapters/*/enhance-transcription', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          book_id: BOOK_ID,
+          chapter_id: CHAPTER_ID,
+          enhanced: CLEANED,
+          metadata: {
+            enhancement_type: 'transcription',
+            enhancement_label: 'Dictation Cleanup',
+            original_word_count: 10,
+            enhanced_word_count: 6,
+            model_used: 'gpt-4',
+            generated_at: '2026-06-29 00:00:00',
+          },
+          message: 'Transcription cleaned up successfully',
+        }),
+      })
+    );
+
+    await page.goto(`/dashboard/books/${BOOK_ID}/chapters/${CHAPTER_ID}`);
+
+    // Editor loads with the raw dictation.
+    await expect(page.locator('.tiptap')).toContainText(RAW);
+
+    // Open the cleanup dialog and run it.
+    await page.getByRole('button', { name: /clean up dictation/i }).click();
+    const dialog = page.getByRole('dialog');
+    await dialog.getByRole('button', { name: /^clean up$/i }).click();
+
+    // Raw/cleaned preview renders both versions (scoped to the dialog).
+    await expect(dialog.getByText(/um so the cat/i)).toBeVisible();
+    await expect(dialog.getByText(/^The cat sat on the mat\.$/i)).toBeVisible();
+
+    // Apply → editor now shows the cleaned text, not the raw dictation.
+    await page.getByRole('button', { name: /apply to chapter/i }).click();
+    await expect(page.locator('.tiptap')).toContainText('The cat sat on the mat.');
+    await expect(page.locator('.tiptap')).not.toContainText('um so the cat');
+
+    // Revert → raw dictation is restored.
+    await page.getByRole('button', { name: /revert enhancement/i }).click();
+    await expect(page.locator('.tiptap')).toContainText(RAW);
+    await expect(page.locator('.tiptap')).not.toContainText('The cat sat on the mat.');
+  });
+});

--- a/frontend/src/lib/api/bookClient.ts
+++ b/frontend/src/lib/api/bookClient.ts
@@ -1281,6 +1281,48 @@ export class BookClient {
   }
 
   /**
+   * Clean up raw voice-dictated text into readable prose (issue #56).
+   * Preview-only: removes fillers, breaks paragraphs, fixes grammar/punctuation;
+   * the caller decides whether to apply.
+   */
+  public async enhanceVoiceTranscription(
+    bookId: string,
+    chapterId: string,
+    data: { content: string }
+  ): Promise<{
+    success: boolean;
+    book_id: string;
+    chapter_id: string;
+    enhanced: string;
+    metadata: {
+      enhancement_type: string;
+      enhancement_label: string;
+      original_word_count: number;
+      enhanced_word_count: number;
+      model_used: string;
+      generated_at: string;
+    };
+    message: string;
+  }> {
+    const response = await fetch(
+      `${this.baseUrl}/books/${bookId}/chapters/${chapterId}/enhance-transcription`,
+      {
+        method: 'POST',
+        headers: await this.getHeaders(),
+        credentials: 'include',
+        body: JSON.stringify(data),
+      }
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Failed to clean up transcription: ${response.status} ${error}`);
+    }
+
+    return response.json();
+  }
+
+  /**
    * Generate interview-style questions for a specific chapter
    */
   public async generateChapterQuestions(

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,53 +1,42 @@
-# Issue #57 — [P2.5] Content enhancement for existing chapter text
+# Issue #56 — [P2.6] Enhance voice input with AI analysis and formatting
 
-**Approach (lazy / mirror #58):** Reuse the proven, already-shipped *style transformation* (#58)
-pattern end-to-end. Build the SAME shape — prompt builder → `AIService` async method →
-ownership/rate-limited endpoint → `bookClient` method → dialog component with before/after
-preview → apply-with-snapshot/revert in `ChapterEditor`. No new dependencies, no floating
-selection button, no diff library.
+Branch: `feature/56-voice-input-ai-enhancement`
 
-## Deviations from the traycer plan (decided autonomously, safe defaults)
-- **No `EnhanceButton` floating component, no selection-coordinate math.** A toolbar "Enhance"
-  button mirroring the StyleTransformer button covers the AC; floating-button + `coordsAtPos`
-  is extra surface for no requirement.
-- **No `react-diff-viewer` / `diff-match-patch` dependency.** Side-by-side before/after preview
-  (exactly like StyleTransformer) satisfies "diff view shows original vs enhanced". Adding a
-  diffing dep for color highlighting is over-engineering.
-- **Operate on selected text if a selection exists, else full chapter HTML** (via the editor's
-  content getter). Satisfies "users can select text" without a new UI.
-- **"Blocked by #41" is already satisfied** — structured AI-failure → 503 handling exists.
-- Single new module `content_enhancement.py` mirrors `style_templates.py`.
+## Approach (adapted from Traycer plan)
+Mirror the #57 `enhance-text` / #58 `transform-style` house pattern: a dedicated
+service module + `ai_service` method + chapter-scoped **preview-only** endpoint +
+frontend dialog + client method + tests. Raw dictated text → AI cleanup → side-by-side
+preview → apply/revert (reusing ChapterEditor's existing snapshot/revert infra).
 
-## Enhancement types
-clarity · grammar · tone · vocabulary (per issue AC)
+### Autonomous design decisions (no architectural fork → no approval needed)
+- **Single "cleanup" mode** (one AI pass: filler removal + paragraph breaks at natural
+  pauses + grammar/punctuation), NOT the Traycer 3 boolean toggles. The AC lists all
+  three as expected *outcomes*, not user options; "toggle raw vs enhanced" = the
+  side-by-side preview + revert. Fewer moving parts. (Deviation from original plan.)
+- Temperature **0.3** (conservative, like `enhance_text`) — voice cleanup must not invent content.
+- **Reuse** ChapterEditor `getEnhanceContent` + `handleApplyEnhancement` + `preEnhanceContent`
+  revert button — no new editor state needed.
+- Ignore the unmounted `/transcribe` router and the deleted `chapter_error_handler` /
+  `chapter_cache_service` that the Traycer plan referenced (gone in #120).
+- E2E **route-mocks** the enhance endpoint — browser SpeechRecognition is native and
+  non-deterministic/unavailable headless (same approach as content-enhancement.spec.ts).
 
-## Steps (TDD: tests first where practical)
-1. **Backend prompts** — `backend/app/services/content_enhancement.py`: `ENHANCEMENT_LABELS`,
-   `ENHANCEMENT_GUIDANCE` (4 types), `available_enhancements()`, `is_valid_enhancement()`,
-   `get_enhancement_prompt(content, enhancement_type)`. Mirror `style_templates.py`.
-2. **Backend AIService** — `ai_service.enhance_text(content, enhancement_type)` mirroring
-   `transform_text_style` (temp 0.3, reject truncated output, structured return
-   `{success, enhanced, metadata}`).
-3. **Backend endpoint** — `POST /books/{book_id}/chapters/{chapter_id}/enhance-text` in
-   `books.py` mirroring `transform-style` (auth, ownership 403/404, rate limit 10/h, validate
-   `content` + `enhancement_type`, 503 on AI failure, `log_access`).
-4. **Frontend bookClient** — `enhanceChapterText(bookId, chapterId, {content, enhancement_type})`.
-5. **Frontend component** — `ContentEnhancer.tsx` mirroring `StyleTransformer.tsx`
-   (options → enhancing → preview; DOMPurify; content getter / onApply props).
-6. **ChapterEditor wiring** — mount `ContentEnhancer` in toolbar; snapshot + "Revert enhancement"
-   button (mirror the existing pre-transform snapshot pattern).
-7. **Tests**:
-   - backend `test_content_enhancement.py`, `test_ai_service_enhancement.py`,
-     `test_enhancement_endpoint.py` (happy + 400 + 404 + 403 + 503, all 4 types)
-   - frontend `ContentEnhancer.test.tsx`
-   - e2e `content-enhancement.spec.ts` (route-mocked: open → pick type → preview → apply → revert)
+## Steps (TDD: tests first)
+- [ ] 1. Backend service `app/services/transcription_enhancement.py` + test
+- [ ] 2. `ai_service.enhance_transcription(content)` + test
+- [ ] 3. Endpoint `POST /books/{id}/chapters/{cid}/enhance-transcription` in books.py + test
+- [ ] 4. `bookClient.enhanceVoiceTranscription(bookId, chapterId, {content})`
+- [ ] 5. `VoiceEnhancer.tsx` dialog (intro→enhancing→preview, DOMPurify side-by-side) + test
+- [ ] 6. Wire VoiceEnhancer into ChapterEditor toolbar (reuse revert)
+- [ ] 7. E2E `frontend/src/e2e/voice-enhancement.spec.ts`
+- [ ] 8. Docs (CLAUDE.md Recent Changes) + close #56
 
-## Acceptance Criteria (from #57)
-- [ ] Users can select text in editor (selection used if present, else full content)
-- [ ] "Enhance" button available (toolbar)
-- [ ] AI provides enhancement suggestions
-- [ ] Diff/preview shows original vs. enhanced (side-by-side)
-- [ ] Users can accept or reject changes (apply / revert)
-- [ ] Enhancement preserves original meaning (prompt-enforced)
-- [ ] Multiple enhancement types available (clarity/grammar/tone/vocabulary)
-- [ ] E2E test verifies enhancement workflow
+## Acceptance Criteria (from issue)
+- [ ] Voice transcription works reliably (existing VoiceTextInput — unchanged)
+- [ ] AI enhancement removes filler words
+- [ ] Paragraphs break at natural pauses
+- [ ] Grammar and punctuation improved
+- [ ] Users can toggle raw vs. enhanced (preview + revert)
+- [ ] Enhancement processing shows loading indicator
+- [ ] Side-by-side preview before accepting
+- [ ] E2E test verifies voice-to-enhanced workflow


### PR DESCRIPTION
Closes #56 — [P2.6] Enhance voice input with AI analysis and formatting.

## What
Adds **AI cleanup of voice-dictated text**: a single, conservative AI pass that
removes filler words, breaks paragraphs at natural pauses, and fixes grammar &
punctuation — **preserving exactly what was said**. Preview-only with a
raw-vs-cleaned side-by-side and one-click revert.

Built by **mirroring the shipped #57 `enhance-text` pattern** end to end — no new
dependencies, no changes to the (unmounted) `/transcribe` router.

## Changes
**Backend**
- `app/services/transcription_enhancement.py` — single `TRANSCRIPTION_CLEANUP_GUIDANCE` + `get_transcription_enhancement_prompt(content)` (fact-preserving).
- `ai_service.enhance_transcription(content)` — temp **0.3** (conservative); rejects length-truncated output so a long dictation can't be silently shortened; structured `{success, enhanced, metadata}`.
- `POST /books/{id}/chapters/{cid}/enhance-transcription` — session auth, ownership **403**, chapter-existence **404**, **10/h** rate limit, **400** empty-content, **503** on AI failure. **Preview-only, no persistence.**

**Frontend**
- `VoiceEnhancer.tsx` dialog (intro → enhancing → preview; DOMPurify-sanitized raw-vs-cleaned side-by-side; mirrors `ContentEnhancer`).
- `bookClient.enhanceVoiceTranscription()`.
- `ChapterEditor` toolbar **"Clean up dictation"** button — **reuses** the existing `getEnhanceContent` + `handleApplyEnhancement` + **"Revert enhancement"** snapshot/revert (no new editor state).

## Design decisions
- **Single "cleanup" mode**, not the original plan's 3 boolean toggles — the AC lists filler removal / paragraphing / grammar as expected *outcomes*, not user options; "toggle raw vs enhanced" = the preview + revert. Fewer moving parts.
- E2E **route-mocks** the endpoint: browser `SpeechRecognition` is native, non-deterministic, and unavailable headless (same approach as the #57 spec).

## Acceptance criteria
- [x] AI enhancement removes filler words
- [x] Paragraphs break at natural pauses
- [x] Grammar and punctuation improved
- [x] Users can toggle raw vs. enhanced (preview + revert)
- [x] Processing shows a loading indicator
- [x] Side-by-side preview before accepting
- [x] E2E test verifies the voice-to-enhanced workflow
- [x] Voice transcription itself unchanged (existing `VoiceTextInput`)

## Testing
- Backend: **957 passed, 92.36% cov** (`transcription_enhancement.py` 100%).
- Frontend: **1878 passed**, gates green (85/85/75/85); `VoiceEnhancer.test.tsx` + route-mocked E2E.
- Pre-commit hooks (lint/typecheck/tests/coverage) pass with **no** `--no-verify`.

## Known limitations
- E2E runs on chromium/firefox/mobile-chrome; webkit/Mobile-Safari fail to load the editor in this WSL env — a **pre-existing** environmental issue affecting the already-merged #57 spec identically, not introduced here.
- Applying raw `enhanced` HTML to the editor is unsanitized — the established pattern shared by `ContentEnhancer`/`StyleTransformer` (preview is DOMPurify-sanitized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)