### PR TITLE
feat(questions): complete progress tracking for chapter questions (#53)

### DIFF
--- a/frontend/src/__tests__/ChapterQuestionsIntegration.test.tsx
+++ b/frontend/src/__tests__/ChapterQuestionsIntegration.test.tsx
@@ -335,7 +335,7 @@ describe('Chapter Questions Integration Tests', () => {
       });
 
       // Navigate to next question
-      const nextButton = screen.getByRole('button', { name: /next/i });
+      const nextButton = screen.getByRole('button', { name: /^next$/i });
       fireEvent.click(nextButton);
 
       await waitFor(() => {
@@ -544,7 +544,7 @@ describe('Chapter Questions Integration Tests', () => {
       expect(focusedElement).toHaveProperty('tagName', 'BUTTON');
 
       // Find and click the next button directly
-      const nextButton = screen.getByRole('button', { name: /next/i });
+      const nextButton = screen.getByRole('button', { name: /^next$/i });
       await user.click(nextButton);
 
       await waitFor(() => {

--- a/frontend/src/__tests__/ChapterQuestionsMobileAccessibility.test.tsx
+++ b/frontend/src/__tests__/ChapterQuestionsMobileAccessibility.test.tsx
@@ -284,7 +284,7 @@ describe('Chapter Questions Mobile and Accessibility Tests', () => {
       const questionContainer = screen.getByTestId('question-container');
 
       // Find and click the next button instead of simulating swipe
-      const nextButton = screen.getByRole('button', { name: /next/i });
+      const nextButton = screen.getByRole('button', { name: /^next$/i });
       fireEvent.click(nextButton);
 
       await waitFor(() => {

--- a/frontend/src/components/chapters/questions/QuestionContainer.tsx
+++ b/frontend/src/components/chapters/questions/QuestionContainer.tsx
@@ -249,7 +249,10 @@ export default function QuestionContainer({
 
   // Response saved handler
   const handleResponseSaved = async () => {
-    await fetchProgress();
+    // Refresh the questions array (not just aggregate progress) so per-question
+    // response_status stays current in the navigation dropdown and progress dots.
+    // fetchQuestions also refreshes progress internally.
+    await fetchQuestions(true);
     // Call parent callback if provided
     if (parentResponseSaved) {
       parentResponseSaved();
@@ -424,6 +427,7 @@ export default function QuestionContainer({
           progress={progress}
           currentIndex={currentQuestionIndex}
           totalQuestions={questions.length}
+          questions={questions}
         />
       )}
 

--- a/frontend/src/components/chapters/questions/QuestionNavigation.tsx
+++ b/frontend/src/components/chapters/questions/QuestionNavigation.tsx
@@ -3,7 +3,7 @@
 import { Question } from '@/types/chapter-questions';
 import { Button } from '@/components/ui/button';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { ArrowLeft01Icon, ArrowRight01Icon, Tick02Icon, Forward01Icon, Menu01Icon } from '@hugeicons/core-free-icons';
+import { ArrowLeft01Icon, ArrowRight01Icon, Tick02Icon, Forward01Icon, Menu01Icon, ArrowRightDoubleIcon } from '@hugeicons/core-free-icons';
 import { useState } from 'react';
 
 interface QuestionNavigationProps {
@@ -13,6 +13,21 @@ interface QuestionNavigationProps {
   onPrevious: () => void;
   onGoToQuestion: (index: number) => void;
   questions: Question[];
+}
+
+/**
+ * Find the next question without a completed response, searching forward from
+ * currentIndex and wrapping to the start. Returns -1 when all are completed.
+ */
+export function findNextUnanswered(questions: Question[], currentIndex: number): number {
+  const total = questions.length;
+  for (let offset = 1; offset <= total; offset++) {
+    const index = (currentIndex + offset) % total;
+    if (questions[index]?.response_status !== 'completed') {
+      return index;
+    }
+  }
+  return -1;
 }
 
 /**
@@ -50,10 +65,16 @@ export default function QuestionNavigation({
       statusIndicator = '✓ ';
     } else if (question.response_status === 'draft') {
       statusIndicator = '⚙️ ';
+    } else {
+      // Unanswered — distinct marker so it stands out from answered items
+      statusIndicator = '○ ';
     }
 
     return `${statusIndicator}${index + 1}. ${truncatedText}`;
   };
+
+  const nextUnansweredIndex = findNextUnanswered(questions, currentIndex);
+  const allAnswered = nextUnansweredIndex === -1;
 
   return (
     <div className="flex flex-col space-y-2 transition-all" data-slot="question-navigation">
@@ -85,20 +106,24 @@ export default function QuestionNavigation({
           {showQuestionList && (
             <div className="absolute z-10 mt-1 w-64 max-h-80 overflow-y-auto bg-background border border-border rounded-md shadow-lg transition-all">
               <ul className="py-1">
-                {questions.map((_, index) => (
-                  <li
-                    key={index}
-                    className={`px-4 py-2 text-sm cursor-pointer hover:bg-accent transition-all ${
-                      index === currentIndex ? 'bg-accent' : ''
-                    }`}
-                    onClick={() => {
-                      onGoToQuestion(index);
-                      setShowQuestionList(false);
-                    }}
-                  >
-                    {getQuestionTitle(index)}
-                  </li>
-                ))}
+                {questions.map((question, index) => {
+                  const isUnanswered = question.response_status !== 'completed'
+                    && question.response_status !== 'draft';
+                  return (
+                    <li
+                      key={index}
+                      className={`px-4 py-2 text-sm cursor-pointer hover:bg-accent transition-all ${
+                        index === currentIndex ? 'bg-accent' : ''
+                      } ${isUnanswered ? 'text-muted-foreground' : ''}`}
+                      onClick={() => {
+                        onGoToQuestion(index);
+                        setShowQuestionList(false);
+                      }}
+                    >
+                      {getQuestionTitle(index)}
+                    </li>
+                  );
+                })}
               </ul>
             </div>
           )}
@@ -118,6 +143,18 @@ export default function QuestionNavigation({
 
       {/* Secondary actions */}
       <div className="flex justify-center space-x-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-xs min-h-[44px] min-w-[44px] transition-all focus-visible:ring-[3px]"
+          onClick={() => onGoToQuestion(nextUnansweredIndex)}
+          disabled={allAnswered}
+          title={allAnswered ? 'All questions answered' : 'Jump to the next unanswered question'}
+        >
+          <HugeiconsIcon icon={ArrowRightDoubleIcon} size={12} className="mr-1" />
+          <span>Next Unanswered</span>
+        </Button>
+
         <Button
           variant="ghost"
           size="sm"

--- a/frontend/src/components/chapters/questions/QuestionProgress.tsx
+++ b/frontend/src/components/chapters/questions/QuestionProgress.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { QuestionProgressResponse } from '@/types/chapter-questions';
+import { Question, QuestionProgressResponse } from '@/types/chapter-questions';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { CheckmarkCircle01Icon, CircleIcon, Loading03Icon } from '@hugeicons/core-free-icons';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -10,6 +10,9 @@ interface QuestionProgressProps {
   progress: QuestionProgressResponse;
   currentIndex: number;
   totalQuestions: number;
+  // Per-question statuses, so dots reflect actual completion (handles out-of-order
+  // answers). Falls back to positional progress when not provided.
+  questions?: Question[];
 }
 
 /**
@@ -18,7 +21,8 @@ interface QuestionProgressProps {
 export default function QuestionProgress({
   progress,
   currentIndex,
-  totalQuestions
+  totalQuestions,
+  questions
 }: QuestionProgressProps) {
   // Calculate progress percentage for the progress bar (progress is 0.0-1.0, convert to 0-100)
   const progressPercentage = (progress.progress || 0) * 100;
@@ -111,10 +115,16 @@ export default function QuestionProgress({
       {/* Question dots - visual representation of each question's status */}
       <div className="flex items-center justify-center space-x-1 mt-2 transition-all">
         {Array.from({ length: totalQuestions }).map((_, index) => {
-          // For each question, show its status
-          const isCompleted = index < progress.completed;
-          const isInProgress = index === progress.completed && progress.in_progress > 0;
+          // Prefer per-question status (correct for out-of-order answers); fall back
+          // to positional progress when the questions array isn't supplied.
+          const status = questions?.[index]?.response_status;
           const isCurrent = index === currentIndex;
+          const isCompleted = questions
+            ? status === 'completed'
+            : index < progress.completed;
+          const isInProgress = questions
+            ? status === 'draft'
+            : index === progress.completed && progress.in_progress > 0;
 
           let dotClasses = "w-2 h-2 rounded-full transition-all ";
 

--- a/frontend/src/components/chapters/questions/__tests__/QuestionContainer.test.tsx
+++ b/frontend/src/components/chapters/questions/__tests__/QuestionContainer.test.tsx
@@ -539,6 +539,25 @@ describe('QuestionContainer - handleResponseSaved', () => {
     });
   });
 
+  it('re-fetches the questions array when a response is saved (keeps statuses fresh)', async () => {
+    setupTwoQuestions();
+
+    render(<QuestionContainer {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('question-display')).toBeInTheDocument();
+    });
+
+    // Clear count so we only measure the post-save refresh
+    mockedBookClient.getChapterQuestions.mockClear();
+
+    fireEvent.click(screen.getByTestId('response-saved-btn'));
+
+    await waitFor(() => {
+      expect(mockedBookClient.getChapterQuestions).toHaveBeenCalledWith('book-1', 'ch-1');
+    });
+  });
+
   it('calls the parent onResponseSaved callback when response is saved', async () => {
     setupTwoQuestions();
     const onResponseSaved = jest.fn();

--- a/frontend/src/components/chapters/questions/__tests__/QuestionNavigation.test.tsx
+++ b/frontend/src/components/chapters/questions/__tests__/QuestionNavigation.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import QuestionNavigation from '../QuestionNavigation';
+import QuestionNavigation, { findNextUnanswered } from '../QuestionNavigation';
 import { Question, QuestionType, QuestionDifficulty } from '@/types/chapter-questions';
 
 // ---------------------------------------------------------------------------
@@ -168,8 +168,8 @@ describe('QuestionNavigation - dropdown and getQuestionTitle', () => {
     );
     fireEvent.click(screen.getByText('Question 1 of 2').closest('button')!);
 
-    // The truncated form should end with '...'
-    expect(screen.getByText(/^1\. .{50}\.\.\./)).toBeInTheDocument();
+    // The truncated form should end with '...' (unanswered items carry a ○ prefix)
+    expect(screen.getByText(/^○ 1\. .{50}\.\.\./)).toBeInTheDocument();
   });
 
   it('getQuestionTitle adds ✓ prefix for completed questions', () => {
@@ -188,6 +188,27 @@ describe('QuestionNavigation - dropdown and getQuestionTitle', () => {
 
     const items = screen.getAllByRole('listitem');
     expect(items[0].textContent).toMatch(/^✓ /);
+  });
+
+  it('getQuestionTitle adds ○ prefix and muted text for unanswered questions', () => {
+    const questions = [
+      makeQuestion(), // no response_status -> unanswered
+      makeQuestion({ id: 'q-2', response_status: 'completed' as any, order: 2 }),
+    ];
+    render(
+      <QuestionNavigation
+        {...defaultProps}
+        questions={questions}
+        totalQuestions={2}
+      />
+    );
+    fireEvent.click(screen.getByText('Question 1 of 2').closest('button')!);
+
+    const items = screen.getAllByRole('listitem');
+    expect(items[0].textContent).toMatch(/^○ /);
+    expect(items[0].className).toContain('text-muted-foreground');
+    // Answered item is not muted
+    expect(items[1].className).not.toContain('text-muted-foreground');
   });
 
   it('getQuestionTitle adds ⚙️ prefix for draft questions', () => {
@@ -281,5 +302,78 @@ describe('QuestionNavigation - secondary action button', () => {
     );
     fireEvent.click(screen.getByText('Finish and restart').closest('button')!);
     expect(onGoToQuestion).toHaveBeenCalledWith(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findNextUnanswered helper
+// ---------------------------------------------------------------------------
+
+describe('findNextUnanswered', () => {
+  const q = (status?: string) =>
+    makeQuestion({ response_status: status as any });
+
+  it('returns the next non-completed index after currentIndex', () => {
+    const questions = [q('completed'), q('completed'), q(), q()];
+    expect(findNextUnanswered(questions, 0)).toBe(2);
+  });
+
+  it('treats draft as not-yet-answered', () => {
+    const questions = [q('completed'), q('draft'), q('completed')];
+    expect(findNextUnanswered(questions, 0)).toBe(1);
+  });
+
+  it('wraps around to the start', () => {
+    const questions = [q(), q('completed'), q('completed')];
+    expect(findNextUnanswered(questions, 2)).toBe(0);
+  });
+
+  it('returns -1 when every question is completed', () => {
+    const questions = [q('completed'), q('completed')];
+    expect(findNextUnanswered(questions, 0)).toBe(-1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// "Next Unanswered" navigation button
+// ---------------------------------------------------------------------------
+
+describe('QuestionNavigation - Next Unanswered button', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('navigates to the next unanswered question', () => {
+    const onGoToQuestion = jest.fn();
+    const questions = [
+      makeQuestion({ id: 'q-1', response_status: 'completed' as any }),
+      makeQuestion({ id: 'q-2', order: 2 }), // unanswered
+      makeQuestion({ id: 'q-3', order: 3 }),
+    ];
+    render(
+      <QuestionNavigation
+        {...defaultProps}
+        onGoToQuestion={onGoToQuestion}
+        currentIndex={0}
+        totalQuestions={3}
+        questions={questions}
+      />
+    );
+    fireEvent.click(screen.getByText('Next Unanswered').closest('button')!);
+    expect(onGoToQuestion).toHaveBeenCalledWith(1);
+  });
+
+  it('is disabled when all questions are completed', () => {
+    const questions = [
+      makeQuestion({ id: 'q-1', response_status: 'completed' as any }),
+      makeQuestion({ id: 'q-2', response_status: 'completed' as any, order: 2 }),
+    ];
+    render(
+      <QuestionNavigation
+        {...defaultProps}
+        currentIndex={0}
+        totalQuestions={2}
+        questions={questions}
+      />
+    );
+    expect(screen.getByText('Next Unanswered').closest('button')).toBeDisabled();
   });
 });

--- a/frontend/src/components/chapters/questions/__tests__/QuestionProgress.test.tsx
+++ b/frontend/src/components/chapters/questions/__tests__/QuestionProgress.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Tests for QuestionProgress component.
+ * Covers: status label, progress bar value, and per-question dot colouring
+ * (which must reflect each question's response_status, not positional order).
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import QuestionProgress from '../QuestionProgress';
+import {
+  Question,
+  QuestionProgressResponse,
+  QuestionType,
+  QuestionDifficulty,
+} from '@/types/chapter-questions';
+
+function makeQuestion(overrides: Partial<Question> = {}): Question {
+  return {
+    id: 'q-1',
+    chapter_id: 'ch-1',
+    question_text: 'A question',
+    question_type: QuestionType.CHARACTER,
+    difficulty: QuestionDifficulty.MEDIUM,
+    category: 'character',
+    order: 1,
+    generated_at: '2024-01-01T00:00:00Z',
+    metadata: { suggested_response_length: '100 words' },
+    ...overrides,
+  };
+}
+
+const baseProgress: QuestionProgressResponse = {
+  total: 3,
+  completed: 1,
+  in_progress: 0,
+  progress: 1 / 3,
+  status: 'in-progress',
+};
+
+function getDots(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll('[data-slot="progress-dot"]'));
+}
+
+describe('QuestionProgress - status and bar', () => {
+  it('shows "X of Y questions answered" while in progress', () => {
+    render(
+      <QuestionProgress progress={baseProgress} currentIndex={0} totalQuestions={3} />
+    );
+    expect(screen.getByText('1 of 3 questions answered')).toBeInTheDocument();
+  });
+
+  it('sets progressbar aria-valuenow from the 0-1 progress value', () => {
+    render(
+      <QuestionProgress progress={baseProgress} currentIndex={0} totalQuestions={3} />
+    );
+    // 1/3 -> 33
+    expect(screen.getByTestId('question-progressbar')).toHaveAttribute('aria-valuenow', '33');
+  });
+});
+
+describe('QuestionProgress - per-question dots', () => {
+  it('colours dots by each question response_status, not by position', () => {
+    // Out-of-order: only the 3rd question is completed.
+    const questions = [
+      makeQuestion({ id: 'q-1' }),
+      makeQuestion({ id: 'q-2', response_status: 'draft' as any }),
+      makeQuestion({ id: 'q-3', response_status: 'completed' as any }),
+    ];
+
+    const { container } = render(
+      <QuestionProgress
+        progress={baseProgress}
+        currentIndex={0}
+        totalQuestions={3}
+        questions={questions}
+      />
+    );
+
+    const dots = getDots(container);
+    // q-1 unanswered + current -> blue; q-2 draft -> amber; q-3 completed -> green
+    expect(dots[0].className).toContain('bg-blue-600');
+    expect(dots[1].className).toContain('bg-amber-600');
+    expect(dots[2].className).toContain('bg-green-600');
+  });
+
+  it('falls back to positional colouring when no questions array is given', () => {
+    const { container } = render(
+      <QuestionProgress
+        progress={{ ...baseProgress, completed: 2 }}
+        currentIndex={2}
+        totalQuestions={3}
+      />
+    );
+
+    const dots = getDots(container);
+    // First two positions completed (green), third is current (blue)
+    expect(dots[0].className).toContain('bg-green-600');
+    expect(dots[1].className).toContain('bg-green-600');
+    expect(dots[2].className).toContain('bg-blue-600');
+  });
+});

--- a/frontend/src/e2e/chapter-questions-progress.spec.ts
+++ b/frontend/src/e2e/chapter-questions-progress.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * Chapter question progress tracking E2E (issue #53)
+ *
+ * Confirms the progress-tracking UI works end-to-end in a browser:
+ *   - "X of Y questions answered" + progress bar render from real data
+ *   - "Next Unanswered" jumps to the first not-completed question
+ *   - "Next Unanswered" is disabled when every question is completed
+ *
+ * Deterministic: the chapter content, questions list and progress summary are
+ * mocked via page.route(); no real backend / OpenAI. Runs with BYPASS_AUTH=true.
+ * Mirrors the #57 content-enhancement spec (cancel only the editor's 2s
+ * auto-redirect timer so the editor stays mounted).
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BOOK_ID = 'e2e-progress-book';
+const CHAPTER_ID = 'e2e-progress-chapter';
+
+function question(id: string, order: number, text: string, status?: 'completed' | 'draft') {
+  return {
+    id,
+    chapter_id: CHAPTER_ID,
+    question_text: text,
+    question_type: 'character',
+    difficulty: 'medium',
+    category: 'character',
+    order,
+    generated_at: '2026-06-29T00:00:00Z',
+    metadata: { suggested_response_length: '100 words' },
+    ...(status ? { response_status: status, has_response: true } : {}),
+  };
+}
+
+async function mockEditor(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    const original = window.setTimeout.bind(window);
+    // @ts-expect-error - test shim narrows the overload deliberately
+    window.setTimeout = (handler: TimerHandler, timeout?: number, ...args: unknown[]) =>
+      timeout === 2000 ? 0 : original(handler, timeout as number, ...args);
+  });
+
+  await page.route('**/books/*/chapters/*/content*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        content: '<p>Chapter body</p>',
+        chapter_id: CHAPTER_ID,
+        book_id: BOOK_ID,
+        metadata: { word_count: 2, last_modified: '2026-06-29T00:00:00Z', status: 'draft', estimated_reading_time: 1 },
+      }),
+    })
+  );
+}
+
+test.describe('Chapter question progress tracking (issue #53)', () => {
+  test('shows "X of Y answered" and jumps to the next unanswered question', async ({ page }) => {
+    await mockEditor(page);
+
+    // Q1 completed, Q2 unanswered, Q3 completed (out of order → positional logic would be wrong).
+    const questions = [
+      question('q-1', 1, 'First question', 'completed'),
+      question('q-2', 2, 'Second question'),
+      question('q-3', 3, 'Third question', 'completed'),
+    ];
+
+    await page.route('**/books/*/chapters/*/questions?*', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ questions, total: 3, page: 1, pages: 1 }),
+      })
+    );
+    await page.route('**/books/*/chapters/*/question-progress', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ total: 3, completed: 2, in_progress: 0, progress: 2 / 3, status: 'in-progress' }),
+      })
+    );
+
+    await page.goto(`/dashboard/books/${BOOK_ID}/chapters/${CHAPTER_ID}`);
+    await page.getByRole('tab', { name: /Interview Questions/i }).click();
+
+    // Progress summary + bar reflect real data.
+    await expect(page.getByText('2 of 3 questions answered')).toBeVisible();
+    await expect(page.getByTestId('question-progressbar')).toHaveAttribute('aria-valuenow', '67');
+
+    // Starts on Q1 (target the navigation counter button specifically).
+    await expect(page.getByRole('button', { name: /Question 1 of 3/i })).toBeVisible();
+
+    // "Next Unanswered" jumps to Q2 (the only not-completed question).
+    await page.getByRole('button', { name: /Next Unanswered/i }).click();
+    await expect(page.getByRole('button', { name: /Question 2 of 3/i })).toBeVisible();
+    await expect(page.getByText('Second question')).toBeVisible();
+  });
+
+  test('"Next Unanswered" is disabled when all questions are completed', async ({ page }) => {
+    await mockEditor(page);
+
+    const questions = [
+      question('q-1', 1, 'First question', 'completed'),
+      question('q-2', 2, 'Second question', 'completed'),
+    ];
+
+    await page.route('**/books/*/chapters/*/questions?*', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ questions, total: 2, page: 1, pages: 1 }),
+      })
+    );
+    await page.route('**/books/*/chapters/*/question-progress', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ total: 2, completed: 2, in_progress: 0, progress: 1, status: 'completed' }),
+      })
+    );
+
+    await page.goto(`/dashboard/books/${BOOK_ID}/chapters/${CHAPTER_ID}`);
+    await page.getByRole('tab', { name: /Interview Questions/i }).click();
+
+    await expect(page.getByText('All questions completed')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Next Unanswered/i })).toBeDisabled();
+  });
+});

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,42 +1,32 @@
-# Issue #56 — [P2.6] Enhance voice input with AI analysis and formatting
+# Issue #53 [P2.7] — Fix incomplete progress tracking for chapter question workflows
 
-Branch: `feature/56-voice-input-ai-enhancement`
+Branch: `feature/53-question-progress-tracking`
 
-## Approach (adapted from Traycer plan)
-Mirror the #57 `enhance-text` / #58 `transform-style` house pattern: a dedicated
-service module + `ai_service` method + chapter-scoped **preview-only** endpoint +
-frontend dialog + client method + tests. Raw dictated text → AI cleanup → side-by-side
-preview → apply/revert (reusing ChapterEditor's existing snapshot/revert infra).
+## Findings (plan adapted to actual code)
+Backend already supplies progress + per-question `response_status` (DRAFT/COMPLETED;
+unanswered = undefined). The CodeRabbit/Traycer "replace stub Progress bar" task is
+**already done** — `QuestionProgress.tsx` already imports the real shadcn `Progress`.
+Remaining genuine gaps, frontend only:
 
-### Autonomous design decisions (no architectural fork → no approval needed)
-- **Single "cleanup" mode** (one AI pass: filler removal + paragraph breaks at natural
-  pauses + grammar/punctuation), NOT the Traycer 3 boolean toggles. The AC lists all
-  three as expected *outcomes*, not user options; "toggle raw vs enhanced" = the
-  side-by-side preview + revert. Fewer moving parts. (Deviation from original plan.)
-- Temperature **0.3** (conservative, like `enhance_text`) — voice cleanup must not invent content.
-- **Reuse** ChapterEditor `getEnhanceContent` + `handleApplyEnhancement` + `preEnhanceContent`
-  revert button — no new editor state needed.
-- Ignore the unmounted `/transcribe` router and the deleted `chapter_error_handler` /
-  `chapter_cache_service` that the Traycer plan referenced (gone in #120).
-- E2E **route-mocks** the enhance endpoint — browser SpeechRecognition is native and
-  non-deterministic/unavailable headless (same approach as content-enhancement.spec.ts).
+## Tasks
+- [ ] **A** `QuestionContainer.handleResponseSaved` refreshes only progress, not the
+  questions array → dropdown/dots show stale status. Refresh both (call `fetchQuestions`
+  which already re-fetches progress). Pass `questions` to `QuestionProgress`.
+- [ ] **B** `QuestionProgress` dots use positional logic (`index < progress.completed`),
+  wrong for out-of-order answers. Use per-question `response_status`.
+- [ ] **C** `QuestionNavigation`: add `findNextUnanswered` + "Next Unanswered" button
+  (disabled when all completed).
+- [ ] **D** `QuestionNavigation` dropdown: mark unanswered questions distinctly (○ + muted).
+- [ ] **E** Tests: QuestionProgress (per-question dots), QuestionNavigation (next-unanswered
+  + dropdown marker), QuestionContainer (refresh-on-save), E2E progress spec.
 
-## Steps (TDD: tests first)
-- [ ] 1. Backend service `app/services/transcription_enhancement.py` + test
-- [ ] 2. `ai_service.enhance_transcription(content)` + test
-- [ ] 3. Endpoint `POST /books/{id}/chapters/{cid}/enhance-transcription` in books.py + test
-- [ ] 4. `bookClient.enhanceVoiceTranscription(bookId, chapterId, {content})`
-- [ ] 5. `VoiceEnhancer.tsx` dialog (intro→enhancing→preview, DOMPurify side-by-side) + test
-- [ ] 6. Wire VoiceEnhancer into ChapterEditor toolbar (reuse revert)
-- [ ] 7. E2E `frontend/src/e2e/voice-enhancement.spec.ts`
-- [ ] 8. Docs (CLAUDE.md Recent Changes) + close #56
+## Acceptance criteria mapping
+- "X of Y answered" / progress bar % — already present (QuestionProgress). Verify.
+- Unanswered distinct — D.
+- "Next Unanswered" navigates — C.
+- Progress persists across sessions — backend persists; load on mount. Verify.
+- Real-time updates — A.
+- Integration + E2E tests — E.
 
-## Acceptance Criteria (from issue)
-- [ ] Voice transcription works reliably (existing VoiceTextInput — unchanged)
-- [ ] AI enhancement removes filler words
-- [ ] Paragraphs break at natural pauses
-- [ ] Grammar and punctuation improved
-- [ ] Users can toggle raw vs. enhanced (preview + revert)
-- [ ] Enhancement processing shows loading indicator
-- [ ] Side-by-side preview before accepting
-- [ ] E2E test verifies voice-to-enhanced workflow
+## Out of scope
+No backend changes. No new keyboard shortcut (YAGNI). Minimal diff.


### PR DESCRIPTION
## Summary
Closes #53 [P2.7]. The backend already supplied progress data + per-question
`response_status`; this PR closes the remaining **frontend** gaps so progress
tracking is accurate and actionable.

The "replace the stub progress bar with shadcn `Progress`" task from the
CodeRabbit/Traycer plans was **already done** in the codebase, so it's omitted.

## Changes
- **Real-time updates** — `QuestionContainer.handleResponseSaved` now re-fetches
  the questions array (not just the aggregate progress summary), so per-question
  status in the navigation dropdown and progress dots updates immediately after a
  save instead of going stale until reload.
- **Accurate progress dots** — `QuestionProgress` colours each dot from that
  question's `response_status` (green=completed, amber=draft, blue=current, gray)
  instead of positional `index < completed` logic, which was wrong for
  out-of-order answers. Falls back to positional when no questions array is given.
- **"Next Unanswered" navigation** — `QuestionNavigation` gains a button that
  jumps to the first not-completed question (`findNextUnanswered`, wraps around,
  disabled when all completed).
- **Distinct unanswered items** — dropdown marks unanswered questions with a `○`
  prefix + muted text (completed `✓`, draft `⚙️` unchanged).

## Acceptance criteria
- [x] "X of Y questions answered" — already rendered by `QuestionProgress` (verified)
- [x] Visual progress bar % — already rendered (verified)
- [x] Unanswered questions visually distinct — dropdown `○` + muted; gray dots
- [x] "Next Unanswered" button navigates correctly
- [x] Progress persists across sessions — backend-persisted; loaded on mount (verified)
- [x] Progress updates in real-time — refresh questions on save
- [x] Integration test verifies progress calculation
- [x] E2E test confirms progress tracking works

## Testing
- Frontend: 1890 passed / 8 skipped, 94 suites. Coverage 90.98% stmts /
  82.99% branch / 88.62% func / 91.97% lines (clears 85/85/75/85).
- Backend: 957 passed (no backend changes).
- New unit tests: `QuestionProgress.test.tsx` (per-question dots, positional
  fallback), `QuestionNavigation.test.tsx` (`findNextUnanswered`, Next-Unanswered
  button, dropdown marker), `QuestionContainer.test.tsx` (refresh-on-save).
- New route-mocked E2E `chapter-questions-progress.spec.ts` (2/2 on Chromium):
  X-of-Y + bar render, Next-Unanswered jumps correctly, disabled when all done.
- `codex review` (cross-family) flagged no issues in these changes.

## Known limitations
- No new keyboard shortcut for "Next Unanswered" (YAGNI; tooltip hint only).
- The E2E is route-mocked (deterministic, no real backend/AI), mirroring the
  #57/#58 specs; it reaches `QuestionContainer` via the ChapterEditor
  "Interview Questions" tab (wired in #105).

🤖 Generated with [Claude Code](https://claude.com/claude-code)