### PR TITLE
chore: remove stale test-failures dump & unused @dnd-kit deps (#90)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,9 +8,6 @@
       "name": "auto-author-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@dnd-kit/core": "^6.1.0",
-        "@dnd-kit/sortable": "^8.0.0",
-        "@dnd-kit/utilities": "^3.2.2",
         "@hello-pangea/dnd": "^18.0.1",
         "@hookform/resolvers": "^3.10.0",
         "@hugeicons/core-free-icons": "^3.1.0",
@@ -662,60 +659,6 @@
       "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
       "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==",
       "peer": true
-    },
-    "node_modules/@dnd-kit/accessibility": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
-      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/core": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
-      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@dnd-kit/accessibility": "^3.1.1",
-        "@dnd-kit/utilities": "^3.2.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/sortable": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
-      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
-      "license": "MIT",
-      "dependencies": {
-        "@dnd-kit/utilities": "^3.2.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@dnd-kit/core": "^6.1.0",
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/utilities": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
-      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.7.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,9 +20,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@dnd-kit/core": "^6.1.0",
-    "@dnd-kit/sortable": "^8.0.0",
-    "@dnd-kit/utilities": "^3.2.2",
     "@hello-pangea/dnd": "^18.0.1",
     "@hookform/resolvers": "^3.10.0",
     "@hugeicons/core-free-icons": "^3.1.0",


### PR DESCRIPTION
Closes #90 (P3.2 repo hygiene).

## What
- **Delete `test_failures_2025-11-19.md`** — a 4.2MB stale Jest/Playwright error dump in the repo root, unreferenced by any code (only the plan mentioned it).
- **Remove `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities`** from frontend deps — nothing imports them (`grep -rn "dnd-kit" frontend/src` → 0). The app's only DnD library is `@hello-pangea/dnd` (used in `TabBar.tsx`), which stays. Lockfile regenerated: `npm install` removed 4 packages.

No `src/` code changed.

## Verification
- `grep -n "dnd-kit" frontend/package.json` → no matches
- `grep -c "@dnd-kit" frontend/package-lock.json` → 0
- `cd frontend && npm run build` → exit 0
- Pre-commit gates green: lint, typecheck, frontend unit tests, coverage ≥85%

## Known Limitations
- Other loose root clutter (`*.ps1`, `backend/*.log`, misc root markdown) left untouched — out of scope per the plan (needs a judgment call on intent).
- `.gitignore` hardening to prevent future large dumps deferred (plan maintenance note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused drag-and-drop packages from the app’s dependency list, reducing maintenance overhead and keeping the project setup cleaner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->