### PR TITLE
fix(ci): harden deploy-staging.yml test gate + SSH preflight (#163)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,10 +1,12 @@
 name: Deploy to Staging
 
 on:
-  push:
-    branches: [main]
+  # Deploy only after the real test workflow ("Tests and Quality Checks" in
+  # tests.yml) succeeds on main. The old name "Test Suite" matched no workflow,
+  # so this trigger never fired and the removed `push` trigger deployed every
+  # push regardless of test results. See #163.
   workflow_run:
-    workflows: ["Test Suite"]
+    workflows: ["Tests and Quality Checks"]
     types: [completed]
     branches: [main]
 
@@ -48,7 +50,7 @@ jobs:
   build-and-deploy:
     name: Build and Deploy to Staging
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'push' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     environment:
       name: staging
@@ -57,6 +59,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Deploy the exact commit that passed "Tests and Quality Checks",
+          # not whatever HEAD happens to be when this workflow_run fires.
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -112,11 +118,34 @@ jobs:
           tar -czf /tmp/deploy-package.tar.gz .
 
       - name: Setup SSH
+        env:
+          HOST: ${{ secrets.HOST }}
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_KEY }}" > ~/.ssh/staging_key
           chmod 600 ~/.ssh/staging_key
-          ssh-keyscan -H ${{ secrets.HOST }} >> ~/.ssh/known_hosts
+
+          # Preflight: confirm the staging host answers on TCP/22 before doing
+          # anything SSH. Without this, an unreachable host (see #162) surfaces
+          # only as an opaque "Process completed with exit code 1" from the 5s
+          # ssh-keyscan timeout, masking a server outage as a deploy failure.
+          if ! nc -z -w5 "$HOST" 22; then
+            echo "::error::Staging host ($HOST):22 is unreachable — the server may be down or firewalled, not a deploy bug. See #162."
+            exit 1
+          fi
+
+          # Retry ssh-keyscan to ride out transient network blips.
+          for attempt in 1 2 3; do
+            if ssh-keyscan -H "$HOST" >> ~/.ssh/known_hosts 2>/dev/null; then
+              break
+            fi
+            echo "ssh-keyscan attempt $attempt/3 failed"
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::ssh-keyscan failed for the staging host after 3 attempts. See #162."
+              exit 1
+            fi
+            sleep 3
+          done
 
       - name: Upload package to server
         run: |


### PR DESCRIPTION
Closes #163.

## What

Hardens `.github/workflows/deploy-staging.yml` so a staging deploy is actually gated on tests and an infra outage fails loud and diagnosable. CI robustness only — **no application code, secrets, or other workflows change.**

## Changes

1. **Restore the test gate**
   - `workflow_run` now references the real workflow name `"Tests and Quality Checks"` (was `"Test Suite"`, which matched no workflow, so the trigger never fired).
   - Dropped the `push: branches: [main]` trigger — the escape hatch that deployed **every** push to main regardless of whether tests passed.
   - Job `if:` tightened to `github.event.workflow_run.conclusion == 'success'`.
   - Checkout now uses `github.event.workflow_run.head_sha` so the deployed commit is exactly the one that passed tests.

2. **Loud SSH preflight** (Setup SSH)
   - `nc -z -w5 "$HOST" 22` reachability check before any SSH work → clear `::error::` referencing #162 when the host is down/firewalled, instead of the opaque `Process completed with exit code 1` from the 5s `ssh-keyscan` timeout.
   - `ssh-keyscan` wrapped in a 3× retry loop to ride out transient blips, with an error annotation on final failure.
   - `HOST` passed via `env:` so it's usable in bash and consistently masked in logs.

## Verification

- YAML parses; only the `workflow_run` trigger remains; job condition and checkout ref confirmed.
- Cross-family review (`codex`): no CI-logic blockers.
- Not runnable in unit tests (workflow file); logic reviewed for `bash -e` interaction (all failure paths are inside `if`/explicit `exit`).

## Known limitations

- Does **not** restore staging — that's the infra outage #162 (server unreachable at the provider), which needs cloud-console action, not code.
- `nc` availability relies on the standard `ubuntu-latest` image (present in normal practice); not pinned via an explicit install to keep the change minimal.
- The duplicated SSH block in the disabled `deploy-production.yml.disabled` is intentionally left untouched (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Staging deployments now run only after a successful test-and-quality workflow on `main`, reducing accidental deployments.
  * Deployments now target the exact approved commit, helping ensure what was tested is what gets released.
  * Improved connection checks during deployment setup to make staging releases more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->