### PR TITLE
fix(ci): stop staging deploy tripping fail2ban; drop SSH preauth burst (#162)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -9,6 +9,8 @@ on:
     workflows: ["Tests and Quality Checks"]
     types: [completed]
     branches: [main]
+  # Allow on-demand deploys (e.g. server bring-up, re-deploy without a code push).
+  workflow_dispatch:
 
 env:
   NODE_VERSION: '18'
@@ -50,7 +52,8 @@ jobs:
   build-and-deploy:
     name: Build and Deploy to Staging
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Deploy on a manual dispatch, or when the upstream test workflow passed.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     environment:
       name: staging
@@ -118,38 +121,24 @@ jobs:
           tar -czf /tmp/deploy-package.tar.gz .
 
       - name: Setup SSH
-        env:
-          HOST: ${{ secrets.HOST }}
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_KEY }}" > ~/.ssh/staging_key
           chmod 600 ~/.ssh/staging_key
 
-          # Preflight: confirm the staging host answers on TCP/22 before doing
-          # anything SSH. Without this, an unreachable host (see #162) surfaces
-          # only as an opaque "Process completed with exit code 1" from the 5s
-          # ssh-keyscan timeout, masking a server outage as a deploy failure.
-          if ! nc -z -w5 "$HOST" 22; then
-            echo "::error::Staging host ($HOST):22 is unreachable — the server may be down or firewalled, not a deploy bug. See #162."
-            exit 1
-          fi
-
-          # Retry ssh-keyscan to ride out transient network blips.
-          for attempt in 1 2 3; do
-            if ssh-keyscan -H "$HOST" >> ~/.ssh/known_hosts 2>/dev/null; then
-              break
-            fi
-            echo "ssh-keyscan attempt $attempt/3 failed"
-            if [ "$attempt" -eq 3 ]; then
-              echo "::error::ssh-keyscan failed for the staging host after 3 attempts. See #162."
-              exit 1
-            fi
-            sleep 3
-          done
+          # NOTE: no `nc` preflight or `ssh-keyscan` here. Those open connections
+          # that close *before authenticating*, which the staging host's
+          # fail2ban (aggressive mode, maxretry=4) counts as attacks — the
+          # nc + 3x keyscan burst hit the threshold and banned the runner every
+          # run (see #162). The scp/ssh steps below authenticate on the first
+          # connection via StrictHostKeyChecking=accept-new, so the runner only
+          # ever makes successful ("Accepted publickey") connections. An
+          # unreachable host now surfaces as a clear scp/ssh failure below.
 
       - name: Upload package to server
         run: |
-          scp -i ~/.ssh/staging_key /tmp/deploy-package.tar.gz \
+          scp -i ~/.ssh/staging_key -o StrictHostKeyChecking=accept-new \
+            /tmp/deploy-package.tar.gz \
             ${{ secrets.USER }}@${{ secrets.HOST }}:/tmp/
 
       - name: Validate security configuration
@@ -171,7 +160,7 @@ jobs:
 
       - name: Deploy to staging
         run: |
-          ssh -i ~/.ssh/staging_key \
+          ssh -i ~/.ssh/staging_key -o StrictHostKeyChecking=accept-new \
             ${{ secrets.USER }}@${{ secrets.HOST }} \
             'bash -s' << 'ENDSSH'
           set -euo pipefail


### PR DESCRIPTION
## Problem
Staging is down (dead provider) and being rebuilt on a new host (`195.35.14.177`). After provisioning the box, the `Deploy to Staging` workflow kept failing at **Upload package to server** even with the correct `SSH_KEY` and open firewall.

Root cause: the new host runs **fail2ban in `mode = aggressive`, `maxretry = 4`**, which counts `Connection closed ... [preauth]` as an attack. The workflow's `Setup SSH` step opened exactly 4 keyless connections before authenticating — `nc -z` preflight (1) + `ssh-keyscan` with 3 retries (3) — hitting the threshold and **banning the runner IP on every run** (escalating bantime up to 1 week). scp then timed out / got its connection closed, looking like a deploy bug.

Verified from the host: runner IPs (`20.29.29.56`, `52.240.168.192`, …) each logged 3 `[preauth]` closes immediately before being banned.

## Fix
- Drop the `nc` probe and `ssh-keyscan` from `Setup SSH`.
- `scp` and the deploy `ssh` now authenticate on their first connection via `StrictHostKeyChecking=accept-new` → the runner only ever makes **successful** (`Accepted publickey`) connections, so fail2ban never triggers.
- Leaves the shared host's ufw/fail2ban configuration **untouched** (no security posture change).
- Add a `workflow_dispatch` trigger (+ widen the job `if`) so staging can be deployed on demand during bring-up.

An unreachable host now surfaces as a clear scp/ssh failure instead of the old opaque keyscan timeout.

## Test
Workflow-only change; `Frontend Tests` / `Backend Tests` unaffected. Real validation is the deploy itself running clean through Upload → Deploy → health checks once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Staging deployments can now be started manually, in addition to running automatically after successful checks on `main`.

* **Chores**
  * Simplified staging deployment connectivity handling for more streamlined SSH and file transfer operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->