### PR TITLE
fix(ci): staging deploy — devDeps for build + CORS env format (#162)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -207,8 +207,13 @@ jobs:
             echo "DATABASE_URL=${{ secrets.MONGODB_URI }}"
             echo "DATABASE_NAME=${{ secrets.DATABASE_NAME }}"
             echo ""
-            echo "# CORS Settings"
-            echo "BACKEND_CORS_ORIGINS=[\"$FRONTEND_URL\",\"$API_URL\"]"
+            echo "# CORS Settings — plain comma-separated origins (the app's
+            # config validator splits on ',' for non-JSON values). A quoted
+            # JSON array here gets its quotes mangled by the dotenv reader into
+            # invalid JSON, crashing Settings() on startup. Only the frontend
+            # origin makes cross-origin calls to the API; an API URL with a
+            # /api/v1 path is not a valid Origin, so it is not listed."
+            echo "BACKEND_CORS_ORIGINS=$FRONTEND_URL"
             echo ""
             echo "# OpenAI"
             echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}"
@@ -272,7 +277,11 @@ jobs:
           rm -rf .next
 
           echo "==> Installing frontend dependencies..."
-          npm ci
+          # --include=dev: NODE_ENV=production (exported above) makes `npm ci`
+          # skip devDependencies, but the build needs them — notably typescript,
+          # which `next build` requires to load next.config.ts. Without this the
+          # build fails with "Cannot find module 'typescript'".
+          npm ci --include=dev
 
           echo "==> Building frontend..."
           npm run build


### PR DESCRIPTION
Follow-up to #167. With SSH/fail2ban fixed, the deploy reached the on-server build/start and exposed two more bugs (both fixed here, verified live on the new host).

## 1. Frontend build: `Cannot find module 'typescript'`
The on-server block exports `NODE_ENV=production` before `npm ci`, so npm skips **devDependencies** — but `next build` needs `typescript` to load `next.config.ts`. → `npm ci --include=dev`.

## 2. Backend crash: `BACKEND_CORS_ORIGINS` ValidationError
The `.env` was written as a quoted JSON array `["$FRONTEND_URL","$API_URL"]`; the dotenv reader mangles the quotes into invalid JSON, so `Settings()` throws on startup. → write **plain comma-separated** origins (the config validator at `config.py:74` splits non-JSON values on `,`), and list **only the frontend origin** (an API URL with an `/api/v1` path is not a valid Origin).

## Verified live on `195.35.14.177`
- `https://dev.autoauthor.app` → 200
- `https://api.dev.autoauthor.app/api/v1/health` → `{"status":"healthy"}`
- `/docs` → 200
- CORS preflight → `access-control-allow-origin: https://dev.autoauthor.app`

Staging was brought up manually with these fixes applied; this PR bakes them into the pipeline so the next automated deploy stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staging deployment reliability by ensuring the frontend builds successfully during release.
  * Fixed staging environment configuration so browser access is restricted to the correct frontend origin, reducing cross-origin access issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->