### PR TITLE
test: add staging edge-case and smoke coverage

### DIFF
--- a/.github/workflows/e2e-staging-tests.yml
+++ b/.github/workflows/e2e-staging-tests.yml
@@ -4,17 +4,30 @@ name: E2E Staging Tests
 #
 # Triggers (chosen to avoid hammering live staging / spending AI tokens on every PR):
 #   - schedule: every 6 hours
-#   - workflow_dispatch: manual runs
+#   - workflow_dispatch: manual runs, with optional load-smoke and worker controls
 #   - pull_request: ONLY when the PR carries the `e2e-staging` label
 #
 # Required GitHub Secrets (in the `staging` environment):
 #   - TEST_USER_EMAIL
 #   - TEST_USER_PASSWORD
+# Optional GitHub Secrets (in the `staging` environment):
+#   - SLACK_WEBHOOK_URL
+#   - DISCORD_WEBHOOK_URL
 
 on:
   schedule:
     - cron: '0 */6 * * *'
   workflow_dispatch:
+    inputs:
+      staging_e2e_workers:
+        description: 'Number of Playwright workers for staging tests (default: 1)'
+        required: false
+        default: '1'
+      run_load_smoke:
+        description: 'Run a low-impact Locust load smoke against staging'
+        required: false
+        type: boolean
+        default: false
   pull_request:
     types: [labeled, opened, synchronize, reopened]
 
@@ -27,7 +40,7 @@ jobs:
   e2e-staging:
     name: E2E Staging (Playwright)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     # TEST_USER_EMAIL / TEST_USER_PASSWORD live in the `staging` environment.
     environment:
       name: staging
@@ -63,7 +76,21 @@ jobs:
           # env names the auth fixture reads first.
           STAGING_TEST_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
           STAGING_TEST_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+          STAGING_E2E_WORKERS: ${{ github.event.inputs.staging_e2e_workers || '1' }}
         run: npm run test:e2e:staging
+
+      - name: Write staging E2E summary
+        if: always()
+        run: |
+          {
+            echo "## Staging E2E run"
+            echo ""
+            echo "- Environment: https://dev.autoauthor.app"
+            echo "- Workflow result: ${{ job.status }}"
+            echo "- Workers: ${{ github.event.inputs.staging_e2e_workers || '1' }}"
+            echo "- Visual smoke screenshots: see the staging test-results artifact"
+            echo "- Playwright HTML report: see the playwright-report-staging artifact"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Playwright report
         if: always()
@@ -73,10 +100,115 @@ jobs:
           path: frontend/tests/e2e/staging/playwright-report-staging/
           retention-days: 7
 
+      - name: Upload staging test results and visual smoke screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: staging-test-results
+          path: |
+            frontend/tests/e2e/staging/test-results/
+            frontend/test-results/
+          retention-days: 7
+
       - name: Upload failure artifacts (screenshots/videos/traces)
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: staging-failure-artifacts
-          path: frontend/tests/e2e/staging/test-results/
+          path: |
+            frontend/tests/e2e/staging/test-results/
+            frontend/test-results/
+          retention-days: 7
+
+      - name: Notify scheduled staging failure
+        if: failure() && github.event_name == 'schedule'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          message="Scheduled staging E2E failed for ${GITHUB_REPOSITORY}: ${RUN_URL}"
+
+          if [ -n "$SLACK_WEBHOOK_URL" ]; then
+            jq -n --arg text "$message" '{text: $text}' \
+              | curl -fsS -X POST -H "Content-Type: application/json" --data @- "$SLACK_WEBHOOK_URL" \
+              || echo "Slack failure notification could not be delivered."
+          fi
+
+          if [ -n "$DISCORD_WEBHOOK_URL" ]; then
+            jq -n --arg content "$message" '{content: $content}' \
+              | curl -fsS -X POST -H "Content-Type: application/json" --data @- "$DISCORD_WEBHOOK_URL" \
+              || echo "Discord failure notification could not be delivered."
+          fi
+
+          if [ -z "$SLACK_WEBHOOK_URL" ] && [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "No Slack or Discord webhook configured; skipped scheduled failure notification."
+          fi
+
+  load-smoke:
+    name: Staging Load Smoke (Locust)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: staging
+      url: https://dev.autoauthor.app
+    needs: e2e-staging
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.run_load_smoke == 'true'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: backend/uv.lock
+
+      - name: Setup Python
+        working-directory: backend
+        run: uv python install 3.13
+
+      - name: Install backend load dependencies
+        working-directory: backend
+        run: uv sync --extra load
+
+      - name: Run low-impact staging load smoke
+        working-directory: backend
+        env:
+          STAGING_TEST_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
+          STAGING_TEST_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+          STAGING_API_URL: https://api.dev.autoauthor.app/api/v1
+        run: >-
+          uv run locust -f tests/load/staging_smoke.py StagingSmokeUser
+          --headless
+          --host=https://dev.autoauthor.app
+          --users=2
+          --spawn-rate=1
+          --run-time=30s
+          --html=load-smoke-report.html
+          --csv=load-smoke
+
+      - name: Write load smoke summary
+        if: always()
+        run: |
+          {
+            echo "## Staging load smoke"
+            echo ""
+            echo "- Target: https://dev.autoauthor.app"
+            echo "- Users: 2"
+            echo "- Duration: 30s"
+            echo "- Report: see staging-load-smoke artifact"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload load smoke report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: staging-load-smoke
+          path: |
+            backend/load-smoke-report.html
+            backend/load-smoke*.csv
           retention-days: 7

--- a/backend/tests/load/staging_smoke.py
+++ b/backend/tests/load/staging_smoke.py
@@ -1,0 +1,120 @@
+"""Low-impact staging load smoke for GitHub Actions.
+
+This file is intentionally separate from ``locustfile.py`` because staging uses
+Better Auth cookie sessions and the public frontend/API hosts. It exercises the
+staging auth boundary plus cheap API endpoints without repeatedly triggering AI
+work or creating high request volume.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+from locust import HttpUser, between, task
+
+
+STAGING_API_URL = os.getenv("STAGING_API_URL", "https://api.dev.autoauthor.app/api/v1")
+STAGING_TEST_EMAIL = os.getenv("STAGING_TEST_EMAIL") or os.getenv("TEST_USER_EMAIL")
+STAGING_TEST_PASSWORD = os.getenv("STAGING_TEST_PASSWORD") or os.getenv("TEST_USER_PASSWORD")
+AUTH_FAILURE_STATUSES = {401, 403}
+
+
+class StagingSmokeUser(HttpUser):
+    """Authenticated, low-volume staging API smoke user."""
+
+    wait_time = between(2, 5)
+
+    def on_start(self) -> None:
+        if not STAGING_TEST_EMAIL or not STAGING_TEST_PASSWORD:
+            raise RuntimeError(
+                "Set STAGING_TEST_EMAIL/STAGING_TEST_PASSWORD or TEST_USER_EMAIL/TEST_USER_PASSWORD"
+            )
+
+        self.book_id: str | None = None
+        self._sign_in()
+        self._ensure_book()
+
+    def _sign_in(self) -> None:
+        with self.client.post(
+            "/api/auth/sign-in/email",
+            json={
+                "email": STAGING_TEST_EMAIL,
+                "password": STAGING_TEST_PASSWORD,
+                "callbackURL": "/dashboard",
+            },
+            name="better-auth sign-in",
+            catch_response=True,
+        ) as response:
+            if response.status_code >= 400:
+                response.failure(f"sign-in returned {response.status_code}: {response.text[:300]}")
+                raise RuntimeError("Better Auth sign-in failed during staging load smoke")
+            response.success()
+
+    def _api(self, path: str) -> str:
+        return f"{STAGING_API_URL.rstrip('/')}/{path.lstrip('/')}"
+
+    def _ensure_book(self) -> None:
+        title = f"Load Smoke Book {int(time.time())}"
+        with self.client.post(
+            self._api("/books/"),
+            json={"title": title, "description": "Created by low-impact staging load smoke."},
+            name="POST /api/v1/books/",
+            catch_response=True,
+        ) as response:
+            if response.status_code in AUTH_FAILURE_STATUSES:
+                response.failure(f"book create auth failed with {response.status_code}")
+                raise RuntimeError("Authenticated book create failed during staging load smoke")
+            if response.status_code >= 500:
+                response.failure(f"book create returned {response.status_code}: {response.text[:300]}")
+                return
+            if response.status_code < 400:
+                payload: dict[str, Any] = response.json()
+                self.book_id = payload.get("id") or payload.get("_id")
+            response.success()
+
+    @task(4)
+    def list_books(self) -> None:
+        with self.client.get(
+            self._api("/books/"),
+            name="GET /api/v1/books/",
+            catch_response=True,
+        ) as response:
+            if response.status_code in AUTH_FAILURE_STATUSES:
+                response.failure(f"list books auth failed with {response.status_code}")
+            elif response.status_code >= 500:
+                response.failure(f"list books returned {response.status_code}")
+            else:
+                response.success()
+
+    @task(2)
+    def health(self) -> None:
+        with self.client.get(
+            self._api("/health"),
+            name="GET /api/v1/health",
+            catch_response=True,
+        ) as response:
+            if response.status_code >= 500:
+                response.failure(f"health returned {response.status_code}")
+            else:
+                response.success()
+
+    @task(1)
+    def toc_readiness_boundary(self) -> None:
+        if not self.book_id:
+            return
+
+        with self.client.get(
+            self._api(f"/books/{self.book_id}/toc-readiness"),
+            name="GET /api/v1/books/:id/toc-readiness",
+            catch_response=True,
+        ) as response:
+            # 400/404 is acceptable when the smoke-created book has no summary;
+            # auth failures and 5xx responses indicate staging instability.
+            if response.status_code in AUTH_FAILURE_STATUSES:
+                response.failure(f"toc readiness auth failed with {response.status_code}")
+            elif response.status_code >= 500:
+                response.failure(f"toc readiness returned {response.status_code}")
+            else:
+                response.success()

--- a/frontend/tests/e2e/staging/edge-cases.spec.ts
+++ b/frontend/tests/e2e/staging/edge-cases.spec.ts
@@ -1,0 +1,153 @@
+import { Page, expect } from '@playwright/test';
+import { test } from './fixtures/auth.fixture';
+import { addSummary, createBook, READY_SUMMARY } from './fixtures/journey.helpers';
+
+const API_BASE_URL =
+  process.env.STAGING_API_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  'https://api.dev.autoauthor.app/api/v1';
+
+async function createBookOnPage(page: Page, title: string): Promise<string> {
+  const id = await createBook(page, title);
+  expect(id).toMatch(/^[a-f0-9]+$/);
+  return id;
+}
+
+async function updateToc(page: Page, bookId: string, chapterCount: number): Promise<void> {
+  const toc = {
+    chapters: Array.from({ length: chapterCount }, (_, index) => ({
+      id: `edge-ch-${index + 1}`,
+      title: `Edge Case Chapter ${index + 1}`,
+      description: `Generated staging edge-case chapter ${index + 1}`,
+      level: 1,
+      order: index + 1,
+      status: 'draft',
+      word_count: 0,
+      estimated_reading_time: 0,
+      subchapters: [],
+    })),
+    total_chapters: chapterCount,
+    estimated_pages: chapterCount * 10,
+    structure_notes: 'Staging edge-case large TOC smoke data',
+  };
+
+  const response = await page.request.put(`${API_BASE_URL}/books/${bookId}/toc`, {
+    data: toc,
+  });
+
+  expect(response.status(), await response.text()).toBeLessThan(400);
+}
+
+async function expectAuthenticatedDashboard(page: Page): Promise<void> {
+  await page.goto('/dashboard');
+  await expect(page).toHaveURL(/\/dashboard/);
+  await expect(page.locator('h1, h2')).toContainText(/dashboard|books/i, {
+    timeout: 15_000,
+  });
+}
+
+// Mutation testing note: these specs validate live staging environment behavior and
+// cross-process browser/network effects; local production-code mutation is not practical.
+test.describe('Staging edge cases', () => {
+  test('session expiration redirects protected pages back to sign-in', async ({
+    authenticatedPage: page,
+  }) => {
+    await expectAuthenticatedDashboard(page);
+
+    await page.context().clearCookies();
+    await page.goto('/dashboard');
+
+    await expect(page).toHaveURL(/\/auth\/sign-in|\/sign-in|\/login/, {
+      timeout: 20_000,
+    });
+    await expect(page.locator('input[type="email"]')).toBeVisible();
+  });
+
+  test('concurrent book creation succeeds for separate tabs in the same session', async ({
+    authenticatedPage: page,
+  }) => {
+    const secondPage = await page.context().newPage();
+    const timestamp = Date.now();
+
+    try {
+      const [firstBookId, secondBookId] = await Promise.all([
+        createBookOnPage(page, `Concurrent Edge Book A ${timestamp}`),
+        createBookOnPage(secondPage, `Concurrent Edge Book B ${timestamp}`),
+      ]);
+
+      expect(firstBookId).not.toBe(secondBookId);
+    } finally {
+      await secondPage.close();
+    }
+  });
+
+  test('network interruption during TOC readiness shows retryable error UI', async ({
+    authenticatedPage: page,
+  }) => {
+    const bookId = await createBookOnPage(page, `Network Edge Book ${Date.now()}`);
+    let abortedReadiness = false;
+
+    await page.route(/\/api\/v1\/books\/[^/]+\/toc-readiness$/, async (route) => {
+      if (!abortedReadiness) {
+        abortedReadiness = true;
+        await route.abort('internetdisconnected');
+        return;
+      }
+      await route.continue();
+    });
+
+    await addSummary(page, bookId, READY_SUMMARY);
+
+    await expect(page.getByRole('heading', { name: /something went wrong/i })).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByRole('button', { name: /try again/i })).toBeVisible();
+  });
+
+  test('large table of contents with 50 chapters renders and saves from edit screen', async ({
+    authenticatedPage: page,
+  }) => {
+    const bookId = await createBookOnPage(page, `Large TOC Edge Book ${Date.now()}`);
+    await updateToc(page, bookId, 50);
+
+    await page.goto(`/dashboard/books/${bookId}/edit-toc`);
+    await expect(page.getByRole('heading', { name: /edit table of contents/i })).toBeVisible();
+    await expect(page.locator('input[value^="Edge Case Chapter"]')).toHaveCount(50, {
+      timeout: 20_000,
+    });
+
+    const saveResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes(`/books/${bookId}/toc`) &&
+        response.request().method() === 'PUT' &&
+        response.status() < 400,
+      { timeout: 30_000 }
+    );
+
+    await page.getByRole('button', { name: /save & continue/i }).click();
+    await saveResponse;
+    await expect(page).toHaveURL(new RegExp(`/dashboard/books/${bookId}(?:[/?#]|$)`));
+  });
+
+  test('Unicode metadata is preserved in dashboard rendering', async ({ authenticatedPage: page }) => {
+    const title = `Unicode Edge Café 東京 🚀 ${Date.now()}`;
+    await createBookOnPage(page, title);
+
+    await page.goto('/dashboard');
+    await expect(page.getByText(title)).toBeVisible({ timeout: 20_000 });
+  });
+
+  test('XSS-like book metadata is rendered as inert text, not executable markup', async ({
+    authenticatedPage: page,
+  }) => {
+    const marker = `xss-edge-${Date.now()}`;
+    const xssTitle = `<img src=x onerror="window.__${marker}=true"> ${marker}`;
+
+    await createBookOnPage(page, xssTitle);
+    await page.goto('/dashboard');
+
+    await expect(page.getByText(marker)).toBeVisible({ timeout: 20_000 });
+    const executed = await page.evaluate((key) => Boolean((window as unknown as Record<string, unknown>)[`__${key}`]), marker);
+    expect(executed).toBe(false);
+  });
+});

--- a/frontend/tests/e2e/staging/playwright.config.ts
+++ b/frontend/tests/e2e/staging/playwright.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
 
   // Opt out of parallel tests on CI
-  workers: 1, // Single worker to avoid session conflicts
+  workers: process.env.STAGING_E2E_WORKERS ? Number(process.env.STAGING_E2E_WORKERS) : 1, // Single worker by default to avoid session conflicts
 
   // Reporter to use
   reporter: [

--- a/frontend/tests/e2e/staging/visual-smoke.spec.ts
+++ b/frontend/tests/e2e/staging/visual-smoke.spec.ts
@@ -1,0 +1,41 @@
+import { mkdirSync } from 'fs';
+import { expect } from '@playwright/test';
+import { test } from './fixtures/auth.fixture';
+import { createBook } from './fixtures/journey.helpers';
+
+async function expectMeaningfulScreenshot(buffer: Buffer, label: string): Promise<void> {
+  expect(buffer.length, `${label} screenshot should not be empty`).toBeGreaterThan(10_000);
+}
+
+// Mutation testing note: this is an external visual smoke/artifact test;
+// its value is the generated Playwright artifact, not a local code branch mutation.
+test.describe('Staging visual smoke', () => {
+  test('dashboard and summary screens produce reviewable screenshots', async ({
+    authenticatedPage: page,
+  }) => {
+    mkdirSync('tests/e2e/staging/test-results', { recursive: true });
+
+    await page.goto('/dashboard');
+    await expect(page.locator('h1, h2')).toContainText(/dashboard|books/i, {
+      timeout: 15_000,
+    });
+
+    const dashboardShot = await page.screenshot({
+      path: 'tests/e2e/staging/test-results/visual-smoke-dashboard.png',
+      fullPage: true,
+    });
+    await expectMeaningfulScreenshot(dashboardShot, 'dashboard');
+
+    const bookId = await createBook(page, `Visual Smoke Book ${Date.now()}`);
+    await page.goto(`/dashboard/books/${bookId}/summary`);
+    await expect(page.getByRole('textbox', { name: /book summary/i })).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const summaryShot = await page.screenshot({
+      path: 'tests/e2e/staging/test-results/visual-smoke-summary.png',
+      fullPage: true,
+    });
+    await expectMeaningfulScreenshot(summaryShot, 'summary');
+  });
+});

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -79,3 +79,57 @@ Replaced with a minimal rating→prompt-guidance wiring so the already-collected
   matching #56/#57/#58 precedent.
 
 No substantive architectural fork → proceeding autonomously per Phase 4.
+---
+
+# Issue #106 - [P3.7] Add staging E2E edge-case + visual/load coverage
+
+## Auto-Pick Summary
+Picked by `implementing-issue-plans --next` because #106 has the lowest open priority prefix (`P3.7`) after filtering unassigned, unblocked issues with no open linked PRs. Runner-up: #158 (`P3.9`). Dependency #105 is closed.
+
+## Plan Source
+Self-authored. The issue body lists deferred coverage areas but no concrete implementation plan; the only issue comment is a CodeRabbit placeholder.
+
+## Assumptions and Design Decisions
+- Keep the PR inside existing infrastructure: Playwright staging tests, GitHub Actions artifacts/summaries, and a staging-specific Locust smoke script.
+- Avoid adding Slack/Discord or other external notification services; provide scheduled-run failure visibility through GitHub Actions summaries and retained artifacts.
+- Keep staging tests sequential by default to avoid shared staging account conflicts; add a documented opt-in for parallelism rather than changing CI behavior.
+- Use deterministic edge-case assertions and lightweight screenshots/load smoke checks so scheduled staging runs do not hammer live AI services.
+
+## Acceptance Criteria Checklist
+- [ ] Add staging E2E edge-case coverage for session expiration, concurrent book creation, network interruption during TOC generation, large TOC/chapter handling, Unicode metadata, and XSS-like metadata.
+- [ ] Add visual coverage for key staging pages without introducing a new visual regression service.
+- [ ] Add load-smoke coverage for staging API/TOC-readiness boundaries using backend Locust tooling.
+- [ ] Improve scheduled-run failure visibility through workflow summaries/artifacts.
+- [ ] Preserve existing staging test workflow behavior unless explicitly opted in.
+
+## Implementation Steps
+1. Add staging edge-case Playwright tests.
+   - Create `frontend/tests/e2e/staging/edge-cases.spec.ts`.
+   - Reuse `auth.fixture.ts` and `journey.helpers.ts` where possible.
+   - Keep tests web-first and network-aware; avoid arbitrary sleeps and silent skips.
+
+2. Add staging visual smoke coverage.
+   - Create `frontend/tests/e2e/staging/visual-smoke.spec.ts`.
+   - Capture deterministic screenshots for authenticated dashboard/book-summary surfaces and assert screenshots are non-empty and stable enough for artifact review.
+   - Use Playwright artifacts instead of a new visual regression SaaS or snapshot baseline service.
+
+3. Add load-smoke support to CI.
+   - Create `backend/tests/load/staging_smoke.py` for Better Auth staging smoke behavior.
+   - Add a manual workflow-dispatch load-smoke job that runs Locust headlessly at very low volume.
+   - Keep it opt-in to avoid scheduled AI/API spend.
+
+4. Improve staging workflow reporting.
+   - Upload visual artifacts/test results.
+   - Write a GitHub Actions summary on failure/success with artifact pointers and run context.
+   - Document the parallelism opt-in rather than making CI parallel by default.
+
+5. Validate locally.
+   - Run frontend type-check.
+   - Run targeted Playwright list/compile checks for the staging config.
+   - Run Python compile checks for the staging Locust smoke script.
+
+## Test Strategy
+- `npm run typecheck` in `frontend` verifies new Playwright TypeScript files compile.
+- `npx playwright test --config=tests/e2e/staging/playwright.config.ts --list` verifies staging tests are discoverable without credentials/live traffic.
+- `uv run python -m py_compile tests/load/staging_smoke.py` verifies load script syntax.
+- Full live staging E2E/load execution remains gated by staging credentials and workflow/manual dispatch.


### PR DESCRIPTION
## Summary
Implements #106: add staging E2E edge-case + visual/load coverage.

- Adds staging Playwright edge-case coverage for expired sessions, concurrent book creation, TOC-readiness network interruption, large 50-chapter TOCs, Unicode metadata, and XSS-like metadata rendering.
- Adds visual smoke screenshots for authenticated dashboard and summary surfaces, retained as staging artifacts.
- Adds a Better Auth-aware low-impact Locust staging smoke and wires it into manual workflow dispatch.
- Improves staging workflow summaries/artifact uploads, keeps parallel staging execution opt-in, and adds optional Slack/Discord notification for scheduled-run failures.

## Acceptance Criteria
- [x] Add staging E2E edge-case coverage for session expiration, concurrent book creation, network interruption during TOC generation, large TOC/chapter handling, Unicode metadata, and XSS-like metadata.
- [x] Add visual coverage for key staging pages without introducing a new visual regression service.
- [x] Add load-smoke coverage for staging API/TOC-readiness boundaries using backend Locust tooling.
- [x] Improve scheduled-run failure visibility through workflow summaries/artifacts and optional Slack/Discord webhooks.
- [x] Preserve existing staging test workflow behavior unless explicitly opted in.

## Test Plan
- [x] `npm run typecheck`
- [x] `npx playwright test --config=tests/e2e/staging/playwright.config.ts --list`
- [x] `uv run python -m py_compile tests/load/staging_smoke.py`
- [x] `npx eslint tests/e2e/staging/edge-cases.spec.ts tests/e2e/staging/visual-smoke.spec.ts tests/e2e/staging/playwright.config.ts`
- [x] `npm run lint` (passes with existing warnings)
- [x] `git diff --check`
- [x] Internal code review completed; fixed load-smoke auth failure handling found during review.
- [x] Test mutation sanity check documented in staging smoke tests; local mutation is impractical for external staging/browser artifact behavior.
- [x] Phase 11 Showboat demo evidence created at `frontend/tests/e2e/staging/test-results/issue-106-demo-stable.md` (ignored artifact).

## Known Limitations / Intentionally Deferred
- Cross-family review was unavailable: local `codex review` was blocked by tenant policy because it would transmit private repo diff content externally, and CodeRabbit's GitHub App reached the organization's temporary review limit/spending cap after this PR was marked ready. No Critical/Major bot findings were posted to triage.
- Full live staging execution is not run locally; it requires staging credentials and the GitHub Actions staging environment.
- Load smoke is manual-dispatch only to avoid increasing scheduled staging/API/AI spend.
- Visual coverage is artifact-based smoke coverage, not pixel-baseline regression with an external visual service.

## Implementation Notes
- Kept staging Playwright workers at `1` by default and added `staging_e2e_workers` as an explicit workflow-dispatch input.
- Added `run_load_smoke` as a manual workflow-dispatch input so scheduled runs stay low-impact.
- Added optional `SLACK_WEBHOOK_URL` / `DISCORD_WEBHOOK_URL` scheduled-failure notifications in the staging environment.
- Added a staging-specific Locust file because the existing load script targets older auth/API assumptions.

Closes #106