### PR TITLE
fix(deps): dependabot github-actions cooldown keys unsupported

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,8 +27,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # github-actions doesn't support semver-* cooldown keys (config parse error)
     cooldown:
       default-days: 14
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 7


### PR DESCRIPTION
The dependabot config check on `main` has been failing since #250 merged:

```
The property '#/updates/2/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/2/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/2/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.
```

A parse error disables Dependabot version updates entirely, so this blocks the whole #250 policy, not just the actions ecosystem. Fix: keep `default-days: 14` (the flat cooldown the file's own header prescribes for non-semver ecosystems) and drop the three unsupported keys. npm/uv entries untouched.

Found while merging #251 (the failing check surfaced on the PR after a branch update). Verification is the dependabot check itself going green on this PR/main after merge — no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)