### PR TITLE
test: enumerate served routes via app.openapi(), not app.routes

### DIFF
--- a/backend/tests/test_api/test_routes/test_chapters_characterization.py
+++ b/backend/tests/test_api/test_routes/test_chapters_characterization.py
@@ -34,15 +34,18 @@ MOVED_CHAPTER_ROUTES = {
 
 
 def _app_routes():
-    """Set of (method, full-path) pairs registered on the app."""
-    pairs = set()
-    for route in app.routes:
-        methods = getattr(route, "methods", None)
-        if not methods:
-            continue
-        for method in methods:
-            pairs.add((method, route.path))
-    return pairs
+    """Set of (METHOD, full-path) pairs the app serves, via the OpenAPI schema.
+
+    Enumerated through app.openapi() rather than app.routes: FastAPI >= 0.138
+    keeps include_router mounts lazy (an _IncludedRouter node), so app.routes
+    no longer flattens to APIRoutes. The OpenAPI schema is public API and lists
+    every served route with its composed path on all supported versions.
+    """
+    return {
+        (method.upper(), path)
+        for path, operations in app.openapi()["paths"].items()
+        for method in operations
+    }
 
 
 def test_moved_chapter_routes_still_served_by_app():


### PR DESCRIPTION
Unblocks dependabot's fastapi bump (#262). FastAPI ≥ 0.138 keeps `include_router` mounts lazy (`_IncludedRouter` in `app.routes`), so the #94 route-table characterization test reported all 9 chapter routes "lost" on #262 while every behavioral chapter test passed — the routes are served fine; only the enumeration broke.

`_app_routes()` now derives (METHOD, path) pairs from `app.openapi()["paths"]` — public API, composed full paths, verified to pass on both fastapi 0.116.1 (main) and 0.138.1 (the #262 worktree). All 4 characterization tests green on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)