### PR TITLE
fix(security): PATCH /users/me can no longer self-elevate role — privileged fields unwritable via API (#244)

### DIFF
--- a/backend/app/api/endpoints/users.py
+++ b/backend/app/api/endpoints/users.py
@@ -310,13 +310,6 @@ async def update_user_data(
             status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
         )
 
-    # Prevent non-admin users from changing their role
-    if user_update.role and current_user["role"] != "admin":
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only admins can change user roles",
-        )
-
     # Update with current timestamp
     update_data = {
         k: v

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -91,9 +91,17 @@ class UserUpdate(BaseModel):
     bio: Optional[str] = Field(None, max_length=1000)
     preferences: Optional[UserPreferences] = None
     metadata: Optional[Dict[str, Any]] = None
-    role: Optional[str] = None
+    # role is deliberately absent (#244): it flows into a generic $set in the
+    # /users handlers, so exposing it here lets any user self-elevate to admin.
+    # Same policy as plan/stripe_* (#220) — privileged fields are not
+    # API-writable; roles are managed directly in the database.
 
     model_config = ConfigDict(
+        # extra="forbid" (#244): these fields ARE the writable allowlist for the
+        # generic $set in the /users handlers. Unknown keys (role, plan, …) are
+        # a loud 422, not a silent ignore — adding a privileged field here is
+        # the only way to make it writable, and that takes a review.
+        extra="forbid",
         json_schema_extra={
             "example": {
                 "email": "updated@example.com",
@@ -108,7 +116,6 @@ class UserUpdate(BaseModel):
                     "marketing_emails": False,
                 },
                 "metadata": {"preferences": {"theme": "dark"}},
-                "role": "admin",
             }
         }
     )

--- a/backend/tests/test_api/test_routes/test_users_coverage.py
+++ b/backend/tests/test_api/test_routes/test_users_coverage.py
@@ -162,13 +162,68 @@ async def test_put_user_other_non_admin_returns_403(auth_client_factory):
     assert "permissions" in resp.json()["detail"]
 
 
-async def test_put_user_non_admin_role_change_returns_403(auth_client_factory):
+# ---------------------------------------------------------------------------
+# Issue #244 — privileged fields are not writable via the API
+# UserUpdate is extra="forbid", so an unknown/privileged key is a 422 and the
+# handler (and its generic $set) never runs.
+# ---------------------------------------------------------------------------
+PRIVILEGED_FIELDS = [
+    ("role", "admin"),
+    ("plan", "pro"),
+    ("is_active", False),
+    ("stripe_customer_id", "cus_evil"),
+    ("stripe_subscription_id", "sub_evil"),
+    ("book_ids", ["not-yours"]),
+    ("auth_id", "someone-else"),
+]
+
+
+@pytest.mark.parametrize("field,value", PRIVILEGED_FIELDS)
+async def test_patch_me_privileged_field_rejected_and_not_persisted(
+    auth_client_factory, field, value
+):
+    """AC (#244): authenticated PATCH /users/me with a privileged field is
+    rejected with 422 and the stored document is byte-identical afterwards."""
+    from app.db import base
+
+    client = await auth_client_factory()
+    before = await base.users_collection.find_one({"auth_id": "test-auth-id-123"})
+    resp = await client.patch("/api/v1/users/me", json={field: value})
+    assert resp.status_code == 422
+    after = await base.users_collection.find_one({"auth_id": "test-auth-id-123"})
+    assert after == before
+
+
+async def test_put_user_role_rejected_and_not_persisted(auth_client_factory):
+    """#244: role is unwritable via PUT /users/{auth_id} as well."""
+    from app.db import base
+
     client = await auth_client_factory()
     resp = await client.put(
-        "/api/v1/users/test-auth-id-123", json={"role": "admin"}
+        "/api/v1/users/test-auth-id-123",
+        json={"role": "admin", "first_name": "Kept"},
     )
-    assert resp.status_code == 403
-    assert "admins" in resp.json()["detail"]
+    assert resp.status_code == 422
+    stored = await base.users_collection.find_one({"auth_id": "test-auth-id-123"})
+    assert stored["role"] == "user"
+    assert stored["first_name"] != "Kept"
+
+
+async def test_put_user_role_rejected_even_for_admin(auth_client_factory):
+    """#244: no API path writes role — an admin PUT targeting another user is
+    422 too; roles are managed directly in the database."""
+    from app.db import base
+
+    admin_client = await auth_client_factory(
+        overrides={"role": "admin", "auth_id": "admin-244"}
+    )
+    await auth_client_factory()  # seeds the default test-auth-id-123 user
+    resp = await admin_client.put(
+        "/api/v1/users/test-auth-id-123", json={"role": "superadmin"}
+    )
+    assert resp.status_code == 422
+    stored = await base.users_collection.find_one({"auth_id": "test-auth-id-123"})
+    assert stored["role"] == "user"
 
 
 async def test_put_user_fetch_error_returns_504(auth_client_factory):

--- a/backend/tests/test_api/test_routes/test_users_coverage.py
+++ b/backend/tests/test_api/test_routes/test_users_coverage.py
@@ -188,10 +188,26 @@ async def test_patch_me_privileged_field_rejected_and_not_persisted(
 
     client = await auth_client_factory()
     before = await base.users_collection.find_one({"auth_id": "test-auth-id-123"})
+    assert before is not None  # fail fast if the factory didn't seed the user
     resp = await client.patch("/api/v1/users/me", json={field: value})
     assert resp.status_code == 422
     after = await base.users_collection.find_one({"auth_id": "test-auth-id-123"})
     assert after == before
+
+
+async def test_patch_me_declared_fields_still_persist(auth_client_factory):
+    """extra="forbid" (#244) must not break a normal update: declared fields
+    still round-trip to the stored document."""
+    from app.db import base
+
+    client = await auth_client_factory()
+    resp = await client.patch(
+        "/api/v1/users/me", json={"first_name": "Ada", "bio": "Mathematician"}
+    )
+    assert resp.status_code == 200
+    stored = await base.users_collection.find_one({"auth_id": "test-auth-id-123"})
+    assert stored["first_name"] == "Ada"
+    assert stored["bio"] == "Mathematician"
 
 
 async def test_put_user_role_rejected_and_not_persisted(auth_client_factory):

--- a/docs/api-profile-endpoints.md
+++ b/docs/api-profile-endpoints.md
@@ -254,6 +254,10 @@ curl -X GET "http://localhost:8000/api/users/admin/users" \
 
 **Request Body**: Same format as PATCH /users/me
 
+> **Note**: `role` is not writable through the API (issue #244). A `role` key
+> (or any other undeclared field) in the request body is rejected with a 422
+> error; roles are managed directly in the database.
+
 **Response**: Updated user object
 
 **Example Request**:
@@ -262,7 +266,6 @@ curl -X PUT "http://localhost:8000/api/users/user_2NxAa1pyy8THf937QUAhKR2tXCI" \
   -H "Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ..." \
   -H "Content-Type: application/json" \
   -d '{
-    "role": "admin",
     "bio": "Admin user"
   }'
 ```

--- a/docs/demos/2026-07-10-issue-244-role-self-elevation.md
+++ b/docs/demos/2026-07-10-issue-244-role-self-elevation.md
@@ -1,0 +1,97 @@
+# Issue #244 — PATCH /users/me role self-elevation: reproduced on main, closed on the fix branch
+
+*2026-07-10T18:20:47Z*
+
+Setup: two **real** uvicorn servers share one **real** MongoDB (`auto_author_demo244`), both with `BYPASS_AUTH=false` so genuine better-auth session cookies are validated against the DB.
+
+- **:8802** runs `main` (commit e323f82, a git worktree) — the vulnerable code.
+- **:8801** runs the fix branch `fix/244-role-self-elevation`.
+
+A normal user (`role: user`) and a valid better-auth session are seeded directly into Mongo, so `PATCH /users/me` can be driven with a real session cookie — no UI needed for an API-only privilege-escalation bug.
+
+```bash
+uv run --project /home/frankbria/projects/auto-author/backend python /tmp/claude-1000/-home-frankbria-projects-auto-author/a1970958-55cf-4990-b245-4b0b467827bd/scratchpad/seed244.py
+```
+
+```output
+Seeded DB=auto_author_demo244 user auth_id=demo-victim-244 role=user
+```
+
+## The attack on `main` (:8802)
+
+A logged-in, non-admin user sends `PATCH /users/me` with `{\"role\": \"admin\"}` — the same body any browser devtools could fire — using their genuine session cookie. On main the schema accepts `role` and dumps it into a generic Mongo `$set`.
+
+```bash
+curl -s -m8 -o /dev/null -w 'HTTP %{http_code}\n' -X PATCH http://127.0.0.1:8802/api/v1/users/me -H 'Content-Type: application/json' -b 'better-auth.session_token=demo-session-token-244' -d '{"role": "admin"}'
+```
+
+```output
+HTTP 200
+```
+
+The request succeeded (HTTP 200). Now read the **stored** role straight from Mongo — the ground truth, not the API response:
+
+```bash
+uv run --project /home/frankbria/projects/auto-author/backend python /tmp/claude-1000/-home-frankbria-projects-auto-author/a1970958-55cf-4990-b245-4b0b467827bd/scratchpad/role244.py
+```
+
+```output
+stored role = 'admin'
+```
+
+The victim just escalated themselves to **admin** — everything gated on `SessionRoleChecker` (e.g. `GET /users/admin/users`) is now theirs.
+
+## The same attack on the fix branch (:8801)
+
+Re-seed the user back to `role: user`, then fire the identical request at the branch.
+
+```bash
+uv run --project /home/frankbria/projects/auto-author/backend python /tmp/claude-1000/-home-frankbria-projects-auto-author/a1970958-55cf-4990-b245-4b0b467827bd/scratchpad/seed244.py
+```
+
+```output
+Seeded DB=auto_author_demo244 user auth_id=demo-victim-244 role=user
+```
+
+```bash
+curl -s -m8 -w '\nHTTP %{http_code}\n' -X PATCH http://127.0.0.1:8801/api/v1/users/me -H 'Content-Type: application/json' -b 'better-auth.session_token=demo-session-token-244' -d '{"role": "admin"}'
+```
+
+```output
+{"detail":"Validation error","errors":[{"type":"extra_forbidden","loc":["body","role"],"msg":"Extra inputs are not permitted","input":"admin"}],"error_summary":"body -> role: Extra inputs are not permitted"}
+HTTP 422
+```
+
+The branch rejects the request with **HTTP 422** — `UserUpdate` is now `extra=\"forbid\"`, so `role` (an undeclared, privileged key) is refused at the validation boundary before any `$set` runs. Confirm the stored role is untouched:
+
+```bash
+uv run --project /home/frankbria/projects/auto-author/backend python /tmp/claude-1000/-home-frankbria-projects-auto-author/a1970958-55cf-4990-b245-4b0b467827bd/scratchpad/role244.py
+```
+
+```output
+stored role = 'user'
+```
+
+`extra=\"forbid\"` is strict, so the last thing to prove is that a **normal** profile update still works on the branch — the declared fields round-trip, only the privileged/unknown keys are refused:
+
+```bash
+curl -s -m8 -X PATCH http://127.0.0.1:8801/api/v1/users/me -H 'Content-Type: application/json' -b 'better-auth.session_token=demo-session-token-244' -d '{"first_name": "Ada", "bio": "Mathematician"}' | jq '{first_name, bio, role}'
+```
+
+```output
+{
+  "first_name": "Ada",
+  "bio": "Mathematician",
+  "role": "user"
+}
+```
+
+## Verdict
+
+| | `main` (:8802) | `fix/244` (:8801) |
+|---|---|---|
+| `PATCH /users/me {\"role\":\"admin\"}` | **200 OK** | **422 rejected** |
+| Stored role after | **`admin`** ⚠️ escalated | **`user`** ✅ unchanged |
+| Normal profile edit | works | works (declared fields round-trip) |
+
+The privilege-escalation path is closed at the schema boundary. Because the fix is `extra=\"forbid\"` rather than a one-field strip, the *same* 422 now guards every other privileged field (`plan`, `is_active`, `stripe_*`, `book_ids`, `auth_id`) — pinned by the parameterized regression tests.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,29 +1,28 @@
-# Issue #188 — [P1.8] Nested retry wrappers can multiply OpenAI calls to max_retries²
+# Issue #244 — [P0.9] Privilege escalation: PATCH /users/me accepts role
 
-Backend-only. No plan comment on the issue — plan authored from the codebase. **No architectural fork** → approved autonomously.
+**Plan source**: self-authored (no plan comment on the issue; CodeRabbit boilerplate only).
+**Approved**: autonomously (no architectural fork — the AC itself allows "removed … or ignored/stripped"; removal matches repo precedent: #220 deliberately kept stripe fields out of `UserUpdate`, #186 deleted rather than gated).
 
-## Premise verification (drift check)
-- Confirmed nesting: `_make_openai_request` (ai_service.py:216) already wraps itself in `_retry_with_backoff`; `generate_clarifying_questions` (:314) and `generate_table_of_contents` (:555) wrap it in a second `_retry_with_backoff`.
-- **Premise partially stale**: no actual `AI_MAX_RETRIES²` call multiplication occurs today. The inner layer converts every OpenAI error into an `AIServiceError` subclass (ai_errors.py), and the outer wrapper's `except AIServiceError: raise` re-raises without retrying. A persistent failure makes exactly `AI_MAX_RETRIES` real calls on main.
-- Real defects the nesting causes today:
-  1. Outer logs a spurious extra "Attempting API call (attempt 1/N)" per request — 4 log records for 3 real calls.
-  2. The caller's `correlation_id` is consumed by the outer wrapper; the inner retry loop (where the real attempts/backoff happen) generates its OWN uuid — retry/backoff logs are uncorrelated with the request.
-  3. The non-squaring is accidental: it depends on the inner layer never leaking a raw `openai.*` exception. Any future edit to the inner error conversion silently re-introduces squaring.
-- AC unchanged and valid: retry at exactly one layer; test pins ≤ AI_MAX_RETRIES requests on persistent failure.
+## Root cause
+`UserUpdate` (`backend/app/schemas/user.py:94`) exposes `role: Optional[str]`; `PATCH /api/v1/users/me` (`update_profile`) dumps `exclude_unset=True` straight into the generic `update_user()` `$set` — any authenticated user can persist `{"role": "admin"}` and everything gated on `SessionRoleChecker` is escalatable.
 
-## Plan (TDD)
-1. **RED** — new `TestSingleRetryLayer` class in `backend/tests/test_services/test_ai_service_errors.py`:
-   - Persistent `openai.RateLimitError`: `generate_clarifying_questions` makes exactly `settings.AI_MAX_RETRIES` calls to `client.chat.completions.create` (AC pin — passes on main too; regression guard against squaring).
-   - Same assertion for `generate_table_of_contents` (AC pin).
-   - Log-based red test: exactly `AI_MAX_RETRIES` "Attempting API call" log records (caplog) — FAILS on main (outer layer adds one more), proving single-layer.
-   - Correlation red test: every "Attempting API call" record carries the same correlation_id (main has two distinct ids: outer's vs inner's uuid).
-   - Patch `asyncio.sleep` in ai_service to keep tests fast.
-2. **GREEN** — `backend/app/services/ai_service.py`:
-   - `_make_openai_request` gains optional `correlation_id: Optional[str] = None`, forwarded to its internal `_retry_with_backoff` (preserves request-scoped correlation in retry logs; the other 5 direct call sites are unaffected).
-   - Sites ~314 and ~555: replace `await self._retry_with_backoff(self._make_openai_request, ...)` with direct `await self._make_openai_request(messages=..., temperature=..., max_tokens=..., correlation_id=correlation_id)`.
-3. Targeted tests → full backend suite + ruff (ping mongod first — pre-commit hang gotcha).
-4. Deslop scan → pre-PR opencode (GLM) review → PR → post-PR review → demo (wire-boundary stub per stale-local-key memory; show attempt-count + single-layer log evidence main vs branch) → CI gate → docs sync → merge.
+## Decision
+Remove `role` from `UserUpdate` entirely (root fix — no current or future handler can pass it through), rather than stripping it in one handler. Consequences:
+- `PUT /users/{auth_id}`'s non-admin role guard becomes dead code (references the removed field) → deleted. Role is now unwritable via the API for **everyone**, admins included — no admin role-change path exists in any UI/script/test today (verified), so per YAGNI roles are managed directly in the DB.
+- Unknown `role` key in a request body is ignored by pydantic (BaseModel default) → 200 with role untouched, other fields applied.
 
-## Decisions (no fork)
-- Keep the retry inside `_make_openai_request`, strip the outer wrappers (AC's first branch) — 5 other call sites already rely on the internal retry; stripping the internal one would touch 7 sites.
-- Thread `correlation_id` through rather than dropping it — preserves the only useful thing the outer layer provided.
+## Audit of other privileged fields (AC 3)
+- `plan`, `stripe_customer_id`, `stripe_subscription_id`, `is_active`, `book_ids`, `auth_id`: already absent from `UserUpdate` (deliberate, #220).
+- `metadata` (arbitrary dict): stored under its own key, never read for authz anywhere in `app/` — not privileged.
+- `email`: self-service with duplicate-key guard; pre-existing intended behavior, out of scope.
+→ `role` was the only privileged field reachable.
+
+## Steps (TDD)
+- [ ] 1. Branch `fix/244-role-self-elevation`
+- [ ] 2. RED — tests in `tests/test_api/test_routes/test_users_coverage.py`:
+  - AC regression: `PATCH /users/me` with `{"role": "admin", "first_name": "X"}` → 200, response role `user`, **stored DB role unchanged**, first_name applied
+  - Same stored-role-unchanged property for `PUT /users/{auth_id}` (self-target)
+  - Re-target `test_put_user_non_admin_role_change_returns_403`: the 403 guard is superseded by field removal — replaced with a strictly stronger assertion (stored role unchanged; the 403 only proved the request was rejected, not that role was unwritable)
+- [ ] 3. GREEN — remove `role` from `UserUpdate` + its json_schema example; delete the dead PUT role guard
+- [ ] 4. Full backend suite + coverage + ruff
+- [ ] 5. Deslop scan, quality gate (opencode GLM pre-PR review), PR, post-PR review, demo (two real servers: main self-elevates, branch doesn't), CI, docs sync, merge


### PR DESCRIPTION
Closes #244 ([P0.9] Privilege escalation: PATCH /users/me accepts role).

## Root cause
`UserUpdate` exposed `role: Optional[str]`, and `PATCH /api/v1/users/me` dumped `model_dump(exclude_unset=True)` straight into the generic `update_user()` Mongo `$set` — any authenticated user could persist `{"role": "admin"}` and everything gated on `SessionRoleChecker` was self-escalatable.

## Fix (root cause, not symptom)
- **`role` removed from `UserUpdate`** (and its OpenAPI example) — privileged fields follow the #220 policy: not API-writable.
- **`extra="forbid"` on `UserUpdate`** — the declared fields are now the single writable allowlist, enforced by pydantic before any handler runs. An unknown/privileged key (`role`, `plan`, `is_active`, `stripe_*`, `book_ids`, `auth_id`) is a **loud 422**, never a silent `$set` — closing the mass-assignment *class*, not just the `role` instance, and preserving the audit signal (escalation attempts are visible as 4xx).
- **Dead non-admin role guard deleted** from `PUT /users/{auth_id}` (it referenced the removed field). No API path writes `role` for anyone — admins included; no admin role-change UI/script exists (verified), so roles are managed directly in the database.

## Privileged-field audit (AC 3)
`plan`/`stripe_customer_id`/`stripe_subscription_id`/`is_active`/`book_ids`/`auth_id` were already deliberately absent from `UserUpdate` (#220) and are now also forbid-guarded. `metadata` is stored under its own key and nothing in `app/` ever reads `user["metadata"]` (authz or otherwise). `email` stays self-service (duplicate-key guarded, pre-existing behavior).

## Tests
- Parameterized regression: `PATCH /users/me` with each privileged field → **422 + stored document byte-identical** (before/after full-doc compare, real Mongo).
- `PUT /users/{auth_id}` with `role` → 422 + nothing persisted; **admin-caller variant** pins that no API path writes role.
- `test_put_user_non_admin_role_change_returns_403` was superseded: the 403 guard is gone with the field; replaced by the strictly stronger unwritable-pin above (the 403 only proved rejection, not unwritability).
- Backend **1157 passed / 13 skipped, 92.21% coverage**; ruff clean; pre-commit gates green.

## Review
opencode (GLM) pre-PR review ×2: round 1 — 1 Major (mass-assignment class) **adopted** via `extra="forbid"`; its duplicate handler-level allowlist **rebutted** (schema is the single source of truth, pydantic already enforces at the boundary); sibling-field + admin-context test minors adopted; metadata minor rebutted with grep evidence. Round 2: **clean to merge** after a one-word doc fix (applied). Pre-existing `PUT` sanitize_input gap filed as #265.

## Known limitations
- `extra="forbid"` is a strict contract change: clients sending undeclared keys now get 422 instead of silent-ignore. The only production caller (`useProfileApi.ProfileUpdateData`) sends declared keys exclusively (verified); full suite green.
- Admins can no longer change roles via the API (no consumer existed); role changes are a direct-DB operation until a real admin surface is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)