### PR TITLE
fix(frontend): gate client console.log debug statements behind dev-only logger (#208)

### DIFF
--- a/docs/demos/2026-07-18-issue-208-gate-client-console-logs.md
+++ b/docs/demos/2026-07-18-issue-208-gate-client-console-logs.md
@@ -1,0 +1,52 @@
+# Demo — #208: gate client `console.log` debug statements behind a dev-only logger
+
+**PR:** #314 · **Type:** frontend-only · **Change:** new `lib/logger.ts` + `console.log` → `logger.debug` across client hooks/components.
+
+The issue: ~2 dozen ungated `console.log` calls printed internal client state to the
+production browser console. AC: *route through a dev-only logger gated on
+`process.env.NODE_ENV`; keep genuine `console.error`/`console.warn`.*
+
+---
+
+## AC 1 — ungated debug logs no longer run in the production browser
+
+**Mechanism:** `logger.debug` calls `console.log` only when `process.env.NODE_ENV !== 'production'`.
+In a production build Next.js inlines `NODE_ENV`, so the guard is `if (false)` → the log never executes.
+
+**Outcome (real module, real runtime gate — `lib/__tests__/logger.test.ts`):**
+
+```
+✓ does not call console.log in production      (0 console.log calls under NODE_ENV=production)
+✓ calls console.log with all args outside production
+✓ also logs under test env (non-production)
+```
+
+**No ungated debug `console.log` remain in client production code** (grep over
+`src/**/*.{ts,tsx}`, excluding server files / JSDoc comments / test helpers):
+
+```
+=== remaining EXECUTED console.log in client production code ===
+lib/logger.ts:15:      console.log(...args);      # the single gated call, by design
+```
+
+## AC 2 — genuine `console.error` / `console.warn` preserved
+
+Only `console.log` was converted. A real `console.error` string survives into the
+production client bundle:
+
+```
+'Verification query failed' (a console.error) → present in .next/static  (1 file)
+```
+
+## Build / suites
+
+- `npm run build` → exit 0 (production build succeeds).
+- 15 affected hook/component suites → **244 passed**; new `logger.test.ts` → 3 passed.
+- Typecheck clean; lint 0 errors.
+
+## Scope note
+
+Server code (`lib/auth.ts`, `lib/email.ts`), JSDoc `* console.log` examples, and
+`lib/testing/*` / `e2e/*` helpers are out of scope — they never ship to the browser.
+The two client files the issue didn't list (`NotReadyMessage.tsx`,
+`chapters/[chapterId]/page.tsx`) were included as the same class (root-cause completeness).

--- a/frontend/src/app/dashboard/books/[bookId]/chapters/[chapterId]/page.tsx
+++ b/frontend/src/app/dashboard/books/[bookId]/chapters/[chapterId]/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { logger } from '@/lib/logger';
+
 import { use, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
@@ -88,10 +90,10 @@ export default function ChapterContentPage({ params }: ChapterContentPageProps) 
           bookId={bookId}
           chapterId={chapterId}
           onSave={(content: string) => {
-            console.log('Chapter saved from individual page:', content.length, 'characters');
+            logger.debug('Chapter saved from individual page:', content.length, 'characters');
           }}
           onContentChange={(content: string) => {
-            console.log('Content changed:', content.length, 'characters');
+            logger.debug('Content changed:', content.length, 'characters');
           }}
         />
       </div>

--- a/frontend/src/app/dashboard/books/[bookId]/edit-toc/page.tsx
+++ b/frontend/src/app/dashboard/books/[bookId]/edit-toc/page.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable react/no-unescaped-entities */
 'use client';
 
+import { logger } from '@/lib/logger';
+
 import { useState, useEffect, use } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSession } from '@/lib/auth-client';
@@ -410,7 +412,7 @@ export default function EditTOCPage({ params }: { params: Promise<{ bookId: stri
 
       // Convert local Chapter format to API TocData format
       const tocData = convertChaptersToTocData(toc);
-      console.log('TOC to save:', tocData);
+      logger.debug('TOC to save:', tocData);
 
       // Save TOC using the real API
       await bookClient.updateToc(bookId, tocData);

--- a/frontend/src/components/chapters/ChapterEditor.tsx
+++ b/frontend/src/components/chapters/ChapterEditor.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { logger } from '@/lib/logger';
+
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
@@ -317,7 +319,7 @@ export function ChapterEditor({
         onSave(content);
       }
       if (!isAutoSave) {
-        console.log('Chapter content saved successfully');
+        logger.debug('Chapter content saved successfully');
       }
     } catch (err) {
       console.error('Failed to save chapter:', err);

--- a/frontend/src/components/chapters/ChapterTabs.tsx
+++ b/frontend/src/components/chapters/ChapterTabs.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { logger } from '@/lib/logger';
+
 import { useEffect, useCallback } from 'react';
 import { useChapterTabs } from '@/hooks/useChapterTabs';
 import { useTocSync } from '@/hooks/useTocSync';
@@ -255,11 +257,11 @@ export function ChapterTabs({ bookId, initialActiveChapter, className, orientati
             chapters={state.chapters}
             onContentChange={(chapterId, contentValue) => {
               // Handle real-time content changes for auto-save
-              console.log(`Content changed for chapter ${chapterId}: ${contentValue.length} characters`);
+              logger.debug(`Content changed for chapter ${chapterId}: ${contentValue.length} characters`);
             }}
             onChapterSave={(chapterId) => {
               // Handle chapter save completion
-              console.log(`Chapter ${chapterId} saved successfully`);
+              logger.debug(`Chapter ${chapterId} saved successfully`);
               saveTabState(); // Update tab state when content is saved
             }}
             data-testid="tab-content"

--- a/frontend/src/components/chapters/questions/QuestionDisplay.tsx
+++ b/frontend/src/components/chapters/questions/QuestionDisplay.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { logger } from '@/lib/logger';
+
 import { Question, QuestionType, QuestionDifficulty, ResponseStatus, MAX_REGENERATION_COUNT } from '@/types/chapter-questions';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -209,7 +211,7 @@ export default function QuestionDisplay({
         }
 
         // Log successful verification
-        console.log(
+        logger.debug(
           `Verification successful: Response confirmed in database (question_id=${question.id}, status=${savedResponse.status})`
         );
       } catch (verifyError) {

--- a/frontend/src/components/toc/NotReadyMessage.tsx
+++ b/frontend/src/components/toc/NotReadyMessage.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { TocReadiness } from '@/types/toc';
@@ -21,9 +22,9 @@ export default function NotReadyMessage({ readiness, onRetry, bookId }: NotReady
   const handleAnalyzeSummary = async () => {
     try {
       setIsAnalyzing(true);
-      console.log('Running fresh analysis on summary...');
+      logger.debug('Running fresh analysis on summary...');
       await bookClient.analyzeSummary(bookId);
-      console.log('Analysis completed, refreshing readiness check...');
+      logger.debug('Analysis completed, refreshing readiness check...');
       onRetry(); // This will trigger a fresh readiness check
     } catch (error) {
       console.error('Error analyzing summary:', error);

--- a/frontend/src/components/toc/TocGenerationWizard.tsx
+++ b/frontend/src/components/toc/TocGenerationWizard.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { logger } from '@/lib/logger';
+
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSession } from '@/lib/auth-client';
@@ -74,11 +76,11 @@ export default function TocGenerationWizard({ bookId }: TocGenerationWizardProps
 
       // First, analyze the summary using AI to get readiness assessment
       try {
-        console.log('Analyzing summary with AI...');
+        logger.debug('Analyzing summary with AI...');
         await trackOperation('analyze-summary', async () => {
           return await bookClient.analyzeSummary(bookId);
         }, { bookId });
-        console.log('Summary analysis completed');
+        logger.debug('Summary analysis completed');
       } catch (analysisError) {
         // An entitlement denial is a paywall, not a transient analysis
         // failure — surface the upgrade path instead of swallowing it (#247).

--- a/frontend/src/hooks/useChapterTabs.ts
+++ b/frontend/src/hooks/useChapterTabs.ts
@@ -1,3 +1,4 @@
+import { logger } from '../lib/logger';
 import { useState, useEffect, useCallback } from 'react';
 import { ChapterTabsState, ChapterStatus, ChapterTabMetadata } from '../types/chapter-tabs';
 import bookClient from '../lib/api/bookClient';
@@ -40,7 +41,7 @@ export function useChapterTabs(bookId: string, initialActiveChapter?: string) {
             // Convert TOC data to chapter tab metadata format
             chapterTabsMetadata = convertTocToChapterTabs(processedTocData);
 
-            console.log('Successfully loaded TOC structure and converted to chapter tabs');
+            logger.debug('Successfully loaded TOC structure and converted to chapter tabs');
           }
         } catch (tocError) {
           console.warn('Failed to load TOC structure:', tocError);          // If TOC fails, fall back to direct chapter tabs API
@@ -53,7 +54,7 @@ export function useChapterTabs(bookId: string, initialActiveChapter?: string) {
             }));
             lastActiveChapter = metadata.last_active_chapter;
 
-            console.log('Loaded chapter data from chapter-tabs API');
+            logger.debug('Loaded chapter data from chapter-tabs API');
           } catch (apiError) {
             console.error('Failed to load chapter metadata:', apiError);
             // If both methods fail, we'll end up with an empty array
@@ -66,7 +67,7 @@ export function useChapterTabs(bookId: string, initialActiveChapter?: string) {
           const savedState = localStorage.getItem(`tabState_${bookId}`);
           if (savedState) {
             localTabState = JSON.parse(savedState);
-            console.log('Loaded tab state from localStorage:', localTabState);
+            logger.debug('Loaded tab state from localStorage:', localTabState);
           }
         } catch (e) {
           console.warn('Failed to load tab state from localStorage:', e);
@@ -78,7 +79,7 @@ export function useChapterTabs(bookId: string, initialActiveChapter?: string) {
 
         try {
           backendTabState = await bookClient.getTabState(bookId);
-          console.log('Loaded tab state from backend:', backendTabState);
+          logger.debug('Loaded tab state from backend:', backendTabState);
 
           // Get the actual state object (the API might return different formats)
           // @ts-expect-error - Handle different response formats for backwards compatibility
@@ -91,10 +92,10 @@ export function useChapterTabs(bookId: string, initialActiveChapter?: string) {
 
             // Use the newer state
             if (backendDate > localDate) {
-              console.log('Backend state is newer, using backend state');
+              logger.debug('Backend state is newer, using backend state');
               tabState = backendStateData;
             } else {
-              console.log('Local state is newer, using local state');
+              logger.debug('Local state is newer, using local state');
               tabState = localTabState;
             }
           } else {
@@ -104,7 +105,7 @@ export function useChapterTabs(bookId: string, initialActiveChapter?: string) {
         } catch (error) {
           // If backend fails, fall back to local state
           console.error('Error loading backend state:', error);
-          console.log('Failed to load backend state, falling back to local state');
+          logger.debug('Failed to load backend state, falling back to local state');
           tabState = localTabState;
         }
 
@@ -270,7 +271,7 @@ export function useChapterTabs(bookId: string, initialActiveChapter?: string) {
           };
 
           chapterTabsMetadata = convertTocToChapterTabs(processedTocData);
-          console.log('Successfully refreshed TOC structure and converted to chapter tabs');
+          logger.debug('Successfully refreshed TOC structure and converted to chapter tabs');
         }
       } catch (tocError) {        console.warn('Failed to refresh TOC structure:', tocError);
         // Fall back to direct chapter tabs API
@@ -281,7 +282,7 @@ export function useChapterTabs(bookId: string, initialActiveChapter?: string) {
             status: ch.status as ChapterStatus,
             has_content: false // We'll need to check this separately if needed
           }));
-          console.log('Refreshed chapter data from chapter-tabs API');
+          logger.debug('Refreshed chapter data from chapter-tabs API');
         } catch (apiError) {
           console.error('Failed to refresh chapter metadata:', apiError);
           throw new Error('Unable to refresh chapter data');
@@ -321,7 +322,7 @@ export function useChapterTabs(bookId: string, initialActiveChapter?: string) {
         is_loading: false,
       }));
 
-      console.log('Successfully refreshed chapter tabs state');
+      logger.debug('Successfully refreshed chapter tabs state');
     } catch (error) {
       setState(prev => ({
         ...prev,

--- a/frontend/src/hooks/useTocSync.ts
+++ b/frontend/src/hooks/useTocSync.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 import { useEffect, useRef, useCallback } from 'react';
 import bookClient from '@/lib/api/bookClient';
 
@@ -53,7 +54,7 @@ export function useTocSync({ bookId, onTocChanged, pollInterval = 0 }: UseTocSyn
     const currentHash = await generateTocHash();
 
     if (currentHash && lastTocHashRef.current && currentHash !== lastTocHashRef.current) {
-      console.log('TOC change detected, triggering sync');
+      logger.debug('TOC change detected, triggering sync');
       onTocChanged();
     }
 
@@ -64,7 +65,7 @@ export function useTocSync({ bookId, onTocChanged, pollInterval = 0 }: UseTocSyn
   useEffect(() => {
     const handleTocUpdate = (event: CustomEvent) => {
       if (event.detail.bookId === bookId) {
-        console.log('TOC update event received, triggering sync');
+        logger.debug('TOC update event received, triggering sync');
         onTocChanged();
       }
     };
@@ -80,7 +81,7 @@ export function useTocSync({ bookId, onTocChanged, pollInterval = 0 }: UseTocSyn
   useEffect(() => {
     const handleStorageChange = (event: StorageEvent) => {
       if (event.key === `toc-updated-${bookId}` && event.newValue) {
-        console.log('TOC update detected via localStorage, triggering sync');
+        logger.debug('TOC update detected via localStorage, triggering sync');
         onTocChanged();
         // Clear the flag after handling
         localStorage.removeItem(`toc-updated-${bookId}`);
@@ -142,5 +143,5 @@ export function triggerTocUpdateEvent(bookId: string) {
   // Set localStorage flag for cross-tab communication
   localStorage.setItem(`toc-updated-${bookId}`, Date.now().toString());
 
-  console.log('TOC update event triggered for book:', bookId);
+  logger.debug('TOC update event triggered for book:', bookId);
 }

--- a/frontend/src/lib/__tests__/logger.test.ts
+++ b/frontend/src/lib/__tests__/logger.test.ts
@@ -1,0 +1,33 @@
+import { logger } from '../logger';
+
+describe('logger.debug', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('does not call console.log in production', () => {
+    process.env.NODE_ENV = 'production';
+    logger.debug('internal state', { foo: 1 });
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls console.log with all args outside production', () => {
+    process.env.NODE_ENV = 'development';
+    logger.debug('loaded state', { foo: 1 });
+    expect(logSpy).toHaveBeenCalledWith('loaded state', { foo: 1 });
+  });
+
+  it('also logs under test env (non-production)', () => {
+    process.env.NODE_ENV = 'test';
+    logger.debug('hi');
+    expect(logSpy).toHaveBeenCalledWith('hi');
+  });
+});

--- a/frontend/src/lib/logger.ts
+++ b/frontend/src/lib/logger.ts
@@ -1,0 +1,18 @@
+/**
+ * Dev-only console logger.
+ *
+ * `logger.debug` is silenced in production builds so internal client state never
+ * ships to the user's browser. Next.js statically inlines `process.env.NODE_ENV`
+ * at build time, so the guarded `console.log` is dead-code-eliminated from the
+ * production bundle entirely.
+ *
+ * For genuine errors/warnings that SHOULD surface in production, keep using
+ * `console.error` / `console.warn` directly.
+ */
+export const logger = {
+  debug: (...args: unknown[]): void => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log(...args);
+    }
+  },
+};


### PR DESCRIPTION
Closes #208

## Problem
~2 dozen unconditional `console.log` calls ran in the client in production, printing internal state to the user's browser console (unlike the correctly `NODE_ENV`-gated log in `lib/performance/metrics.ts`).

## Fix
- **New `frontend/src/lib/logger.ts`** — a small dev-only logger. `logger.debug(...)` calls `console.log` only when `process.env.NODE_ENV !== 'production'`. In a production build Next.js inlines `NODE_ENV`, so the guard becomes `if (false)` and the debug log **never executes** — nothing prints to the browser console. (This gates the *runtime output*; the inert debug-label strings passed as arguments may remain in the bundle, but they never run and interpolate no state.)
- Replaced every ungated debug `console.log` → `logger.debug` across the client hooks/components named in the issue: `useChapterTabs.ts`, `useTocSync.ts`, `ChapterEditor.tsx`, `ChapterTabs.tsx`, `edit-toc/page.tsx`, `QuestionDisplay.tsx`, `TocGenerationWizard.tsx`.
- Also covered two client files the issue missed but are the same class: `NotReadyMessage.tsx`, `chapters/[chapterId]/page.tsx` (root-cause completeness).
- **Genuine `console.error` / `console.warn` are untouched** — they should surface in production.

## Out of scope (deliberately)
- `lib/auth.ts` / `lib/email.ts` — run on the **server**, never ship to the browser.
- JSDoc `* console.log` examples in `bookClient.ts` / `types/*` — comments, not executed.
- `lib/testing/*`, `e2e/*` — test helpers, not production code.

## Tests
- New `lib/__tests__/logger.test.ts` (3 pins, RED-verified against a naive impl): silent in production, logs (with all args) in development, and under test env.
- All 15 affected hook/component suites pass (244 tests). Typecheck clean; lint 0 errors (only pre-existing warnings).

## Verification (outcome evidence)
- **Runtime gate on the real module**: `logger.test.ts` proves `logger.debug` makes **0** `console.log` calls under `NODE_ENV=production` and logs with all args otherwise.
- **Production build**: `npm run build` succeeds (exit 0).
- **Genuine errors preserved**: a real `console.error` string (`Verification query failed`) is still present in the production client bundle; the converted debug logs no longer execute.

## Review
Pre-PR cross-family review (opencode / GLM): **"clean to merge"** — verified `console.error`/`console.warn` preserved, gating logic correct, all imports resolve.

## Known limitations
The fix gates the debug logs at **runtime** (they no longer print in production). It does not strip the call sites from the bundle — the AC asks for runtime gating ("route through a dev-only logger gated on `process.env.NODE_ENV`"), which this satisfies; the residual inert label strings carry no runtime state and never print. Build-time removal of the call sites would need a babel transform and is out of scope (YAGNI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)