### PR TITLE
docs: add missing LICENSE (MIT) and CONTRIBUTING.md (#213)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,97 @@
+# Contributing to Auto-Author
+
+Thanks for your interest in contributing! Auto-Author is in an early MVP phase,
+and contributions, suggestions, and pull requests are welcome.
+
+This guide covers how to get set up and the standards a change is expected to
+meet before it can be merged.
+
+## Project layout
+
+- `frontend/` — Next.js app (TypeScript, Tailwind, Jest, Playwright)
+- `backend/` — FastAPI app (Python, `uv`, pytest)
+- `docs/` — project documentation
+
+## Getting set up
+
+### Backend (FastAPI + uv)
+
+```bash
+cd backend
+uv sync --extra test          # installs runtime + test dependencies
+uv run pytest --cov=app tests/ --cov-report=term-missing
+```
+
+### Frontend (Next.js + npm)
+
+```bash
+cd frontend
+npm install
+npm run dev                   # local dev server
+npm test                      # unit tests
+npx playwright test           # E2E tests
+```
+
+## Development workflow
+
+1. **Branch from `main`.** Never commit directly to `main`. Use a descriptive
+   branch name, e.g. `feature/short-description` or `fix/short-description`.
+2. **Write tests first (TDD).** New code needs unit tests; user-facing features
+   need an E2E test.
+3. **Keep the quality gates green.** Before opening a PR:
+   ```bash
+   # Frontend
+   cd frontend && npm run lint && npm run typecheck && npm test
+   # Backend
+   cd backend && uv run ruff check && uv run pytest tests/
+   ```
+4. **Update documentation** affected by your change.
+5. **Open a pull request to `main`** with a clear description of what changed
+   and why. Address review feedback before merge.
+
+## Quality standards
+
+- **Test coverage ≥ 85%** — enforced in CI for both frontend and backend. A PR
+  that drops coverage below the threshold will fail its checks.
+- **All tests pass** — 100% pass rate; no skipped tests standing in for real
+  coverage.
+- **Linting and type checking clean** — `ruff` (backend), `eslint` +
+  `tsc --noEmit` (frontend).
+- **No secrets in commits** — pre-commit hooks scan for private keys and
+  credentials.
+
+## Pre-commit hooks
+
+The repo uses pre-commit hooks that run linting, tests, and coverage checks on
+every commit. Install them once:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Bypassing hooks (`git commit --no-verify`) is reserved for genuine emergencies,
+not routine work — `main` is branch-protected and requires the CI checks to pass
+before merge regardless.
+
+## Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add EPUB export format
+fix: prevent lost-update clobber on concurrent chapter saves
+docs: add LICENSE and CONTRIBUTING guide
+test: cover the batch response-save validation path
+```
+
+## Reporting issues
+
+Open a GitHub issue describing the problem or suggestion. For bugs, include
+steps to reproduce, expected vs. actual behavior, and relevant environment
+details.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+[MIT License](LICENSE) that covers this project.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Noatak Enterprises, LLC, dba Bria Strategy Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
Closes #213 (P3.7, documentation/compliance).

MIT was declared in `package.json` (`"license": "MIT"`) and all three READMEs, and `README.md` linked `CONTRIBUTING.md`, but **neither file was tracked** (`git ls-files LICENSE CONTRIBUTING.md` → empty) — a claimed license with no license text is a compliance gap for release.

Took the AC's **add-files** branch (over remove-claims): this is a real product heading for SaaS launch with MIT declared in the machine-readable `package.json` and an active call for contributions — stripping the MIT claim would be the wrong fix.

## Changes
- **`LICENSE`** — standard MIT text. Copyright line **`Noatak Enterprises, LLC, dba Bria Strategy Group © 2025`**, matching the holder already declared in `README.md:521` and `frontend/README.md:389` verbatim. Opens with the `MIT License` header so GitHub's Licensee detector recognizes it.
- **`CONTRIBUTING.md`** — reflects the project's **actual** documented workflow (verified against CLAUDE.md/READMEs), not aspirational boilerplate: `uv sync --extra test` + `npm install` setup, feature branch → PR to `main`, TDD with ≥85% CI-enforced coverage, `ruff`/`eslint`/`tsc` gates, pre-commit hooks, conventional commits. Links back to `LICENSE`.

## Verification (docs-only, no runtime surface)
Every previously-dangling claim now resolves:
- `README.md:515` `[CONTRIBUTING.md](CONTRIBUTING.md)` link target now exists ✅
- `backend/README.md:131` "See the LICENSE file" now resolves ✅
- `LICENSE` copyright matches the README-declared holder byte-for-byte ✅
- `CONTRIBUTING.md` "By contributing… MIT License" links to `LICENSE` ✅

## Known limitations
None — additive docs only; no code, config, or behavior changed. No tests added (license text and contributor prose have no executable logic to assert; the file-existence + link-resolution + copyright-match checks above are the verification). No runtime surface, so no demo/agent-browser evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)