### PR TITLE
fix(ux): beta polish bundle — 9 small UX fixes (#215)

### DIFF
--- a/frontend/src/__tests__/ProfilePageSave.test.tsx
+++ b/frontend/src/__tests__/ProfilePageSave.test.tsx
@@ -62,31 +62,29 @@ describe('ProfilePage save preserves preferences (#204)', () => {
   });
 
   it('sends the full merged preferences object on save, preserving unexposed fields', async () => {
-    mockAuthFetch.mockImplementation(async (_path: string, opts?: { method?: string }) => {
-      if (opts?.method === 'PATCH') {
-        return profile({ ...fullPreferences, theme: 'dark' });
-      }
-      return profile(fullPreferences);
-    });
+    mockAuthFetch.mockResolvedValue(profile(fullPreferences));
 
     render(<UserProfile />);
 
-    await waitFor(() => expect(screen.getByLabelText('Theme')).toHaveValue('light'));
+    // The profile page no longer exposes a Theme control (#215 — Settings owns
+    // theme). Editing an exposed field (bio) must still round-trip the full
+    // loaded preferences, including the theme it can no longer edit.
+    await waitFor(() => expect(screen.getByLabelText('Bio')).toHaveValue('hi'));
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled()
     );
+    expect(screen.queryByLabelText('Theme')).not.toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText('Theme'), { target: { value: 'dark' } });
+    fireEvent.change(screen.getByLabelText('Bio'), { target: { value: 'updated bio' } });
     fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
 
     await waitFor(() => expect(patchCall()).toBeDefined());
     const [path, options] = patchCall()!;
     expect(path).toBe('/users/me');
     const body = JSON.parse(options.body);
-    expect(body.preferences).toMatchObject({
-      ...fullPreferences,
-      theme: 'dark',
-    });
+    expect(body.bio).toBe('updated bio');
+    // Every preference — including the theme the form can't edit — survives.
+    expect(body.preferences).toMatchObject(fullPreferences);
   });
 
   it('invalidates the shared preferences cache after a successful save', async () => {

--- a/frontend/src/__tests__/SettingsPageSave.test.tsx
+++ b/frontend/src/__tests__/SettingsPageSave.test.tsx
@@ -213,6 +213,20 @@ describe('SettingsPage', () => {
     });
   });
 
+  it('hints why Save is disabled when an off-tab (Writing) validation fails (#215)', async () => {
+    const user = userEvent.setup();
+    // An out-of-range auto-save interval lives on the Writing tab; from the
+    // Export tab the disabled Save button would otherwise be unexplained.
+    mockAuthFetch.mockResolvedValue(loadedProfile({ auto_save_interval: 999 }));
+    render(<SettingsPage />);
+
+    await waitFor(() => expect(screen.getByRole('tab', { name: /export/i })).toBeInTheDocument());
+    await user.click(screen.getByRole('tab', { name: /export/i }));
+
+    expect(screen.getByRole('button', { name: /save settings/i })).toBeDisabled();
+    expect(screen.getByRole('alert')).toHaveTextContent(/auto-save interval on the Writing tab/i);
+  });
+
   it('shows all five notification toggles disabled as "coming soon" (#195)', async () => {
     const user = userEvent.setup();
     mockAuthFetch.mockResolvedValue(

--- a/frontend/src/__tests__/SignInPage.test.tsx
+++ b/frontend/src/__tests__/SignInPage.test.tsx
@@ -99,6 +99,19 @@ describe("SignInPage error and 2FA handling (#198)", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows a generic message (never the raw backend text) for an unmatched error (#215)", async () => {
+    mockSignInEmail.mockResolvedValue({
+      data: null,
+      error: { message: "Backend raised an unexpected 500 at layer xyz" },
+    });
+    setup(null);
+    await signIn();
+    expect(
+      await screen.findByText("Failed to sign in. Please try again")
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Backend raised|layer xyz/i)).not.toBeInTheDocument();
+  });
+
   it("returns early on twoFactorRedirect: no navigation, no error (2FA race guard, #64)", async () => {
     // A 2FA-enabled account resolves with a twoFactorRedirect flag instead of
     // a session; the twoFactorClient plugin owns the /auth/verify-2fa

--- a/frontend/src/__tests__/SignUpPage.test.tsx
+++ b/frontend/src/__tests__/SignUpPage.test.tsx
@@ -72,6 +72,22 @@ describe("SignUpPage (#198)", () => {
     expect(push).not.toHaveBeenCalled();
   });
 
+  it("shows a generic message (never the raw backend text) for an unmatched error (#215)", async () => {
+    mockSignUpEmail.mockResolvedValue({
+      data: null,
+      error: { message: "Backend raised an unexpected 500 at layer xyz" },
+    });
+    const { push } = setup();
+    const user = await fillForm();
+    await user.click(submitButton());
+
+    expect(
+      await screen.findByText("Unable to create account. Please try again later")
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Backend raised|layer xyz/i)).not.toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+
   it("blocks submission with inline error when passwords do not match", async () => {
     const { push } = setup();
     await fillForm("Different1");

--- a/frontend/src/app/auth/sign-in/page.tsx
+++ b/frontend/src/app/auth/sign-in/page.tsx
@@ -74,8 +74,8 @@ function getErrorMessage(error: { message?: string; code?: string } | null): str
     return "Connection error. Please check your internet";
   }
 
-  // Return original message if no pattern matched
-  return error.message || "Failed to sign in. Please try again";
+  // Unmatched: show a safe generic message, never the raw backend text (#215).
+  return "Failed to sign in. Please try again";
 }
 
 function SignInForm() {
@@ -120,7 +120,7 @@ function SignInForm() {
         if (err.message.includes("network") || err.message.includes("fetch")) {
           setError("Connection error. Please check your internet");
         } else {
-          setError(err.message);
+          setError("Failed to sign in. Please try again");
         }
       } else {
         setError("An unexpected error occurred");

--- a/frontend/src/app/auth/sign-up/page.tsx
+++ b/frontend/src/app/auth/sign-up/page.tsx
@@ -75,8 +75,8 @@ function getErrorMessage(error: { message?: string; code?: string } | null): str
     return "Connection error. Please check your internet";
   }
 
-  // Return original message if no pattern matched
-  return error.message || "Unable to create account. Please try again later";
+  // Unmatched: show a safe generic message, never the raw backend text (#215).
+  return "Unable to create account. Please try again later";
 }
 
 export default function SignUpPage() {
@@ -141,7 +141,7 @@ export default function SignUpPage() {
         if (err.message.includes("network") || err.message.includes("fetch")) {
           setError("Connection error. Please check your internet");
         } else {
-          setError(err.message);
+          setError("Unable to create account. Please try again later");
         }
       } else {
         setError("An unexpected error occurred");

--- a/frontend/src/app/dashboard/books/[bookId]/__tests__/page.errorRetry.test.tsx
+++ b/frontend/src/app/dashboard/books/[bookId]/__tests__/page.errorRetry.test.tsx
@@ -1,0 +1,83 @@
+import React, { Suspense } from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import BookPage from '../page';
+import { useSession } from '@/lib/auth-client';
+import bookClient from '@/lib/api/bookClient';
+
+// The book-overview page's error state used to offer a Try Again button wired
+// to window.location.reload() — a full page reload instead of an in-place
+// refetch (#215). This suite pins the refetch behavior.
+
+jest.mock('@/lib/auth-client');
+jest.mock('@/lib/api/bookClient');
+jest.mock('@/lib/toast', () => ({
+  toast: Object.assign(jest.fn(), {
+    success: jest.fn(),
+    error: jest.fn(),
+    warning: jest.fn(),
+    info: jest.fn(),
+  }),
+}));
+// next/navigation is mocked globally in jest.setup.ts (useSearchParams →
+// empty URLSearchParams, useRouter → push spy) — no local override needed.
+
+const mockBookClient = bookClient as jest.Mocked<typeof bookClient>;
+
+// React's use(params) can't suspend-then-resume on a plain resolved Promise in
+// jest; a pre-fulfilled thenable lets it read the value synchronously (#194).
+function fulfilledParams<T>(value: T): Promise<T> {
+  const p = Promise.resolve(value) as Promise<T> & { status: string; value: T };
+  p.status = 'fulfilled';
+  p.value = value;
+  return p;
+}
+
+function renderPage() {
+  return render(
+    <Suspense fallback={null}>
+      <BookPage params={fulfilledParams({ bookId: 'book-1' })} />
+    </Suspense>
+  );
+}
+
+describe('BookPage error → in-place refetch (#215)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useSession as jest.Mock).mockReturnValue({ data: { user: { id: 'u1' } } });
+    mockBookClient.getToc.mockResolvedValue({ toc: null } as never);
+    mockBookClient.getBookSummary.mockResolvedValue({ summary: '' } as never);
+  });
+
+  it('refetches in place when Try Again is clicked — no window.location.reload', async () => {
+    const reload = jest.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload },
+    });
+
+    // First load fails → error state; retry succeeds → book renders.
+    mockBookClient.getBook
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({
+        id: 'book-1',
+        title: 'My Nonfiction Book',
+        description: 'desc',
+        progress: 0,
+      } as never);
+
+    renderPage();
+
+    const retry = await screen.findByRole('button', { name: /try again/i });
+    expect(mockBookClient.getBook).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(retry);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('heading', { level: 1, name: 'My Nonfiction Book' })
+      ).toBeInTheDocument()
+    );
+    expect(mockBookClient.getBook).toHaveBeenCalledTimes(2);
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/dashboard/books/[bookId]/page.tsx
+++ b/frontend/src/app/dashboard/books/[bookId]/page.tsx
@@ -98,8 +98,7 @@ export default function BookPage({ params }: { params: Promise<{ bookId: string 
   // Unwrap params using React.use (Next.js 15+)
   const { bookId } = React.use(params);
 
-  useEffect(() => {
-    const fetchBookData = async () => {
+  const fetchBookData = React.useCallback(async () => {
       setIsLoading(true);
       try {
 
@@ -147,10 +146,11 @@ export default function BookPage({ params }: { params: Promise<{ bookId: string 
       } finally {
         setIsLoading(false);
       }
-    };
-
-    fetchBookData();
   }, [bookId, session]);
+
+  useEffect(() => {
+    fetchBookData();
+  }, [fetchBookData]);
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
     return date.toLocaleDateString('en-US', {
@@ -371,7 +371,7 @@ export default function BookPage({ params }: { params: Promise<{ bookId: string 
           <p className="text-gray-300 mb-4">{error}</p>
           <div className="flex space-x-4">
             <button
-              onClick={() => window.location.reload()}
+              onClick={() => fetchBookData()}
               className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white font-medium rounded-md"
             >
               Try Again

--- a/frontend/src/app/dashboard/help/__tests__/page.test.tsx
+++ b/frontend/src/app/dashboard/help/__tests__/page.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import HelpPage from '../page';
+
+describe('HelpPage', () => {
+  it('renders the support email as a mailto: link (#215)', () => {
+    render(<HelpPage />);
+    const link = screen.getByRole('link', { name: 'support@autoauthor.com' });
+    expect(link).toHaveAttribute('href', 'mailto:support@autoauthor.com');
+  });
+});

--- a/frontend/src/app/dashboard/help/page.tsx
+++ b/frontend/src/app/dashboard/help/page.tsx
@@ -38,7 +38,13 @@ export default function HelpPage() {
         <section>
           <h2 className="text-2xl font-semibold mb-3">Need More Help?</h2>
           <p className="text-muted-foreground">
-            If you need additional assistance, please contact our support team at support@autoauthor.com
+            If you need additional assistance, please contact our support team at{' '}
+            <a
+              href="mailto:support@autoauthor.com"
+              className="text-primary underline-offset-4 hover:underline"
+            >
+              support@autoauthor.com
+            </a>
           </p>
         </section>
       </div>

--- a/frontend/src/app/dashboard/settings/page.tsx
+++ b/frontend/src/app/dashboard/settings/page.tsx
@@ -222,7 +222,14 @@ export default function SettingsPage() {
 
       {/* Security and Billing actions save/self-serve themselves; the shared button covers preference tabs */}
       {activeTab !== 'security' && activeTab !== 'billing' && (
-        <div className="mt-6 flex justify-end">
+        <div className="mt-6 flex flex-col items-end gap-2">
+          {/* The auto-save interval lives on the Writing tab, so an invalid value
+              there would otherwise disable Save with no hint on the current tab (#215). */}
+          {isLoaded && !intervalValid && activeTab !== 'writing' && (
+            <p role="alert" className="text-sm text-destructive">
+              Fix the auto-save interval on the Writing tab before saving.
+            </p>
+          )}
           <Button
             onClick={handleSaveSettings}
             size="lg"

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -32,7 +32,6 @@ const profileSchema = z.object({
   lastName: z.string().trim().max(50, 'Max 50 characters'),
   displayName: z.string().trim().max(100, 'Max 100 characters'),
   bio: z.string().max(BIO_MAX, `Max ${BIO_MAX} characters`).optional(),
-  theme: z.enum(['light', 'dark', 'system']),
   emailNotifications: z.boolean(),
   marketingEmails: z.boolean(),
 });
@@ -66,7 +65,6 @@ export default function UserProfile() {
       lastName: '',
       displayName: '',
       bio: '',
-      theme: 'system',
       emailNotifications: true,
       marketingEmails: false,
     },
@@ -89,7 +87,6 @@ export default function UserProfile() {
       lastName,
       displayName: user?.name ?? '',
       bio: '',
-      theme: 'system',
       emailNotifications: true,
       marketingEmails: false,
     });
@@ -122,7 +119,6 @@ export default function UserProfile() {
               p.display_name ??
               [p.first_name ?? firstName, p.last_name ?? lastName].filter(Boolean).join(' '),
             bio: p.bio ?? '',
-            theme: p.preferences?.theme ?? 'system',
             emailNotifications: p.preferences?.email_notifications ?? true,
             marketingEmails: p.preferences?.marketing_emails ?? false,
           },
@@ -150,8 +146,9 @@ export default function UserProfile() {
         display_name: values.displayName,
         bio: values.bio,
         preferences: {
+          // Theme is owned by the Settings page (next-themes); the profile
+          // form no longer exposes it (#215). The loaded value is preserved.
           ...preferences,
-          theme: values.theme,
           email_notifications: values.emailNotifications,
           marketing_emails: values.marketingEmails,
         },
@@ -301,26 +298,6 @@ export default function UserProfile() {
           {/* Preferences */}
           <section className="space-y-4">
             <h2 className="text-lg font-semibold">Preferences</h2>
-
-            <FormField
-              control={form.control}
-              name="theme"
-              render={({ field }) => (
-                <div className="space-y-2">
-                  <Label htmlFor="theme">Theme</Label>
-                  <select
-                    id="theme"
-                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                    value={field.value}
-                    onChange={field.onChange}
-                  >
-                    <option value="light">Light</option>
-                    <option value="dark">Dark</option>
-                    <option value="system">System</option>
-                  </select>
-                </div>
-              )}
-            />
 
             <FormField
               control={form.control}

--- a/frontend/src/components/__tests__/BookMetadataForm.test.tsx
+++ b/frontend/src/components/__tests__/BookMetadataForm.test.tsx
@@ -27,6 +27,13 @@ describe('BookMetadataForm genre taxonomy (shared with BookCreationWizard, #205)
     expect(screen.getByRole('option', { name: 'Self-Help' })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: 'Business' })).toBeInTheDocument();
   });
+
+  it('offers no fiction-only genres — Auto Author is nonfiction (#215)', () => {
+    render(<BookMetadataForm book={book} onUpdate={jest.fn()} isSaving={false} />);
+    for (const fiction of ['Fiction', 'Science Fiction', 'Fantasy', 'Mystery', 'Romance']) {
+      expect(screen.queryByRole('option', { name: fiction })).not.toBeInTheDocument();
+    }
+  });
 });
 
 describe('BookMetadataForm saving state', () => {

--- a/frontend/src/components/books/__tests__/BookCreationWizard.test.tsx
+++ b/frontend/src/components/books/__tests__/BookCreationWizard.test.tsx
@@ -45,7 +45,7 @@ describe('BookCreationWizard', () => {
     title: 'My Test Book',
     subtitle: 'A subtitle',
     description: 'A description of my test book',
-    genre: 'fiction',
+    genre: 'business',
     target_audience: 'adult',
     cover_image_url: 'https://example.com/cover.jpg',
   };
@@ -241,7 +241,7 @@ describe('BookCreationWizard', () => {
 
       // Fill all required fields
       await user.type(screen.getByLabelText(/Book Title/i), validBookData.title);
-      await selectOption(user, /Genre/i, 'Fiction');
+      await selectOption(user, /Genre/i, 'Business');
       await selectOption(user, /Target Audience/i, 'Adult');
 
       // Submit button should be enabled
@@ -316,7 +316,7 @@ describe('BookCreationWizard', () => {
       await user.type(screen.getByLabelText(/Book Title/i), 'Test Book');
 
       // For this test, we're verifying genre field exists and accepts input
-      await selectOption(user, /Genre/i, 'Fiction');
+      await selectOption(user, /Genre/i, 'Business');
 
       const genreButton = screen.getByLabelText(/Genre/i);
       expect(genreButton).toBeInTheDocument();
@@ -380,7 +380,7 @@ describe('BookCreationWizard', () => {
 
       // Fill all required fields
       await user.type(screen.getByLabelText(/Book Title/i), validBookData.title);
-      await selectOption(user, /Genre/i, 'Fiction');
+      await selectOption(user, /Genre/i, 'Business');
       await selectOption(user, /Target Audience/i, 'Adult');
 
       await user.click(screen.getByRole('button', { name: /Create Book/i }));
@@ -399,7 +399,7 @@ describe('BookCreationWizard', () => {
       await user.type(screen.getByLabelText(/Subtitle/i), validBookData.subtitle!);
       await user.type(screen.getByLabelText(/Description/i), validBookData.description!);
       await user.type(screen.getByLabelText(/Cover Image URL/i), validBookData.cover_image_url!);
-      await selectOption(user, /Genre/i, 'Fiction');
+      await selectOption(user, /Genre/i, 'Business');
       await selectOption(user, /Target Audience/i, 'Adult');
 
       await user.click(screen.getByRole('button', { name: /Create Book/i }));
@@ -493,7 +493,7 @@ describe('BookCreationWizard', () => {
       await user.click(screen.getByLabelText(/Book Title/i));
       await user.paste('Book: "Test" & More! <Special>'); // Input with special chars
 
-      await selectOption(user, /Genre/i, 'Fiction');
+      await selectOption(user, /Genre/i, 'Business');
       await selectOption(user, /Target Audience/i, 'Adult');
 
       await user.click(screen.getByRole('button', { name: /Create Book/i }));
@@ -512,7 +512,7 @@ describe('BookCreationWizard', () => {
 
       // Rapid typing and selection
       await user.type(screen.getByLabelText(/Book Title/i), 'Quick Book');
-      await selectOption(user, /Genre/i, 'Fiction');
+      await selectOption(user, /Genre/i, 'Business');
       await selectOption(user, /Target Audience/i, 'Adult');
 
       // Form should handle rapid interactions

--- a/frontend/src/components/profile/ProfilePictureUpload.test.tsx
+++ b/frontend/src/components/profile/ProfilePictureUpload.test.tsx
@@ -81,4 +81,21 @@ describe('ProfilePictureUpload', () => {
     });
     await waitFor(() => expect(toast.error).toHaveBeenCalled());
   });
+
+  it('renders a readable message for a FastAPI 422 array detail, not [object Object] (#215)', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      json: async () => ({
+        detail: [{ loc: ['body', 'file'], msg: 'file too large', type: 'value_error' }],
+      }),
+    });
+    render(<ProfilePictureUpload currentAvatarUrl={null} onUploaded={jest.fn()} />);
+    fireEvent.change(screen.getByTestId('avatar-input'), {
+      target: { files: [makeFile('image/jpeg', 1000)] },
+    });
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    const arg = (toast.error as jest.Mock).mock.calls.at(-1)![0];
+    expect(arg.description).toBe('file too large');
+    expect(arg.description).not.toContain('[object Object]');
+  });
 });

--- a/frontend/src/components/profile/ProfilePictureUpload.tsx
+++ b/frontend/src/components/profile/ProfilePictureUpload.tsx
@@ -10,6 +10,21 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/a
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
 const MAX_SIZE = 5 * 1024 * 1024; // 5MB — matches backend
 
+/**
+ * FastAPI's `detail` is polymorphic: a string for HTTPException, but an array
+ * of {loc, msg, type} for 422 validation errors. Interpolating the array gives
+ * "[object Object]" (#215), so pull out the msg fields.
+ */
+function extractDetail(detail: unknown): string | null {
+  if (typeof detail === 'string') return detail || null;
+  if (Array.isArray(detail)) {
+    const msgs = detail.map((d) => (d && typeof d === 'object' && 'msg' in d ? String((d as { msg: unknown }).msg) : null)).filter(Boolean);
+    return msgs.length ? msgs.join('; ') : null;
+  }
+  if (detail && typeof detail === 'object' && 'msg' in detail) return String((detail as { msg: unknown }).msg);
+  return null;
+}
+
 interface ProfilePictureUploadProps {
   currentAvatarUrl: string | null;
   onUploaded: (url: string) => void;
@@ -49,7 +64,7 @@ export function ProfilePictureUpload({ currentAvatarUrl, onUploaded }: ProfilePi
       });
       if (!res.ok) {
         const body = await res.json().catch(() => null);
-        throw new Error(body?.detail || 'Upload failed');
+        throw new Error(extractDetail(body?.detail) || 'Upload failed');
       }
       const data = await res.json();
       onUploaded(data.avatar_url);

--- a/frontend/src/components/settings/ActiveSessionsList.tsx
+++ b/frontend/src/components/settings/ActiveSessionsList.tsx
@@ -142,6 +142,9 @@ export default function ActiveSessionsList() {
                         <p className="text-sm text-muted-foreground">
                           Last active: {formatLastActive(s.updatedAt ?? s.createdAt)}
                         </p>
+                        {s.ipAddress && (
+                          <p className="text-sm text-muted-foreground">IP: {s.ipAddress}</p>
+                        )}
                       </div>
                       {!isCurrent && (
                         <Button

--- a/frontend/src/components/settings/__tests__/SecuritySettings.test.tsx
+++ b/frontend/src/components/settings/__tests__/SecuritySettings.test.tsx
@@ -337,6 +337,7 @@ describe('ActiveSessionsList', () => {
     {
       token: 'tok',
       userAgent: 'Mozilla/5.0 Chrome/120',
+      ipAddress: '203.0.113.7',
       updatedAt: '2026-07-01T10:00:00Z',
     },
     {
@@ -363,6 +364,13 @@ describe('ActiveSessionsList', () => {
     expect(screen.getByText('Mobile device')).toBeInTheDocument();
     // Only the other session is revocable
     expect(screen.getAllByRole('button', { name: /^revoke$/i })).toHaveLength(1);
+  });
+
+  it('renders the session IP address when present (#215)', async () => {
+    render(<ActiveSessionsList />);
+    await waitFor(() => expect(screen.getByText('This device')).toBeInTheDocument());
+    // The IP is the most useful datum for spotting a rogue session.
+    expect(screen.getByText(/203\.0\.113\.7/)).toBeInTheDocument();
   });
 
   it('revokes another session and removes it from the list', async () => {

--- a/frontend/src/components/toc/TocGenerationWizard.tsx
+++ b/frontend/src/components/toc/TocGenerationWizard.tsx
@@ -331,6 +331,22 @@ export default function TocGenerationWizard({ bookId }: TocGenerationWizardProps
       </div>
 
       {renderCurrentStep()}
+
+      {/* Cancel affordance on the long-running (10-60s) AI steps so the user
+          isn't stranded on a spinner (#215). Returns to the book overview; the
+          in-flight request is abandoned, not aborted. */}
+      {(wizardState.step === WizardStep.CHECKING_READINESS ||
+        wizardState.step === WizardStep.GENERATING) && (
+        <div className="mt-6 flex justify-center">
+          <button
+            type="button"
+            onClick={() => router.push(`/dashboard/books/${bookId}`)}
+            className="px-4 py-2 text-gray-300 hover:text-white border border-gray-600 hover:border-gray-500 rounded-md transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/toc/__tests__/TocGenerationWizardEntitlement.test.tsx
+++ b/frontend/src/components/toc/__tests__/TocGenerationWizardEntitlement.test.tsx
@@ -308,4 +308,19 @@ describe('TocGenerationWizard step flow', () => {
     expect(await screen.findByRole('link', { name: /upgrade/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
   });
+
+  it('offers a Cancel affordance on the long-running readiness step → back to the book (#215)', async () => {
+    const push = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({ push });
+    // analyze-summary never resolves → the wizard stays on CHECKING_READINESS,
+    // where a user would otherwise be stranded on the spinner.
+    mockedBookClient.analyzeSummary.mockReturnValue(new Promise(() => {}) as never);
+
+    const user = userEvent.setup();
+    render(<TocGenerationWizard bookId="book-1" />);
+
+    const cancel = await screen.findByRole('button', { name: /cancel/i });
+    await user.click(cancel);
+    expect(push).toHaveBeenCalledWith('/dashboard/books/book-1');
+  });
 });

--- a/frontend/src/lib/constants/book-metadata.ts
+++ b/frontend/src/lib/constants/book-metadata.ts
@@ -4,20 +4,21 @@
  * BookCreationWizard and BookMetadataForm — the two previously carried
  * divergent hardcoded lists.
  *
- * Values are persisted as free-text strings (bookCreationSchema / backend
- * accept ≤100-char free text); consistency is enforced here at the UI layer.
+ * Nonfiction-only (#215): Auto Author positions itself for nonfiction books
+ * (landing page), so the fiction-only genres (Fiction/Sci-Fi/Fantasy/Mystery/
+ * Romance) were removed. Values are persisted as free-text strings
+ * (bookCreationSchema / backend accept ≤100-char free text); consistency is
+ * enforced here at the UI layer.
  */
 export const GENRE_OPTIONS = [
-  { label: 'Fiction', value: 'fiction' },
   { label: 'Non-Fiction', value: 'non-fiction' },
-  { label: 'Science Fiction', value: 'sci-fi' },
-  { label: 'Fantasy', value: 'fantasy' },
-  { label: 'Mystery', value: 'mystery' },
-  { label: 'Romance', value: 'romance' },
+  { label: 'Business', value: 'business' },
+  { label: 'Self-Help', value: 'self-help' },
+  { label: 'Personal Development', value: 'personal-development' },
+  { label: 'Health & Wellness', value: 'health-wellness' },
+  { label: 'How-To / Guide', value: 'how-to' },
   { label: 'Historical', value: 'historical' },
   { label: 'Biography', value: 'biography' },
-  { label: 'Self-Help', value: 'self-help' },
-  { label: 'Business', value: 'business' },
   { label: 'Other', value: 'other' },
 ] as const;
 


### PR DESCRIPTION
## Summary

Closes #215

Nine isolated UX polish fixes found during the beta pass. Each is a small, independent change.

## Changes

| # | Fix | File(s) |
|---|-----|---------|
| 1 | Remove duplicate Theme select from Profile page (Settings owns theme via next-themes) | `profile/page.tsx` |
| 2 | Show cross-tab validation hint when Save Settings button is disabled by an error on a hidden tab | `settings/page.tsx` |
| 3 | Render `ipAddress` in Active Sessions list (was captured but never displayed) | `ActiveSessionsList.tsx` |
| 4 | Fix avatar upload showing `[object Object]` for FastAPI 422 array-`detail` responses | `ProfilePictureUpload.tsx` |
| 5 | Replace raw `error.message` with user-friendly fallback strings in sign-up and sign-in | `sign-up/page.tsx`, `sign-in/page.tsx` |
| 6 | Replace `window.location.reload()` with in-place `fetchBookData()` on book overview load error | `books/[bookId]/page.tsx` |
| 7 | Wire support email as `mailto:` anchor on help page | `help/page.tsx` |
| 8 | Add Cancel button during CHECKING_READINESS/GENERATING steps in TOC wizard | `TocGenerationWizard.tsx` |
| 9 | Remove fiction genres; `book-metadata.ts` now has nonfiction-only list used by both wizard and form | `book-metadata.ts` |

## Testing

- 14 test suites, 121 tests — all pass
- New tests: `help/__tests__/page.test.tsx`, `books/[bookId]/__tests__/page.errorRetry.test.tsx`
- TypeScript: clean (`tsc --noEmit` zero errors)
- ESLint: zero errors (pre-existing warnings only, none in changed files)

## Known Limitations

- TOC wizard cancel navigates away but does not abort the in-flight AI request (no AbortController). Acceptable for this pass; a proper abort signal would be a follow-up.
