### PR TITLE
[P3.12] fix(auth): ProtectedRoute preserves ?redirect deep-link on client session expiry (#239)

### DIFF
--- a/frontend/src/__tests__/AuthPersistence.test.tsx
+++ b/frontend/src/__tests__/AuthPersistence.test.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 // Mock Next.js navigation
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
+  usePathname: jest.fn(() => '/dashboard'),
 }));
 
 // Mock better-auth's useSession hook
@@ -44,9 +45,9 @@ describe('Authentication State Persistence', () => {
       </ProtectedRoute>
     );
 
-    // Expect router.push to be called with the sign-in route (better-auth uses /auth/sign-in)
+    // Expect router.push to the sign-in route with a ?redirect deep-link (#239)
     await waitFor(() => {
-      expect(mockRouter.push).toHaveBeenCalledWith('/auth/sign-in');
+      expect(mockRouter.push).toHaveBeenCalledWith('/auth/sign-in?redirect=%2Fdashboard');
     });
 
     // Should not render protected content

--- a/frontend/src/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/__tests__/ProfilePage.test.tsx
@@ -10,6 +10,7 @@ import { toast } from '../lib/toast';
 // Mock Next.js hooks
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
+  usePathname: jest.fn(() => '/profile'),
 }));
 
 // Mock better-auth
@@ -493,7 +494,7 @@ describe('UserProfile page authentication guard (#185)', () => {
     render(<UserProfile />);
 
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/auth/sign-in');
+      expect(mockPush).toHaveBeenCalledWith('/auth/sign-in?redirect=%2Fprofile');
     });
     expect(screen.queryByText('Profile')).not.toBeInTheDocument();
     expect(screen.queryByText('Save Changes')).not.toBeInTheDocument();

--- a/frontend/src/__tests__/ProfilePageDelete.test.tsx
+++ b/frontend/src/__tests__/ProfilePageDelete.test.tsx
@@ -12,6 +12,7 @@ import { useSession } from '@/lib/auth-client';
 const mockPush = jest.fn();
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
+  usePathname: () => '/profile',
 }));
 
 jest.mock('@/lib/toast', () => ({

--- a/frontend/src/__tests__/ProfilePageSave.test.tsx
+++ b/frontend/src/__tests__/ProfilePageSave.test.tsx
@@ -12,6 +12,7 @@ import { useSession } from '@/lib/auth-client';
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => '/profile',
 }));
 
 jest.mock('@/lib/toast', () => ({

--- a/frontend/src/__tests__/ProtectedRoute.test.tsx
+++ b/frontend/src/__tests__/ProtectedRoute.test.tsx
@@ -1,11 +1,12 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { useSession } from '@/lib/auth-client';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 
 // Mock Next.js navigation
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
+  usePathname: jest.fn(),
 }));
 
 // Mock better-auth's useSession hook
@@ -26,6 +27,7 @@ describe('ProtectedRoute Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (useRouter as jest.Mock).mockReturnValue(mockRouter);
+    (usePathname as jest.Mock).mockReturnValue('/dashboard');
     // Ensure auth bypass is disabled for these tests
     delete process.env.NEXT_PUBLIC_BYPASS_AUTH;
   });
@@ -51,7 +53,8 @@ describe('ProtectedRoute Component', () => {
     expect(screen.queryByText('Protected Content')).not.toBeInTheDocument();
   });
 
-  test('redirects to sign-in page when user is not authenticated', async () => {
+  test('redirects to sign-in with a ?redirect deep-link back to the current path (#239)', async () => {
+    (usePathname as jest.Mock).mockReturnValue('/dashboard');
     // Mock unauthenticated state
     (useSession as jest.Mock).mockReturnValue({
       data: null,
@@ -65,11 +68,35 @@ describe('ProtectedRoute Component', () => {
       </ProtectedRoute>
     );
 
-    // Should redirect to sign-in (better-auth uses /auth/sign-in)
+    // On a client-side session expiry the user must land back where they were,
+    // not at a bare sign-in page (matches the middleware's ?redirect behavior).
     await waitFor(() => {
-      expect(mockRouter.push).toHaveBeenCalledWith('/auth/sign-in');
+      expect(mockRouter.push).toHaveBeenCalledWith(
+        '/auth/sign-in?redirect=%2Fdashboard'
+      );
     });
     expect(screen.queryByText('Protected Content')).not.toBeInTheDocument();
+  });
+
+  test('encodes the current path (incl. nested/query) into the ?redirect param (#239)', async () => {
+    (usePathname as jest.Mock).mockReturnValue('/dashboard/books/abc123');
+    (useSession as jest.Mock).mockReturnValue({
+      data: null,
+      isPending: false,
+      error: null,
+    });
+
+    render(
+      <ProtectedRoute>
+        <div>Protected Content</div>
+      </ProtectedRoute>
+    );
+
+    await waitFor(() => {
+      expect(mockRouter.push).toHaveBeenCalledWith(
+        '/auth/sign-in?redirect=%2Fdashboard%2Fbooks%2Fabc123'
+      );
+    });
   });
 
   test('renders children when user is authenticated', () => {
@@ -160,7 +187,7 @@ describe('ProtectedRoute Component', () => {
       </ProtectedRoute>
     );
 
-    // Should redirect to sign-in (better-auth uses /auth/sign-in)
-    expect(mockRouter.push).toHaveBeenCalledWith('/auth/sign-in');
+    // Should redirect to sign-in with the ?redirect deep-link (#239)
+    expect(mockRouter.push).toHaveBeenCalledWith('/auth/sign-in?redirect=%2Fdashboard');
   });
 });

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useSession } from '@/lib/auth-client';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import { useEffect } from 'react';
 
 interface ProtectedRouteProps {
@@ -17,6 +17,7 @@ interface ProtectedRouteProps {
 export function ProtectedRoute({ children }: ProtectedRouteProps) {
   const { data: session, isPending } = useSession();
   const router = useRouter();
+  const pathname = usePathname();
 
   // Check if auth bypass is enabled for E2E testing
   const bypassAuth = process.env.NEXT_PUBLIC_BYPASS_AUTH === 'true';
@@ -28,11 +29,15 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
     // Wait for session to load before making decisions
     if (isPending) return;
 
-    // If not signed in, redirect to sign-in page
+    // If not signed in, redirect to sign-in page, preserving a deep-link back to
+    // the current path (#239). The middleware sets ?redirect on full navigations;
+    // this client guard fires on a session expiry with no navigation, so it must
+    // set it too or the user loses their place. The sign-in page validates the
+    // param via sanitizeRedirectPath (#184) before honoring it.
     if (!session) {
-      router.push('/auth/sign-in');
+      router.push(`/auth/sign-in?redirect=${encodeURIComponent(pathname)}`);
     }
-  }, [bypassAuth, isPending, session, router]);
+  }, [bypassAuth, isPending, session, router, pathname]);
 
   // If auth bypass is enabled, render children immediately
   if (bypassAuth) {


### PR DESCRIPTION
Closes #239.

## Problem
The client-side `ProtectedRoute` guard pushed a **bare** `/auth/sign-in` on session expiry. Unlike a full navigation (where `middleware.ts` sets `?redirect=<pathname>`), a client-side expiry involves no navigation, so the middleware layer never runs — the user was dropped at sign-in with no deep-link back to where they were, and after re-auth always landed on `/dashboard`.

## Fix (single line, mirrors the middleware)
`ProtectedRoute.tsx` now reads `usePathname()` and pushes `/auth/sign-in?redirect=${encodeURIComponent(pathname)}` — exactly the deep-link the middleware already sets via `searchParams.set('redirect', pathname)`. The sign-in page already validates the param through `sanitizeRedirectPath` (#184, same-origin-only, decode-checked, `/dashboard` fallback) before honoring it, so no new trust surface is introduced.

## Outcome evidence (differential)
The behavior difference is the **navigation target**, pinned at the outcome level:
- **main**: `router.push('/auth/sign-in')` → RED against the new pins
- **branch**: `router.push('/auth/sign-in?redirect=%2Fdashboard%2Fbooks%2Fabc123')` → GREEN

Both new `ProtectedRoute` pins were **mutation-verified RED** against the bare-push code, then GREEN after the fix. `usePathname()` is a hook called unconditionally, so the four sibling suites that render the guard (`AuthPersistence`, `ProfilePage`, `ProfilePageDelete`, `ProfilePageSave`) were updated to mock it and assert the deep-link contract. Full frontend suite: **125 suites, 2209 passed / 5 skipped**.

## Review
Cross-family **codex** review: "clean to merge", no Critical/Major issues. (opencode hung — the documented concurrent-session condition — so codex was the fallback per the review invariants.)

## Known limitations
- `usePathname()` returns the path only, not the query string — a user at `/dashboard/books?tab=export` returns to `/dashboard/books` without the tab. This matches the existing middleware behavior (it also uses `pathname` only), so the two layers stay consistent; preserving search params would be a separate cross-layer change.
- The related 2FA-path redirect drop is tracked separately by #237 (already shipped in #237/PR #323) — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)