### PR TITLE
[#331] fix(a11y): core authoring pages use theme tokens — visible in light theme

### DIFF
--- a/docs/demos/2026-07-23-issue-331-light-theme-tokens.md
+++ b/docs/demos/2026-07-23-issue-331-light-theme-tokens.md
@@ -1,0 +1,74 @@
+# Demo — #331: core authoring pages visible in the light theme
+
+**Claim:** Book-detail, summary, and TOC-wizard headings/body/cards hardcoded
+near-white `text-gray-*` on the theme-aware `bg-background`, so they were
+invisible in the shipped light theme. This migrates them to the design tokens so
+they render with proper contrast in light mode, and adds a guard so it can't
+recur.
+
+For a contrast regression, the outcome evidence is the **actual light-mode WCAG
+contrast** each cited element renders at, before vs after — computed from the
+project's own token values (`globals.css` `:root`) and Tailwind's default gray
+palette. No stack needed; the visual result is fully determined by these values
+(the same shared light/dark palette #64/#206 already ship).
+
+## AC1 — replace hardcoded grays with the token vocabulary
+
+Gray literals remaining on the three pages:
+
+```
+main  (book page.tsx):                                    48
+branch page.tsx:                                           0
+branch summary/page.tsx:                                   0
+branch TocGenerationWizard.tsx:                            0
+```
+
+`bg-gray-800`→`bg-card`, `bg-gray-900`(input)→`bg-background`,
+`bg-gray-700`→`bg-secondary`(buttons)/`bg-muted`(tracks & disabled),
+`border-gray-*`→`border-border`, `text-gray-100/200`→`text-foreground`,
+`text-gray-300/400/500`→`text-muted-foreground`; paired `text-white`/`text-gray-100`
+on now-`bg-secondary` buttons→`text-secondary-foreground`. Brand accents
+(indigo/green/red) stay theme-fixed, as #206 did.
+
+### Outcome — real light-mode contrast (invisible → visible)
+
+`LIGHT THEME (:root) — on --background (white, Y=1.000)`
+
+| Element | BEFORE | | AFTER | |
+|---|---|---|---|---|
+| Book title (`page.tsx:428`) | `text-gray-100` | **1.10:1 — invisible** | `text-foreground` | **19.79:1 — PASS AA** |
+| "Provide a Summary" (`summary:157`) | `text-gray-100` | **1.10:1 — invisible** | `text-foreground` | **19.79:1 — PASS AA** |
+| "Generate Table of Contents" (`wizard:313`) | `text-gray-100` | **1.10:1 — invisible** | `text-foreground` | **19.79:1 — PASS AA** |
+| Stepper description (`page.tsx:454`) | `text-gray-400` | **2.54:1 — fail** | `text-muted-foreground` | **4.73:1 — PASS AA** |
+
+The 1.10:1 matches the issue's reported "~1.1:1 (invisible)" exactly. The core
+authoring flow's headings go from unreadable to WCAG-AA-passing in light mode.
+(Dark mode is unchanged: the `.dark` token values equal the old hardcoded RGBs,
+per #206.)
+
+## AC2 — a guard so the regression can't recur silently
+
+`src/__tests__/theme/core-authoring-pages-tokens.test.ts` source-sweeps all three
+files for any `gray-*` utility; render assertions pin each cited heading to
+`text-foreground`. Mutation check — reintroduce the exact bug on the summary
+heading (`text-foreground` → `text-gray-100`):
+
+```
+-- bug reintroduced --
+Tests:       2 failed, 10 passed, 12 total
+   ✕ source sweep: summary/page.tsx contains no gray literals   → ["text-gray-100"]
+   ✕ renders the page heading with the theme foreground token   → had class "text-gray-100"
+
+-- restored --
+Test Suites: 2 passed, 2 total
+Tests:       12 passed, 12 total
+```
+
+Both the sweep and the render assertion turn RED on the reintroduced bug and
+GREEN when restored — the guard fires.
+
+## Review
+
+Cross-family `codex` (opencode occupied by a concurrent foreign-cwd session):
+**"No substantive defects found."** Its non-blocking note (broaden the sweep past
+`text/bg/border-gray-*`) was adopted — it now bans any `*gray-N` utility.

--- a/frontend/src/__tests__/theme/core-authoring-pages-tokens.test.ts
+++ b/frontend/src/__tests__/theme/core-authoring-pages-tokens.test.ts
@@ -24,9 +24,10 @@ const PAGES = [
   'src/components/toc/TocGenerationWizard.tsx',
 ];
 
-// Matches theme-independent neutral literals like `text-gray-100`,
-// `bg-gray-800/50`, `border-gray-700`.
-const GRAY_LITERAL = /\b(?:text|bg|border)-gray-\d+/g;
+// Matches any theme-independent gray utility — `text-gray-100`,
+// `bg-gray-800/50`, `border-gray-700`, and also `ring-gray-*`/`placeholder-gray-*`
+// so a future reintroduction through a different utility can't slip past.
+const GRAY_LITERAL = /\b[a-z-]*gray-\d+/g;
 
 describe('core authoring pages use theme tokens, not hardcoded grays (#331)', () => {
   it.each(PAGES)('%s contains no text/bg/border-gray literals', (relPath) => {

--- a/frontend/src/__tests__/theme/core-authoring-pages-tokens.test.ts
+++ b/frontend/src/__tests__/theme/core-authoring-pages-tokens.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Recurrence guard for #331 (P0.2): the book-detail, summary, and TOC-wizard
+ * pages hardcoded near-white `text-gray-*` (plus `bg-gray-*`/`border-gray-*`)
+ * directly on the theme-aware `bg-background`. The app ships a working light
+ * theme (#64), so those elements dropped to ~1.1:1 contrast — invisible — and
+ * the core authoring flow was unusable in light mode (WCAG 1.4.3).
+ *
+ * These are the exact pages the issue cites. A source sweep is the strongest
+ * anti-recurrence guard: it catches ANY reintroduced gray literal across the
+ * whole file (not just an element a render test happens to mount), including
+ * the book-detail page whose full render is expensive to set up. Brand/semantic
+ * accents (indigo/green/red) are intentionally theme-fixed here — same as the
+ * #206 migration — so only the gray neutral family is banned.
+ */
+
+const FRONTEND_ROOT = join(__dirname, '..', '..', '..');
+
+const PAGES = [
+  'src/app/dashboard/books/[bookId]/page.tsx',
+  'src/app/dashboard/books/[bookId]/summary/page.tsx',
+  'src/components/toc/TocGenerationWizard.tsx',
+];
+
+// Matches theme-independent neutral literals like `text-gray-100`,
+// `bg-gray-800/50`, `border-gray-700`.
+const GRAY_LITERAL = /\b(?:text|bg|border)-gray-\d+/g;
+
+describe('core authoring pages use theme tokens, not hardcoded grays (#331)', () => {
+  it.each(PAGES)('%s contains no text/bg/border-gray literals', (relPath) => {
+    const source = readFileSync(join(FRONTEND_ROOT, relPath), 'utf8');
+    const matches = source.match(GRAY_LITERAL) ?? [];
+    expect(matches).toEqual([]);
+  });
+});

--- a/frontend/src/app/dashboard/books/[bookId]/__tests__/page.errorRetry.test.tsx
+++ b/frontend/src/app/dashboard/books/[bookId]/__tests__/page.errorRetry.test.tsx
@@ -81,3 +81,33 @@ describe('BookPage error → in-place refetch (#215)', () => {
     expect(reload).not.toHaveBeenCalled();
   });
 });
+
+// #331: the book title hardcoded `text-gray-100` on the theme-aware background,
+// so it was invisible (~1.1:1) in the shipped light theme. Pin that the title
+// renders with the theme foreground token.
+describe('BookPage — light-theme title token (#331)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useSession as jest.Mock).mockReturnValue({ data: { user: { id: 'u1' } } });
+    mockBookClient.getToc.mockResolvedValue({ toc: null } as never);
+    mockBookClient.getBookSummary.mockResolvedValue({ summary: '' } as never);
+  });
+
+  it('renders the book title with the theme foreground token, not near-white gray', async () => {
+    mockBookClient.getBook.mockResolvedValue({
+      id: 'book-1',
+      title: 'My Nonfiction Book',
+      description: 'desc',
+      progress: 0,
+    } as never);
+
+    renderPage();
+
+    const title = await screen.findByRole('heading', {
+      level: 1,
+      name: 'My Nonfiction Book',
+    });
+    expect(title).toHaveClass('text-foreground');
+    expect(title.className).not.toMatch(/text-gray-\d/);
+  });
+});

--- a/frontend/src/app/dashboard/books/[bookId]/page.tsx
+++ b/frontend/src/app/dashboard/books/[bookId]/page.tsx
@@ -368,7 +368,7 @@ export default function BookPage({ params }: { params: Promise<{ bookId: string 
       <div className="container mx-auto flex-1 p-6 flex items-center justify-center">
         <div className="bg-red-900/20 border border-red-700 rounded-lg p-6 max-w-md">
           <h2 className="text-red-400 text-xl font-medium mb-2">Error</h2>
-          <p className="text-gray-300 mb-4">{error}</p>
+          <p className="text-muted-foreground mb-4">{error}</p>
           <div className="flex space-x-4">
             <button
               onClick={() => fetchBookData()}
@@ -378,7 +378,7 @@ export default function BookPage({ params }: { params: Promise<{ bookId: string 
             </button>
             <Link
               href="/dashboard"
-              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white font-medium rounded-md"
+              className="px-4 py-2 bg-secondary hover:bg-secondary/80 text-secondary-foreground font-medium rounded-md"
             >
               Back to Dashboard
             </Link>
@@ -393,7 +393,7 @@ export default function BookPage({ params }: { params: Promise<{ bookId: string 
     return (
       <div className="container mx-auto flex-1 p-6 flex items-center justify-center">
         <div className="text-center">
-          <h2 className="text-xl font-medium text-gray-300 mb-4">Book not found</h2>
+          <h2 className="text-xl font-medium text-foreground mb-4">Book not found</h2>
           <Link
             href="/dashboard"
             className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white font-medium rounded-md"
@@ -425,7 +425,7 @@ export default function BookPage({ params }: { params: Promise<{ bookId: string 
 
       <div className="mb-6">
         <div className="flex justify-between items-center">
-          <h1 className="text-3xl font-bold text-gray-100">{book.title}</h1>
+          <h1 className="text-3xl font-bold text-foreground">{book.title}</h1>
           <div className="flex items-center gap-4">
             <button
               onClick={handleExportClick}
@@ -436,7 +436,7 @@ export default function BookPage({ params }: { params: Promise<{ bookId: string 
               </svg>
               Export Book
             </button>
-            <div className="text-gray-400 text-sm">
+            <div className="text-muted-foreground text-sm">
               Last edited {formatDate(book.updated_at ?? book.created_at ?? '')}
             </div>
           </div>
@@ -450,8 +450,8 @@ export default function BookPage({ params }: { params: Promise<{ bookId: string 
                 <div className="h-8 w-1 bg-indigo-300/30 md:h-1 md:w-8 md:mx-2 md:my-0 my-2"></div>
               </div>
               <div>
-                <div className="font-semibold text-gray-100">Book Summary</div>
-                <div className="text-xs text-gray-400">Describe your book&apos;s main idea and structure</div>
+                <div className="font-semibold text-foreground">Book Summary</div>
+                <div className="text-xs text-muted-foreground">Describe your book&apos;s main idea and structure</div>
                 <Link href={`/dashboard/books/${bookId}/summary`}>
                   <button className="mt-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white font-medium rounded-md">
                     {book?.summary && book.summary.length >= 30 ? 'Edit Book Summary' : 'Start with Book Summary'}
@@ -462,12 +462,12 @@ export default function BookPage({ params }: { params: Promise<{ bookId: string 
             {/* Step 2: TOC Generation */}
             <div className="flex items-center gap-3">
               <div className="flex flex-col items-center">
-                <div className={`w-8 h-8 rounded-full ${(book?.summary && book.summary.length >= 30) ? 'bg-indigo-600 text-white' : 'bg-gray-700 text-gray-400 border border-gray-500'} flex items-center justify-center font-bold`}>2</div>
+                <div className={`w-8 h-8 rounded-full ${(book?.summary && book.summary.length >= 30) ? 'bg-indigo-600 text-white' : 'bg-muted text-muted-foreground border border-border'} flex items-center justify-center font-bold`}>2</div>
                 <div className="h-8 w-1 bg-indigo-300/30 md:h-1 md:w-8 md:mx-2 md:my-0 my-2"></div>
               </div>
               <div>
-                <div className="font-semibold text-gray-100">Generate TOC</div>
-                <div className="text-xs text-gray-400">AI generates a Table of Contents from your summary</div>
+                <div className="font-semibold text-foreground">Generate TOC</div>
+                <div className="text-xs text-muted-foreground">AI generates a Table of Contents from your summary</div>
                 {book?.summary && book.summary.length >= 30 ? (
                   book.chapters && book.chapters.length > 0 ? (
                     <Link href={`/dashboard/books/${bookId}/edit-toc`}>
@@ -483,7 +483,7 @@ export default function BookPage({ params }: { params: Promise<{ bookId: string 
                     </Link>
                   )
                 ) : (
-                  <button className="mt-2 px-4 py-2 bg-gray-700 text-gray-400 font-medium rounded-md cursor-not-allowed" disabled>
+                  <button className="mt-2 px-4 py-2 bg-muted text-muted-foreground font-medium rounded-md cursor-not-allowed" disabled>
                     Complete Book Summary First
                   </button>
                 )}
@@ -492,17 +492,17 @@ export default function BookPage({ params }: { params: Promise<{ bookId: string 
             {/* Step 3: Write Content */}
             <div className="flex items-center gap-3">
               <div className="flex flex-col items-center">
-                <div className={`w-8 h-8 rounded-full ${(book?.summary && book.summary.length >= 30 && book.chapters && book.chapters.length > 0) ? 'bg-indigo-600 text-white' : 'bg-gray-700 text-gray-400 border border-gray-500'} flex items-center justify-center font-bold`}>3</div>
+                <div className={`w-8 h-8 rounded-full ${(book?.summary && book.summary.length >= 30 && book.chapters && book.chapters.length > 0) ? 'bg-indigo-600 text-white' : 'bg-muted text-muted-foreground border border-border'} flex items-center justify-center font-bold`}>3</div>
               </div>
               <div>
-                <div className="font-semibold text-gray-100">Write Content</div>
-                <div className="text-xs text-gray-400">Write and edit your chapter content</div>
+                <div className="font-semibold text-foreground">Write Content</div>
+                <div className="text-xs text-muted-foreground">Write and edit your chapter content</div>
                 {(book?.summary && book.summary.length >= 30 && book.chapters && book.chapters.length > 0) ? (
                   <div className="mt-2 text-sm text-green-400">
                     ✓ Ready to write! Use the tabs below to start writing your chapters.
                   </div>
                 ) : (
-                  <button className="mt-2 px-4 py-2 bg-gray-700 text-gray-400 font-medium rounded-md cursor-not-allowed" disabled>
+                  <button className="mt-2 px-4 py-2 bg-muted text-muted-foreground font-medium rounded-md cursor-not-allowed" disabled>
                     {book?.summary && book.summary.length >= 30 ? 'Generate TOC First' : 'Complete Book Summary First'}
                   </button>
                 )}
@@ -516,14 +516,14 @@ export default function BookPage({ params }: { params: Promise<{ bookId: string 
           <>
             {book.cover_image_url && (
               <div className="mt-4">
-                <Image src={book.cover_image_url} alt="Book cover" width={256} height={384} className="max-w-xs rounded shadow border border-gray-700" />
+                <Image src={book.cover_image_url} alt="Book cover" width={256} height={384} className="max-w-xs rounded shadow border border-border" />
               </div>
             )}
             <div className="mt-2">
-              {book.subtitle && <div className="text-gray-300 text-lg italic mb-1">{book.subtitle}</div>}
-              <div className="text-gray-400 max-w-3xl mb-2">{book.description}</div>
-              {book.genre && <div className="text-gray-400 text-sm">Genre: {book.genre}</div>}
-              {book.target_audience && <div className="text-gray-400 text-sm">Audience: {book.target_audience}</div>}
+              {book.subtitle && <div className="text-muted-foreground text-lg italic mb-1">{book.subtitle}</div>}
+              <div className="text-muted-foreground max-w-3xl mb-2">{book.description}</div>
+              {book.genre && <div className="text-muted-foreground text-sm">Genre: {book.genre}</div>}
+              {book.target_audience && <div className="text-muted-foreground text-sm">Audience: {book.target_audience}</div>}
             </div>
             <button
               className="mt-4 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white font-medium rounded-md"
@@ -559,7 +559,7 @@ export default function BookPage({ params }: { params: Promise<{ bookId: string 
               error={error}
             />
             <button
-              className="mt-4 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-100 rounded-md"
+              className="mt-4 px-4 py-2 bg-secondary hover:bg-secondary/80 text-secondary-foreground rounded-md"
               onClick={() => setEditMode(false)}
             >
               Cancel
@@ -567,7 +567,7 @@ export default function BookPage({ params }: { params: Promise<{ bookId: string 
           </>
         )}
       </div>      <div className="grid grid-cols-1 lg:grid-cols-4 gap-6 mb-8">
-        <div className="bg-gray-800 border border-gray-700 p-5 rounded-lg lg:col-span-3">          {book.chapters.length > 0 ? (
+        <div className="bg-card border border-border p-5 rounded-lg lg:col-span-3">          {book.chapters.length > 0 ? (
             /* Chapter Tabs Interface */
             <ChapterTabs
               bookId={book.id}
@@ -578,11 +578,11 @@ export default function BookPage({ params }: { params: Promise<{ bookId: string 
             /* No chapters placeholder */
             <div className="flex flex-col items-center justify-center h-64 text-center">
               <div className="mb-4">
-                <svg className="h-16 w-16 text-gray-500 mx-auto mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg className="h-16 w-16 text-muted-foreground mx-auto mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
                 </svg>
-                <h3 className="text-xl font-medium text-gray-300 mb-2">No chapters yet</h3>
-                <p className="text-gray-400 text-sm max-w-md">
+                <h3 className="text-xl font-medium text-foreground mb-2">No chapters yet</h3>
+                <p className="text-muted-foreground text-sm max-w-md">
                   Complete your book summary and generate a Table of Contents to start writing chapters.
                 </p>
               </div>
@@ -602,39 +602,39 @@ export default function BookPage({ params }: { params: Promise<{ bookId: string 
             </div>
           )}
         </div>
-        <div className="bg-gray-800 border border-gray-700 p-5 rounded-lg">
-          <h2 className="text-xl font-semibold text-gray-100 mb-4">Book Stats</h2>
+        <div className="bg-card border border-border p-5 rounded-lg">
+          <h2 className="text-xl font-semibold text-foreground mb-4">Book Stats</h2>
           <div className="space-y-3">
             <div>
-              <div className="text-sm text-gray-400 mb-1">Overall Progress</div>
+              <div className="text-sm text-muted-foreground mb-1">Overall Progress</div>
               <div className="flex items-center gap-2">
-                <div className="flex-1 bg-gray-700 rounded-full h-2">
+                <div className="flex-1 bg-muted rounded-full h-2">
                   <div
                     className="bg-indigo-600 h-2 rounded-full"
                     style={{ width: `${book.progress}%` }}
                   ></div>
                 </div>
-                <span className="text-gray-300">{book.progress}%</span>
+                <span className="text-foreground">{book.progress}%</span>
               </div>
             </div>
             <div className="pt-2">
-              <div className="text-sm text-gray-400 mb-1">Chapters</div>
-              <div className="text-gray-100 font-medium">{book.chapters.length}</div>
+              <div className="text-sm text-muted-foreground mb-1">Chapters</div>
+              <div className="text-foreground font-medium">{book.chapters.length}</div>
             </div>
             <div className="pt-2">
-              <div className="text-sm text-gray-400 mb-1">Total Word Count</div>
-              <div className="text-gray-100 font-medium">
+              <div className="text-sm text-muted-foreground mb-1">Total Word Count</div>
+              <div className="text-foreground font-medium">
                 {book.chapters.reduce((sum, chapter) => sum + chapter.wordCount, 0).toLocaleString()}
               </div>
             </div>
             <div className="pt-2">
-              <div className="text-sm text-gray-400 mb-1">Completed Chapters</div>
-              <div className="text-gray-100 font-medium">
+              <div className="text-sm text-muted-foreground mb-1">Completed Chapters</div>
+              <div className="text-foreground font-medium">
                 {book.chapters.filter(ch => ch.completed).length} of {book.chapters.length}
               </div>
             </div>
           </div>
-          <div className="mt-6 pt-4 border-t border-gray-700">
+          <div className="mt-6 pt-4 border-t border-border">
             <button
               onClick={handleExportClick}
               className="w-full py-2 bg-indigo-600 hover:bg-indigo-700 text-white font-medium rounded-md transition-all"

--- a/frontend/src/app/dashboard/books/[bookId]/summary/__tests__/page.test.tsx
+++ b/frontend/src/app/dashboard/books/[bookId]/summary/__tests__/page.test.tsx
@@ -132,3 +132,24 @@ describe('BookSummaryPage — readiness gate (#218)', () => {
     }
   });
 });
+
+// #331: the page heading hardcoded `text-gray-100` on the theme-aware
+// background, so it was invisible (~1.1:1) in the shipped light theme. Pin that
+// it now renders with the theme foreground token.
+describe('BookSummaryPage — light-theme heading token (#331)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    mockClient.getBookSummary.mockResolvedValue({ summary: '', summary_history: [] } as never);
+    mockClient.saveBookSummary.mockResolvedValue({ summary: '' } as never);
+  });
+
+  it('renders the page heading with the theme foreground token, not near-white gray', async () => {
+    render(<BookSummaryPage />);
+    await waitFor(() => expect(mockClient.getBookSummary).toHaveBeenCalled());
+
+    const heading = screen.getByRole('heading', { level: 1, name: /provide a summary/i });
+    expect(heading).toHaveClass('text-foreground');
+    expect(heading.className).not.toMatch(/text-gray-\d/);
+  });
+});

--- a/frontend/src/app/dashboard/books/[bookId]/summary/page.tsx
+++ b/frontend/src/app/dashboard/books/[bookId]/summary/page.tsx
@@ -154,8 +154,8 @@ export default function BookSummaryPage() {
   return (
     <div className="container mx-auto px-4 py-8 max-w-3xl">
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-100 mb-3">Provide a Summary</h1>
-        <p className="text-gray-400">
+        <h1 className="text-3xl font-bold text-foreground mb-3">Provide a Summary</h1>
+        <p className="text-muted-foreground">
           Describe your book's main concepts and structure. This summary will be used to generate a Table of Contents.
         </p>
       </div>
@@ -164,11 +164,11 @@ export default function BookSummaryPage() {
           {error}
         </div>
       )}
-      <div className="bg-gray-800 border border-gray-700 rounded-lg p-6">
+      <div className="bg-card border border-border rounded-lg p-6">
         <form onSubmit={handleSubmit}>
           <div className="mb-4">
             <div className="flex justify-between items-center mb-2">
-              <label className="text-gray-400" htmlFor="summary">Book Summary</label>
+              <label className="text-muted-foreground" htmlFor="summary">Book Summary</label>
               <div className="flex gap-2">
                 <button
                   type="button"
@@ -177,7 +177,7 @@ export default function BookSummaryPage() {
                   className={`px-3 py-1 rounded-md text-sm ${
                     isListening
                       ? 'bg-red-600 text-white'
-                      : 'bg-gray-700 hover:bg-gray-600 text-gray-100'
+                      : 'bg-secondary hover:bg-secondary/80 text-secondary-foreground'
                   }`}
                 >
                   {isListening ? 'Listening...' : '🎤 Voice Input'}
@@ -186,7 +186,7 @@ export default function BookSummaryPage() {
                   <button
                     type="button"
                     onClick={stopListening}
-                    className="px-3 py-1 rounded-md text-sm bg-gray-700 hover:bg-gray-600 text-gray-100 border border-gray-500"
+                    className="px-3 py-1 rounded-md text-sm bg-secondary hover:bg-secondary/80 text-secondary-foreground border border-border"
                   >
                     Stop
                   </button>
@@ -198,20 +198,20 @@ export default function BookSummaryPage() {
               value={summary}
               onChange={(e) => setSummary(e.target.value)}
               rows={10}
-              className="w-full bg-gray-900 border border-gray-700 rounded-md py-2 px-3 text-gray-100"
+              className="w-full bg-background border border-border rounded-md py-2 px-3 text-foreground"
               placeholder="Describe your book's main concepts, structure, and key points that should be organized into chapters..."
               required
             ></textarea>
-            <div className="flex justify-between text-xs text-gray-500 mt-1">
+            <div className="flex justify-between text-xs text-muted-foreground mt-1">
               <span>{countSummaryWords(summary)} / {SUMMARY_MIN_WORDS} words</span>
               <span>{countSummaryCharacters(summary)} / {SUMMARY_MIN_CHARACTERS} characters</span>
             </div>
             {inputError && (
               <div className="text-red-400 text-xs mt-1">{inputError}</div>
             )}
-            <div id="summary-help" className="text-xs text-gray-400 mt-2">
+            <div id="summary-help" className="text-xs text-muted-foreground mt-2">
               <div>Guidelines: Aim for 1-3 paragraphs. Include the main idea, genre, and any key themes or characters. At least {SUMMARY_MIN_WORDS} words and {SUMMARY_MIN_CHARACTERS} characters are required to generate a table of contents — the more detail you give, the better the result.</div>
-              <div className="italic text-gray-500 mt-1">
+              <div className="italic text-muted-foreground mt-1">
                 &quot;A young orphan discovers a hidden world of magic and must stop a dark sorcerer from conquering both realms. The story explores friendship, courage, and the power of believing in oneself.&quot;
               </div>
             </div>
@@ -220,7 +220,7 @@ export default function BookSummaryPage() {
             <button
               type="button"
               onClick={() => router.back()}
-              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-100 rounded-md"
+              className="px-4 py-2 bg-secondary hover:bg-secondary/80 text-secondary-foreground rounded-md"
             >
               Back
             </button>
@@ -234,18 +234,18 @@ export default function BookSummaryPage() {
           </div>
         </form>
       </div>
-      <div className="bg-gray-800 border border-gray-700 rounded-lg p-6 mt-8">
-        <h2 className="text-lg font-semibold text-gray-100 mb-2">Revision History</h2>
+      <div className="bg-card border border-border rounded-lg p-6 mt-8">
+        <h2 className="text-lg font-semibold text-foreground mb-2">Revision History</h2>
         {summaryHistory.length === 0 ? (
-          <div className="text-gray-400 text-sm">No previous revisions yet.</div>
+          <div className="text-muted-foreground text-sm">No previous revisions yet.</div>
         ) : (
           <ul className="space-y-3">
             {summaryHistory.slice().reverse().map((rev, idx) => {
               const revision = rev as Revision;
               return (
-                <li key={idx} className="border-b border-gray-700 pb-2">
+                <li key={idx} className="border-b border-border pb-2">
                   <div className="flex justify-between items-center">
-                    <div className="text-xs text-gray-400">
+                    <div className="text-xs text-muted-foreground">
                       {revision.timestamp
                         ? new Date(revision.timestamp).toLocaleString()
                         : 'Unknown time'}
@@ -257,7 +257,7 @@ export default function BookSummaryPage() {
                       Revert
                     </button>
                   </div>
-                  <div className="text-gray-200 text-sm mt-1 whitespace-pre-line">
+                  <div className="text-foreground text-sm mt-1 whitespace-pre-line">
                     {revision.summary}
                   </div>
                 </li>
@@ -266,9 +266,9 @@ export default function BookSummaryPage() {
           </ul>
         )}
       </div>
-      <div className="mt-8 bg-gray-800/50 border border-gray-700 rounded-lg p-4">
-        <h3 className="text-gray-300 font-medium mb-2">💡 Tips for a good summary:</h3>
-        <ul className="text-gray-400 text-sm list-disc list-inside space-y-1">
+      <div className="mt-8 bg-card/50 border border-border rounded-lg p-4">
+        <h3 className="text-foreground font-medium mb-2">💡 Tips for a good summary:</h3>
+        <ul className="text-muted-foreground text-sm list-disc list-inside space-y-1">
           <li>Include the main topics you want to cover in your book</li>
           <li>Mention specific sections or chapters you have in mind</li>
           <li>Include your target audience and their needs</li>

--- a/frontend/src/components/toc/TocGenerationWizard.tsx
+++ b/frontend/src/components/toc/TocGenerationWizard.tsx
@@ -310,19 +310,19 @@ export default function TocGenerationWizard({ bookId }: TocGenerationWizardProps
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl">
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-100 mb-3">Generate Table of Contents</h1>
-        <p className="text-gray-400">
+        <h1 className="text-3xl font-bold text-foreground mb-3">Generate Table of Contents</h1>
+        <p className="text-muted-foreground">
           Our AI will analyze your summary and guide you through creating a structured table of contents for your book.
         </p>
       </div>
 
       {/* Progress indicator */}
       <div className="mb-8">
-        <div className="flex items-center justify-between text-sm text-gray-400 mb-2">
+        <div className="flex items-center justify-between text-sm text-muted-foreground mb-2">
           <span>Step {getStepNumber(wizardState.step)} of 4</span>
           <span>{getStepTitle(wizardState.step)}</span>
         </div>
-        <div className="w-full bg-gray-700 rounded-full h-2">
+        <div className="w-full bg-muted rounded-full h-2">
           <div
             className="bg-indigo-600 h-2 rounded-full transition-all duration-300"
             style={{ width: `${getProgressPercentage(wizardState.step)}%` }}
@@ -341,7 +341,7 @@ export default function TocGenerationWizard({ bookId }: TocGenerationWizardProps
           <button
             type="button"
             onClick={() => router.push(`/dashboard/books/${bookId}`)}
-            className="px-4 py-2 text-gray-300 hover:text-white border border-gray-600 hover:border-gray-500 rounded-md transition-colors"
+            className="px-4 py-2 text-muted-foreground hover:text-foreground border border-border hover:border-foreground/50 rounded-md transition-colors"
           >
             Cancel
           </button>

--- a/frontend/src/components/toc/__tests__/TocGenerationWizardEntitlement.test.tsx
+++ b/frontend/src/components/toc/__tests__/TocGenerationWizardEntitlement.test.tsx
@@ -324,3 +324,18 @@ describe('TocGenerationWizard step flow', () => {
     expect(push).toHaveBeenCalledWith('/dashboard/books/book-1');
   });
 });
+
+// #331: the wizard heading hardcoded `text-gray-100` on the theme-aware
+// background, so it was invisible in the shipped light theme. The header
+// renders on every step, so mount is enough to pin the token.
+describe('TocGenerationWizard — light-theme heading token (#331)', () => {
+  it('renders the wizard heading with the theme foreground token, not near-white gray', async () => {
+    render(<TocGenerationWizard bookId="book-1" />);
+    const heading = await screen.findByRole('heading', {
+      level: 1,
+      name: /generate table of contents/i,
+    });
+    expect(heading).toHaveClass('text-foreground');
+    expect(heading.className).not.toMatch(/text-gray-\d/);
+  });
+});


### PR DESCRIPTION
Closes #331 (P0.2, launch blocker).

## Problem
Book-detail (`dashboard/books/[bookId]/page.tsx`), summary (`.../summary/page.tsx`), and the TOC wizard (`components/toc/TocGenerationWizard.tsx`) hardcoded near-white `text-gray-100` (plus `bg-gray-*`/`border-gray-*`) directly on the theme-aware `bg-background`. The app ships a working light/dark toggle (#64), so **light mode is a reachable state** and those headings/body/cards dropped to ~1.1:1 contrast — invisible. A user on the Light theme could not see the book title, summary heading, or TOC heading: the core authoring flow was unusable (WCAG 1.4.3). #206 already migrated BookCard/EmptyBookState; these three pages were missed.

## Fix
Migrate the **gray neutral family** on all three pages to the design-token vocabulary, matching the #206 pattern:
- `text-gray-100/200` → `text-foreground`; `text-gray-300/400/500` → `text-muted-foreground`
- `bg-gray-800` → `bg-card`; `bg-gray-900` (input) → `bg-background`; `bg-gray-700` → `bg-secondary` (buttons) / `bg-muted` (progress tracks + disabled indicators)
- `border-gray-*` → `border-border`

Root-cause detail: buttons whose background moved to `bg-secondary`/`bg-muted` and whose text was `text-white`/`text-gray-100` also swap to `text-secondary-foreground`/`text-muted-foreground` — otherwise they'd be white-on-light-gray (invisible again) in light mode. Brand/semantic accents (indigo/green/red buttons, `text-white` **on** colored buttons) stay theme-fixed, exactly as #206 did.

## Tests (mutation-verified)
- **Recurrence guard** (`src/__tests__/theme/core-authoring-pages-tokens.test.ts`): source-sweep banning any `gray-*` utility across all three files — the strongest anti-recurrence guard, and the only coverage for the book-detail page (expensive to fully render).
- **Render assertions**: each cited heading (book title, "Provide a Summary", "Generate Table of Contents") now renders with `text-foreground` and no `text-gray-*`. Added to the existing test files that already mount those surfaces.
- **Mutation check**: reverting the book title to `text-gray-100` turns **both** the sweep and the book render assertion RED; restore → green.

## Review
Cross-family **codex** review (opencode occupied by a concurrent foreign-cwd session — the documented hang condition): **"No substantive defects found."** It verified every token pairing is valid, no button was left with illegible text, and the tests pin the behavior. Its one non-blocking note (broaden the sweep beyond `text/bg/border-gray-*`) was **adopted** — the sweep now catches any `*gray-N` utility.

## Known limitations
- The source sweep pins class literals, not computed pixel contrast; the token values themselves are the shared, already-shipped light/dark palette (#64/#206).
- Semantic red error banners (`bg-red-900/20`) are unchanged — out of the issue's gray scope and legible in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)