### PR TITLE
perf(books): stop loading every chapter's HTML just to check ownership (#344)

### DIFF
--- a/backend/app/api/endpoints/books.py
+++ b/backend/app/api/endpoints/books.py
@@ -53,7 +53,8 @@ from app.schemas.book import (
     QuestionProgressResponse,
 )
 from app.db.database import (
-    create_book, get_book_by_id, get_books_by_user,
+    create_book, get_book_by_id, get_book_owner_id, get_book_metadata_by_id,
+    get_books_by_user,
     update_book, apply_chapter_content_update, update_book_summary_atomic,
     delete_book
 )
@@ -717,7 +718,7 @@ async def analyze_book_summary(
     This endpoint uses OpenAI to analyze the summary's structure and completeness.
     """
     # Get the book and verify ownership
-    book = await get_book_by_id(book_id)
+    book = await get_book_metadata_by_id(book_id)
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
     if book.get("owner_id") != current_user.get("auth_id"):
@@ -839,7 +840,7 @@ async def generate_clarifying_questions(
     Uses AI to create 3-5 targeted questions that help structure the book content.
     """
     # Get the book and verify ownership
-    book = await get_book_by_id(book_id)
+    book = await get_book_metadata_by_id(book_id)
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
     if book.get("owner_id") != current_user.get("auth_id"):
@@ -1507,8 +1508,13 @@ async def update_chapter_content(
     """
     Update chapter content with automatic metadata updates.
     """
-    # Get the book and verify ownership
-    book = await get_book_by_id(book_id)
+    # Verify ownership and read the TOC *structure*. The projection drops every
+    # chapter's draft HTML, which this handler never reads — it only walks the
+    # tree to find the target chapter, its parent, and its current status, then
+    # writes through the scoped apply_chapter_content_update below. This is the
+    # 3s autosave path, so the whole-document read it used to do was the worst
+    # instance of the overfetch in #344.
+    book = await get_book_metadata_by_id(book_id)
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
     if book.get("owner_id") != current_user.get("auth_id"):
@@ -1605,10 +1611,10 @@ async def get_chapter_analytics(
     Get analytics data for a specific chapter.
     """
     # Get the book and verify ownership
-    book = await get_book_by_id(book_id)
-    if not book:
+    owner_id = await get_book_owner_id(book_id)
+    if owner_id is None:
         raise HTTPException(status_code=404, detail="Book not found")
-    if book.get("owner_id") != current_user.get("auth_id"):
+    if owner_id != current_user.get("auth_id"):
         raise HTTPException(
             status_code=403, detail="Not authorized to access this book's analytics"
         )
@@ -1782,11 +1788,11 @@ async def generate_chapter_questions(
         )
 
     # Get the book and verify ownership
-    book = await get_book_by_id(book_id)
-    if not book:
+    owner_id = await get_book_owner_id(book_id)
+    if owner_id is None:
         raise handle_book_not_found(book_id, request_id)
 
-    if book.get("owner_id") != current_user.get("auth_id"):
+    if owner_id != current_user.get("auth_id"):
         raise handle_unauthorized_access(
             resource_type="book",
             resource_id=book_id,
@@ -1892,11 +1898,11 @@ async def list_chapter_questions(
         )
 
     # Get the book and verify ownership
-    book = await get_book_by_id(book_id)
-    if not book:
+    owner_id = await get_book_owner_id(book_id)
+    if owner_id is None:
         raise handle_book_not_found(book_id, request_id)
 
-    if book.get("owner_id") != current_user.get("auth_id"):
+    if owner_id != current_user.get("auth_id"):
         raise handle_unauthorized_access(
             resource_type="book",
             resource_id=book_id,
@@ -1987,11 +1993,11 @@ async def save_question_response(
         )
 
     # Get the book and verify ownership
-    book = await get_book_by_id(book_id)
-    if not book:
+    owner_id = await get_book_owner_id(book_id)
+    if owner_id is None:
         raise handle_book_not_found(book_id, request_id)
 
-    if book.get("owner_id") != current_user.get("auth_id"):
+    if owner_id != current_user.get("auth_id"):
         raise handle_unauthorized_access(
             resource_type="book",
             resource_id=book_id,
@@ -2082,11 +2088,11 @@ async def get_question_response(
     request_id = generate_request_id()
 
     # Get the book and verify ownership
-    book = await get_book_by_id(book_id)
-    if not book:
+    owner_id = await get_book_owner_id(book_id)
+    if owner_id is None:
         raise handle_book_not_found(book_id, request_id)
 
-    if book.get("owner_id") != current_user.get("auth_id"):
+    if owner_id != current_user.get("auth_id"):
         raise handle_unauthorized_access(
             resource_type="book",
             resource_id=book_id,
@@ -2166,11 +2172,11 @@ async def rate_question(
         )
 
     # Get the book and verify ownership
-    book = await get_book_by_id(book_id)
-    if not book:
+    owner_id = await get_book_owner_id(book_id)
+    if owner_id is None:
         raise handle_book_not_found(book_id, request_id)
 
-    if book.get("owner_id") != current_user.get("auth_id"):
+    if owner_id != current_user.get("auth_id"):
         raise handle_unauthorized_access(
             resource_type="book",
             resource_id=book_id,
@@ -2262,11 +2268,11 @@ async def regenerate_single_question(
     request_id = generate_request_id()
 
     # Get the book and verify ownership
-    book = await get_book_by_id(book_id)
-    if not book:
+    owner_id = await get_book_owner_id(book_id)
+    if owner_id is None:
         raise handle_book_not_found(book_id, request_id)
 
-    if book.get("owner_id") != current_user.get("auth_id"):
+    if owner_id != current_user.get("auth_id"):
         raise handle_unauthorized_access(
             resource_type="book",
             resource_id=book_id,
@@ -2352,11 +2358,11 @@ async def get_chapter_question_progress(
     request_id = generate_request_id()
 
     # Get the book and verify ownership
-    book = await get_book_by_id(book_id)
-    if not book:
+    owner_id = await get_book_owner_id(book_id)
+    if owner_id is None:
         raise handle_book_not_found(book_id, request_id)
 
-    if book.get("owner_id") != current_user.get("auth_id"):
+    if owner_id != current_user.get("auth_id"):
         raise handle_unauthorized_access(
             resource_type="book",
             resource_id=book_id,
@@ -2441,11 +2447,11 @@ async def regenerate_chapter_questions(
         )
 
     # Get the book and verify ownership
-    book = await get_book_by_id(book_id)
-    if not book:
+    owner_id = await get_book_owner_id(book_id)
+    if owner_id is None:
         raise handle_book_not_found(book_id, request_id)
 
-    if book.get("owner_id") != current_user.get("auth_id"):
+    if owner_id != current_user.get("auth_id"):
         raise handle_unauthorized_access(
             resource_type="book",
             resource_id=book_id,
@@ -2665,10 +2671,10 @@ async def transform_chapter_style(
     restoring the snapshot it held before applying.
     """
     # Verify book ownership.
-    book = await get_book_by_id(book_id)
-    if not book:
+    owner_id = await get_book_owner_id(book_id)
+    if owner_id is None:
         raise HTTPException(status_code=404, detail="Book not found")
-    if book.get("owner_id") != current_user.get("auth_id"):
+    if owner_id != current_user.get("auth_id"):
         raise HTTPException(
             status_code=403,
             detail="Not authorized to transform content for this book",
@@ -2934,11 +2940,11 @@ async def save_question_responses_batch_endpoint(
         )
 
     # Get the book and verify ownership
-    book = await get_book_by_id(book_id)
-    if not book:
+    owner_id = await get_book_owner_id(book_id)
+    if owner_id is None:
         raise handle_book_not_found(book_id, request_id)
 
-    if book.get("owner_id") != current_user.get("auth_id"):
+    if owner_id != current_user.get("auth_id"):
         raise handle_unauthorized_access(
             resource_type="book",
             resource_id=book_id,

--- a/backend/app/api/endpoints/chapters.py
+++ b/backend/app/api/endpoints/chapters.py
@@ -22,7 +22,7 @@ from app.schemas.book import (
     ChapterMetadata,
     ChapterStatus,
 )
-from app.db.database import get_book_by_id
+from app.db.database import get_book_by_id, get_book_owner_id
 from app.db.toc_transactions import (
     add_chapter_with_transaction,
     update_chapter_with_transaction,
@@ -208,10 +208,10 @@ async def get_tab_state(book_id: str, current_user: Dict = Depends(get_current_u
     """
     try:
         # Verify book ownership
-        book = await get_book_by_id(book_id)
-        if not book:
+        owner_id = await get_book_owner_id(book_id)
+        if owner_id is None:
             raise HTTPException(status_code=404, detail="Book not found")
-        if book.get("owner_id") != current_user.get("auth_id"):
+        if owner_id != current_user.get("auth_id"):
             raise HTTPException(
                 status_code=403, detail="Not authorized to access this book"
             )
@@ -623,10 +623,10 @@ async def save_tab_state(
     """
     try:
         # Verify book ownership
-        book = await get_book_by_id(book_id)
-        if not book:
+        owner_id = await get_book_owner_id(book_id)
+        if owner_id is None:
             raise HTTPException(status_code=404, detail="Book not found")
-        if book.get("owner_id") != current_user.get("auth_id"):
+        if owner_id != current_user.get("auth_id"):
             raise HTTPException(
                 status_code=403, detail="Not authorized to access this book"
             )

--- a/backend/app/api/endpoints/export.py
+++ b/backend/app/api/endpoints/export.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi.responses import StreamingResponse
 from app.api.dependencies import get_rate_limiter
 from app.core.security import get_current_user_from_session
-from app.db.book import get_book_by_id
+from app.db.book import get_book_by_id, get_book_owner_id
 from app.services.export_service import (
     export_service,
     ExportUnavailableError,
@@ -548,11 +548,11 @@ async def get_export_templates(
 
     The frontend renders these directly as the template preview before export.
     """
-    book = await get_book_by_id(book_id)
-    if not book:
+    owner_id = await get_book_owner_id(book_id)
+    if owner_id is None:
         raise HTTPException(status_code=404, detail="Book not found")
 
-    if book.get("owner_id") != current_user.get("auth_id"):
+    if owner_id != current_user.get("auth_id"):
         raise HTTPException(
             status_code=403,
             detail="Not authorized to access this book"

--- a/backend/app/db/book.py
+++ b/backend/app/db/book.py
@@ -51,10 +51,57 @@ async def create_book(book_data: Dict, user_auth_id: str) -> Dict:
         raise
 
 
+# Drops the per-chapter draft HTML (top-level chapters and one level of
+# subchapters) while leaving ids, titles, nesting, status and all top-level book
+# metadata intact. Chapter bodies are the only unbounded field on a book, so
+# excluding them turns a multi-KB→MB read into a small one (#344).
+CONTENT_EXCLUDING_PROJECTION = {
+    "table_of_contents.chapters.content": 0,
+    "table_of_contents.chapters.subchapters.content": 0,
+}
+
+
 async def get_book_by_id(book_id: str) -> Optional[Dict]:
-    """Get a book by its ID"""
+    """Get a book by its ID, including every chapter's draft HTML.
+
+    Prefer :func:`get_book_owner_id` when only ownership matters, or
+    :func:`get_book_metadata_by_id` when the chapter bodies are not read — this
+    one pulls the entire document (#344).
+    """
     try:
         book = await books_collection.find_one({"_id": ObjectId(book_id)})
+        return book
+    except Exception:
+        return None
+
+
+async def get_book_owner_id(book_id: str) -> Optional[str]:
+    """Return just the owner of a book, for an ownership check.
+
+    Most book-scoped endpoints read nothing but ``owner_id`` from the book, yet
+    an unprojected ``find_one`` hands back every chapter's HTML to answer that
+    one question. Returns ``None`` for a missing book and for a malformed id,
+    matching :func:`get_book_by_id` so callers keep turning both into a 404.
+    """
+    try:
+        book = await books_collection.find_one(
+            {"_id": ObjectId(book_id)}, {"owner_id": 1}
+        )
+        return book.get("owner_id") if book else None
+    except Exception:
+        return None
+
+
+async def get_book_metadata_by_id(book_id: str) -> Optional[Dict]:
+    """Get a book without any chapter draft HTML.
+
+    For callers that need the book's metadata or its chapter *structure* —
+    ids, nesting, titles, status — but never a chapter body.
+    """
+    try:
+        book = await books_collection.find_one(
+            {"_id": ObjectId(book_id)}, CONTENT_EXCLUDING_PROJECTION
+        )
         return book
     except Exception:
         return None
@@ -72,12 +119,8 @@ async def get_books_by_user(
     overfetch (a book with long chapters sends KBs of unused HTML per row).
     Titles/structure/``toc_items`` are untouched.
     """
-    projection = {
-        "table_of_contents.chapters.content": 0,
-        "table_of_contents.chapters.subchapters.content": 0,
-    }
     cursor = (
-        books_collection.find({"owner_id": user_auth_id}, projection)
+        books_collection.find({"owner_id": user_auth_id}, CONTENT_EXCLUDING_PROJECTION)
         .skip(skip)
         .limit(limit)
     )

--- a/backend/app/db/database.py
+++ b/backend/app/db/database.py
@@ -38,6 +38,8 @@ get_user_by_clerk_id = get_user_by_auth_id
 from .book import (
     create_book,
     get_book_by_id,
+    get_book_owner_id,
+    get_book_metadata_by_id,
     get_books_by_user,
     update_book,
     apply_chapter_content_update,
@@ -85,6 +87,8 @@ __all__ += [
     # Book DAOs
     "create_book",
     "get_book_by_id",
+    "get_book_owner_id",
+    "get_book_metadata_by_id",
     "get_books_by_user",
     "update_book",
     "delete_book",

--- a/backend/tests/test_api/test_ai_error_responses.py
+++ b/backend/tests/test_api/test_ai_error_responses.py
@@ -74,7 +74,7 @@ class TestGenerateClarifyingQuestionsErrors:
     @pytest.mark.asyncio
     async def test_rate_limit_error_returns_429(self, client, mock_user, mock_book):
         """Test that rate limit errors return 429 status code."""
-        with patch('app.api.endpoints.books.get_book_by_id', return_value=mock_book):
+        with patch('app.api.endpoints.books.get_book_metadata_by_id', return_value=mock_book):
             with patch('app.services.ai_service.ai_service.generate_clarifying_questions') as mock_generate:
                 mock_generate.side_effect = AIRateLimitError(
                     retry_after=60,
@@ -96,7 +96,7 @@ class TestGenerateClarifyingQuestionsErrors:
     @pytest.mark.asyncio
     async def test_network_error_returns_503(self, client, mock_user, mock_book):
         """Test that network errors return 503 status code."""
-        with patch('app.api.endpoints.books.get_book_by_id', return_value=mock_book):
+        with patch('app.api.endpoints.books.get_book_metadata_by_id', return_value=mock_book):
             with patch('app.services.ai_service.ai_service.generate_clarifying_questions') as mock_generate:
                 mock_generate.side_effect = AINetworkError(
                     correlation_id="test-correlation-456"
@@ -115,7 +115,7 @@ class TestGenerateClarifyingQuestionsErrors:
     @pytest.mark.asyncio
     async def test_service_unavailable_returns_503(self, client, mock_user, mock_book):
         """Test that service unavailable errors return 503 status code."""
-        with patch('app.api.endpoints.books.get_book_by_id', return_value=mock_book):
+        with patch('app.api.endpoints.books.get_book_metadata_by_id', return_value=mock_book):
             with patch('app.services.ai_service.ai_service.generate_clarifying_questions') as mock_generate:
                 mock_generate.side_effect = AIServiceUnavailableError(
                     retry_after=30,
@@ -135,7 +135,7 @@ class TestGenerateClarifyingQuestionsErrors:
     @pytest.mark.asyncio
     async def test_invalid_request_returns_400(self, client, mock_user, mock_book):
         """Test that invalid request errors return 400 status code."""
-        with patch('app.api.endpoints.books.get_book_by_id', return_value=mock_book):
+        with patch('app.api.endpoints.books.get_book_metadata_by_id', return_value=mock_book):
             with patch('app.services.ai_service.ai_service.generate_clarifying_questions') as mock_generate:
                 mock_generate.side_effect = AIInvalidRequestError(
                     message="Invalid parameters",
@@ -154,7 +154,7 @@ class TestGenerateClarifyingQuestionsErrors:
     @pytest.mark.asyncio
     async def test_generic_ai_error_returns_500(self, client, mock_user, mock_book):
         """Test that generic AI errors return 500 status code."""
-        with patch('app.api.endpoints.books.get_book_by_id', return_value=mock_book):
+        with patch('app.api.endpoints.books.get_book_metadata_by_id', return_value=mock_book):
             with patch('app.services.ai_service.ai_service.generate_clarifying_questions') as mock_generate:
                 mock_generate.side_effect = AIServiceError(
                     message="Unexpected error",
@@ -257,7 +257,7 @@ class TestAnalyzeSummaryErrors:
     @pytest.mark.asyncio
     async def test_analyze_network_error_returns_503(self, client, mock_user, mock_book):
         """Timeouts/network errors during summary analysis return 503, not 500."""
-        with patch('app.api.endpoints.books.get_book_by_id', return_value=mock_book):
+        with patch('app.api.endpoints.books.get_book_metadata_by_id', return_value=mock_book):
             with patch('app.services.ai_service.ai_service.analyze_summary_for_toc') as mock_analyze:
                 mock_analyze.side_effect = AINetworkError(
                     correlation_id="analyze-correlation-456"
@@ -274,7 +274,7 @@ class TestAnalyzeSummaryErrors:
     @pytest.mark.asyncio
     async def test_analyze_rate_limit_error_returns_429(self, client, mock_user, mock_book):
         """Rate limit errors during summary analysis return 429 with retry info."""
-        with patch('app.api.endpoints.books.get_book_by_id', return_value=mock_book):
+        with patch('app.api.endpoints.books.get_book_metadata_by_id', return_value=mock_book):
             with patch('app.services.ai_service.ai_service.analyze_summary_for_toc') as mock_analyze:
                 mock_analyze.side_effect = AIRateLimitError(
                     retry_after=60,
@@ -291,7 +291,7 @@ class TestAnalyzeSummaryErrors:
     @pytest.mark.asyncio
     async def test_analyze_service_unavailable_returns_503(self, client, mock_user, mock_book):
         """Service-unavailable errors during summary analysis return 503."""
-        with patch('app.api.endpoints.books.get_book_by_id', return_value=mock_book):
+        with patch('app.api.endpoints.books.get_book_metadata_by_id', return_value=mock_book):
             with patch('app.services.ai_service.ai_service.analyze_summary_for_toc') as mock_analyze:
                 mock_analyze.side_effect = AIServiceUnavailableError(
                     retry_after=30,
@@ -320,7 +320,7 @@ class TestAnalyzeSummaryErrors:
             "suggestions": ["Please try again later or contact support"],
             "error": "AI_UNEXPECTED_ERROR: 401 invalid_api_key",
         }
-        with patch('app.api.endpoints.books.get_book_by_id', return_value=mock_book):
+        with patch('app.api.endpoints.books.get_book_metadata_by_id', return_value=mock_book):
             with patch(
                 'app.services.ai_service.ai_service.analyze_summary_for_toc',
                 new=AsyncMock(return_value=error_analysis),
@@ -346,7 +346,7 @@ class TestErrorResponseStructure:
     @pytest.mark.asyncio
     async def test_error_response_includes_all_fields(self, client, mock_user, mock_book):
         """Test that error responses include all expected fields."""
-        with patch('app.api.endpoints.books.get_book_by_id', return_value=mock_book):
+        with patch('app.api.endpoints.books.get_book_metadata_by_id', return_value=mock_book):
             with patch('app.services.ai_service.ai_service.generate_clarifying_questions') as mock_generate:
                 mock_generate.side_effect = AIRateLimitError(
                     message="Custom rate limit message",
@@ -384,7 +384,7 @@ class TestErrorResponseStructure:
         """Test that correlation IDs are preserved in error responses."""
         test_correlation_id = "unique-test-id-12345"
 
-        with patch('app.api.endpoints.books.get_book_by_id', return_value=mock_book):
+        with patch('app.api.endpoints.books.get_book_metadata_by_id', return_value=mock_book):
             with patch('app.services.ai_service.ai_service.generate_clarifying_questions') as mock_generate:
                 mock_generate.side_effect = AIServiceError(
                     message="Test error",
@@ -407,7 +407,7 @@ class TestSuccessfulResponses:
     @pytest.mark.asyncio
     async def test_successful_question_generation(self, client, mock_user, mock_book):
         """Test successful question generation still works."""
-        with patch('app.api.endpoints.books.get_book_by_id', return_value=mock_book):
+        with patch('app.api.endpoints.books.get_book_metadata_by_id', return_value=mock_book):
             with patch('app.api.endpoints.books.update_book', return_value=None):
                 with patch('app.services.ai_service.ai_service.generate_clarifying_questions') as mock_generate:
                     mock_generate.return_value = [

--- a/backend/tests/test_api/test_style_transformation.py
+++ b/backend/tests/test_api/test_style_transformation.py
@@ -27,7 +27,7 @@ async def test_transform_style_success(auth_client_factory):
             "generated_at": "2026-06-25 10:00:00",
         },
     }
-    with patch("app.api.endpoints.books.get_book_by_id", AsyncMock(return_value=MOCK_BOOK)):
+    with patch("app.api.endpoints.books.get_book_owner_id", AsyncMock(return_value=MOCK_BOOK["owner_id"])):
         with patch("app.api.endpoints.books.ai_service.transform_text_style",
                    AsyncMock(return_value=mock_result)):
             response = await client.post(
@@ -43,7 +43,7 @@ async def test_transform_style_success(auth_client_factory):
 @pytest.mark.asyncio
 async def test_transform_style_requires_content(auth_client_factory):
     client = await auth_client_factory()
-    with patch("app.api.endpoints.books.get_book_by_id", AsyncMock(return_value=MOCK_BOOK)):
+    with patch("app.api.endpoints.books.get_book_owner_id", AsyncMock(return_value=MOCK_BOOK["owner_id"])):
         response = await client.post(URL, json={"content": "  ", "target_style": "professional"})
     assert response.status_code == 400
     assert "required" in response.json()["detail"].lower()
@@ -52,7 +52,7 @@ async def test_transform_style_requires_content(auth_client_factory):
 @pytest.mark.asyncio
 async def test_transform_style_rejects_invalid_style(auth_client_factory):
     client = await auth_client_factory()
-    with patch("app.api.endpoints.books.get_book_by_id", AsyncMock(return_value=MOCK_BOOK)):
+    with patch("app.api.endpoints.books.get_book_owner_id", AsyncMock(return_value=MOCK_BOOK["owner_id"])):
         response = await client.post(URL, json={"content": "Hello there.", "target_style": "spicy"})
     assert response.status_code == 400
     assert "unsupported" in response.json()["detail"].lower()
@@ -62,7 +62,7 @@ async def test_transform_style_rejects_invalid_style(auth_client_factory):
 async def test_transform_style_ai_failure_returns_503(auth_client_factory):
     client = await auth_client_factory()
     mock_result = {"success": False, "error": "AI service unavailable", "transformed": "", "metadata": {}}
-    with patch("app.api.endpoints.books.get_book_by_id", AsyncMock(return_value=MOCK_BOOK)):
+    with patch("app.api.endpoints.books.get_book_owner_id", AsyncMock(return_value=MOCK_BOOK["owner_id"])):
         with patch("app.api.endpoints.books.ai_service.transform_text_style",
                    AsyncMock(return_value=mock_result)):
             response = await client.post(
@@ -75,8 +75,7 @@ async def test_transform_style_ai_failure_returns_503(auth_client_factory):
 @pytest.mark.asyncio
 async def test_transform_style_rejects_other_users_book(auth_client_factory):
     client = await auth_client_factory()
-    other_book = {**MOCK_BOOK, "owner_id": "someone-else"}
-    with patch("app.api.endpoints.books.get_book_by_id", AsyncMock(return_value=other_book)):
+    with patch("app.api.endpoints.books.get_book_owner_id", AsyncMock(return_value="someone-else")):
         response = await client.post(
             URL, json={"content": "Some text.", "target_style": "creative"}
         )

--- a/backend/tests/test_db/test_n1_and_projection.py
+++ b/backend/tests/test_db/test_n1_and_projection.py
@@ -22,7 +22,11 @@ from app.db.questions import (
     get_ratings_for_chapter,
     get_chapter_question_progress,
 )
-from app.db.book import get_books_by_user
+from app.db.book import (
+    get_books_by_user,
+    get_book_owner_id,
+    get_book_metadata_by_id,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -174,3 +178,111 @@ async def test_get_books_by_user_projects_out_chapter_content(motor_reinit_db):
     assert chapter["subchapters"][0]["title"] == "Sub"
     assert book["toc_items"][0]["title"] == "Chapter One"
     assert book["title"] == "My Book"
+
+
+# --- #344: ownership checks must not drag chapter HTML over the wire --------
+
+
+async def _seed_book_with_heavy_chapters() -> ObjectId:
+    """A book whose chapter bodies dwarf its metadata, so overfetch is visible."""
+    books = await get_collection("books")
+    book_id = ObjectId()
+    await books.insert_one({
+        "_id": book_id,
+        "owner_id": USER,
+        "title": "Heavy Book",
+        "summary": "A summary.",
+        "genre": "nonfiction",
+        "target_audience": "engineers",
+        "toc_items": [{"id": "c1", "title": "Chapter One", "order": 1, "level": 1}],
+        "table_of_contents": {
+            "version": 1,
+            "chapters": [
+                {
+                    "id": "c1",
+                    "title": "Chapter One",
+                    "status": "in-progress",
+                    "content": "<p>" + "x" * 20000 + "</p>",
+                    "subchapters": [
+                        {
+                            "id": "c1a",
+                            "title": "Sub",
+                            "status": "draft",
+                            "content": "<p>" + "y" * 20000 + "</p>",
+                        }
+                    ],
+                }
+            ],
+        },
+    })
+    return book_id
+
+
+async def test_get_book_owner_id_returns_only_the_owner(motor_reinit_db):
+    book_id = await _seed_book_with_heavy_chapters()
+
+    owner = await get_book_owner_id(str(book_id))
+
+    assert owner == USER
+
+
+async def test_get_book_owner_id_fetches_nothing_but_the_owner(motor_reinit_db):
+    """Pins the projection itself: dropping it makes this fail.
+
+    Asserting on the return value alone would still pass if the projection were
+    removed, since the caller only reads owner_id either way. So capture what
+    Mongo actually sent back.
+    """
+    book_id = await _seed_book_with_heavy_chapters()
+
+    captured = {}
+    real_find_one = motor.motor_asyncio.AsyncIOMotorCollection.find_one
+
+    async def spy(self, filter=None, *args, **kwargs):
+        doc = await real_find_one(self, filter, *args, **kwargs)
+        captured["doc"] = doc
+        return doc
+
+    with patch.object(motor.motor_asyncio.AsyncIOMotorCollection, "find_one", spy):
+        await get_book_owner_id(str(book_id))
+
+    doc = captured["doc"]
+    # _id always comes back unless explicitly suppressed; nothing else may.
+    assert set(doc.keys()) <= {"_id", "owner_id"}
+    assert "table_of_contents" not in doc
+    assert "title" not in doc
+
+
+async def test_get_book_owner_id_returns_none_for_missing_and_malformed_ids(motor_reinit_db):
+    assert await get_book_owner_id(str(ObjectId())) is None
+    # A non-ObjectId string must not raise — callers turn None into a 404.
+    assert await get_book_owner_id("not-an-object-id") is None
+
+
+async def test_get_book_metadata_by_id_excludes_chapter_html(motor_reinit_db):
+    book_id = await _seed_book_with_heavy_chapters()
+
+    book = await get_book_metadata_by_id(str(book_id))
+
+    chapter = book["table_of_contents"]["chapters"][0]
+    # Heavy HTML gone, at both levels...
+    assert "content" not in chapter
+    assert "content" not in chapter["subchapters"][0]
+    # ...but everything the callers actually read survives. The autosave path
+    # needs ids, nesting and status to locate the chapter and compute its
+    # status transition; analyze-summary/generate-questions need the top-level
+    # metadata.
+    assert chapter["id"] == "c1"
+    assert chapter["status"] == "in-progress"
+    assert chapter["subchapters"][0]["id"] == "c1a"
+    assert chapter["subchapters"][0]["status"] == "draft"
+    assert book["owner_id"] == USER
+    assert book["title"] == "Heavy Book"
+    assert book["summary"] == "A summary."
+    assert book["genre"] == "nonfiction"
+    assert book["target_audience"] == "engineers"
+
+
+async def test_get_book_metadata_by_id_returns_none_for_missing_and_malformed_ids(motor_reinit_db):
+    assert await get_book_metadata_by_id(str(ObjectId())) is None
+    assert await get_book_metadata_by_id("not-an-object-id") is None


### PR DESCRIPTION
Closes #344.

## Problem

`get_book_by_id` does an unprojected `find_one`, so a book-scoped endpoint that reads nothing but `owner_id` still pulls the entire document — including every chapter's draft HTML — to answer one question. Worst on the 3s autosave path, which loaded the whole book and then persisted through the already-scoped `apply_chapter_content_update`.

## Two new DAOs

**`get_book_owner_id`** — `find_one({_id}, {owner_id: 1})`.

It returns `Optional[str]` rather than the projected document, and that was a deliberate trade. Returning a dict would have made a 1-line diff per call site instead of two — but it leaves a variable named `book` holding two fields, so a later edit reading `book.get("title")` gets `None` silently rather than failing. The extra line per site buys a type that can't be misused that way.

**`get_book_metadata_by_id`** — the book without chapter draft HTML, for callers needing metadata or chapter *structure* (ids, nesting, status) but never a body.

The content-excluding projection is now a shared `CONTENT_EXCLUDING_PROJECTION` constant, reused by `get_books_by_user` in place of the duplicate literal it carried.

## 17 call sites, not the 4 the issue names

The issue's title says "every book-scoped endpoint", and leaving 13 identical siblings on the unprojected read would keep the bug alive on those paths indefinitely. I classified all 33 `get_book_by_id` call sites by what each actually reads:

| Category | Count | Where |
|----------|-------|-------|
| Ownership-only → `get_book_owner_id` | 14 | `books.py` (11), `chapters.py` (2, tab state), `export.py` (1, templates) |
| Metadata-only → `get_book_metadata_by_id` | 3 | `analyze-summary`, `generate-questions`, `update_chapter_content` |
| Left on the full read | 16 | TOC generation, draft generation, export renderers, `get_chapter` — anything that passes the whole book to a service or renders chapter content |

`update_chapter_content` is the interesting one: it walks the TOC to find the target chapter, its parent, and its current `status`, and never reads a chapter body — so the projection is safe there, and it's the path that benefits most.

## A mistake worth reporting

I converted `get_export_formats` first, and it broke: it passes the whole book to `export_service.book_stats(book)`. My classifier only detected `.get("x")` / `["x"]` access and missed the bare reference.

The suite caught it, but "the tests happened to cover that one" is not evidence the other 16 are clean. So I ran a static `F821` (undefined-name) sweep over the whole app, which is exactly this bug class:

```
$ uvx ruff check --select F821 app/
All checks passed!
```

`get_export_formats` is reverted to the full read.

## Tests

Five real-Mongo tests in `test_db/test_n1_and_projection.py`, alongside the existing `get_books_by_user` projection test.

One of them deserves note — it spies on what Mongo actually returned rather than on the function's return value:

```python
assert set(doc.keys()) <= {"_id", "owner_id"}
```

Asserting only that `get_book_owner_id` returns the right owner would still pass with the projection deleted, since the caller reads `owner_id` either way. The projection has to be pinned by what came back over the wire, or the test doesn't defend the thing the issue is about.

The rest cover: the projection dropping HTML at both nesting levels while preserving ids/status/metadata, and `None` for missing **and** malformed ids (callers turn both into a 404).

## Verification

| Check | Result |
|-------|--------|
| Backend suite | **1198 passed**, 11 skipped, 0 failed |
| `ruff --select F821 app/` | clean — no dangling references from the conversion |
| New lint findings | 3, all `UP045` (`Optional[X]` → `X \| None`) — the same rule the file already violates 20× on `main`; matching surrounding style |
| CodeRabbit | 0 findings |

## Mock-target updates (17 tests)

`test_ai_error_responses.py` and `test_style_transformation.py` patch the DAO by name, so they were repointed at the function their endpoint now calls. **Assertions are untouched** — a rate-limit test still asserts 429, the 403 test still asserts 403 (now by returning a different owner id rather than a book dict with a different owner). The TOC tests in the same file stay on `get_book_by_id`, because that endpoint still needs the full document; my first pass blanket-replaced them and turned them red, which is how I caught it.

## Behaviour note

A book document with **no** `owner_id` field would previously 403 and now 404s, because "not found" and "found but ownerless" both surface as `None`. Such a document can't be produced by `create_book`, and `update_book` scopes by `owner_id`. Flagging it rather than burying it.

## Follow-up not done here

Four `chapters.py` endpoints (`get_chapters_metadata`, `list_chapters`, `update_chapter_status_bulk`, `get_chapter`) read `table_of_contents`. Three of them likely need only structure and could take the metadata projection, but each needs its own read of what the downstream service does with the chapter — the kind of case-by-case check that just bit me on `get_export_formats`. Better as its own change than bolted onto this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)