### PR TITLE
fix(export): run exports on a dedicated bounded pool; stop claiming the timeout cancels them (#345)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -106,6 +106,14 @@ class Settings(BaseSettings):
 
     # Export Settings
     EXPORT_TIMEOUT_SECONDS: int = 120  # Hard cap on a single export's generation
+    # Worker threads reserved for CPU-bound export builds (#345). Exports run on
+    # their own pool so a burst of oversized books cannot occupy the event
+    # loop's default executor, which ai_service uses for blocking OpenAI calls.
+    # A timeout does NOT free a slot — Python cannot kill a running thread — so
+    # this is the real ceiling on how many stuck exports it takes to block
+    # further exports. Tune against the box's core count; keep it below the
+    # default executor's size so AI always has headroom.
+    EXPORT_MAX_WORKERS: int = 2
 
     # AWS Settings (Optional - for transcription and storage)
     AWS_ACCESS_KEY_ID: str = ""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -131,7 +131,13 @@ async def lifespan(app: FastAPI):
     # Application runs here
     yield
 
-    # Shutdown tasks (if needed)
+    # Shutdown tasks
+    # Drop any export builds still queued on the dedicated pool (#345).
+    # wait=False so shutdown isn't held hostage by an in-flight build — a
+    # running thread cannot be cancelled, only waited on.
+    from app.services.export_service import export_executor
+
+    export_executor.shutdown(wait=False, cancel_futures=True)
     logger.info("Application shutdown")
 
 

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -22,10 +22,13 @@ logger = logging.getLogger(__name__)
 # AI generation behind builds whose clients already gave up at the 504. Giving
 # exports their own bounded pool keeps that blast radius inside exports (#345).
 #
-# This bounds the damage; it does not cancel anything. A timed-out build keeps
-# running to completion and holds its slot, because Python cannot kill a
-# running thread. EXPORT_MAX_WORKERS is therefore the number of stuck exports
-# it takes to block further exports — AI stays unaffected either way.
+# This bounds the damage; it does not reliably cancel. A build that is still
+# QUEUED when the timeout fires is genuinely cancelled and never runs — the
+# executor future had not started, so cancel() takes. A build already RUNNING
+# cannot be stopped: Python cannot kill a running thread, so it continues to
+# completion holding its slot. EXPORT_MAX_WORKERS is therefore the number of
+# concurrently-stuck *running* exports it takes to block further exports — AI
+# stays unaffected either way, which is the point.
 EXPORT_THREAD_NAME_PREFIX = "export_worker"
 
 export_executor = ThreadPoolExecutor(
@@ -1021,8 +1024,8 @@ class ExportService:
             # the throughput drop that followed (#345).
             logger.warning(
                 "Export timed out after %ss (format=%s, title=%r, chapters=%d). "
-                "The worker thread is NOT cancelled and is still running; it "
-                "will hold 1 of %d export slots until the build finishes.",
+                "If the build had already started it is NOT cancelled and is "
+                "still running, holding 1 of %d export slots until it finishes.",
                 timeout_seconds,
                 fmt,
                 book_data.get("title", "<untitled>"),

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -4,11 +4,44 @@ Export Service for generating PDF and DOCX files from book content
 import io
 import asyncio
 import html
+import logging
+from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, List, Optional, BinaryIO
 from datetime import datetime
 import re
 
+from app.core.config import settings
 from app.services.export_templates import PAGE_SIZES_INCHES, resolve_template
+
+logger = logging.getLogger(__name__)
+
+# Export builds are CPU-bound (reportlab / python-docx) and run in worker
+# threads. `asyncio.to_thread` would put them on the event loop's DEFAULT
+# executor — the very pool ai_service.py uses to offload blocking OpenAI calls
+# (#175) — so a burst of oversized exports could occupy every worker and queue
+# AI generation behind builds whose clients already gave up at the 504. Giving
+# exports their own bounded pool keeps that blast radius inside exports (#345).
+#
+# This bounds the damage; it does not cancel anything. A timed-out build keeps
+# running to completion and holds its slot, because Python cannot kill a
+# running thread. EXPORT_MAX_WORKERS is therefore the number of stuck exports
+# it takes to block further exports — AI stays unaffected either way.
+EXPORT_THREAD_NAME_PREFIX = "export_worker"
+
+export_executor = ThreadPoolExecutor(
+    max_workers=settings.EXPORT_MAX_WORKERS,
+    thread_name_prefix=EXPORT_THREAD_NAME_PREFIX,
+)
+
+
+async def _run_export_build(func, *args):
+    """Run a blocking export build on the dedicated export pool.
+
+    The drop-in replacement for ``asyncio.to_thread`` in this module — same
+    shape, different (bounded, isolated) executor.
+    """
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(export_executor, func, *args)
 
 # Optional export dependencies are guarded so the service (and the rest of the
 # API) still imports if a library is missing — only the affected format fails,
@@ -203,14 +236,15 @@ class ExportService:
         """
         Generate a PDF from book data and chapters.
 
-        ReportLab is synchronous and CPU-bound, so the build runs in a worker
-        thread to keep the event loop responsive for large books and to let an
-        outer asyncio timeout actually cancel a runaway export.
+        ReportLab is synchronous and CPU-bound, so the build runs on the
+        dedicated export pool to keep the event loop responsive for large books.
+        An outer asyncio timeout stops the *waiting*, not the build — the thread
+        runs to completion regardless (#345).
 
         ``template`` (optional) is a resolved export-template dict; when omitted
         the legacy hardcoded styling is used unchanged.
         """
-        return await asyncio.to_thread(
+        return await _run_export_build(
             self._build_pdf, book_data, chapters, output_stream, page_size, template
         )
 
@@ -451,13 +485,14 @@ class ExportService:
         """
         Generate a DOCX file from book data and chapters.
 
-        python-docx is synchronous and CPU-bound; the build runs in a worker
-        thread so large books don't block the event loop and timeouts can fire.
+        python-docx is synchronous and CPU-bound; the build runs on the
+        dedicated export pool so large books don't block the event loop. A
+        timeout fires on the await, but cannot stop the build (#345).
 
         ``template`` (optional) is a resolved export-template dict; when omitted
         the legacy Word styling is used unchanged.
         """
-        return await asyncio.to_thread(
+        return await _run_export_build(
             self._build_docx, book_data, chapters, output_stream, template
         )
 
@@ -638,11 +673,11 @@ class ExportService:
         """
         Generate an EPUB (3.0) file from book data and chapters.
 
-        ebooklib is synchronous, so the build runs in a worker thread to keep the
-        event loop responsive and let an outer asyncio timeout cancel a runaway
-        export — same pattern as PDF/DOCX.
+        ebooklib is synchronous, so the build runs on the dedicated export pool
+        to keep the event loop responsive — same pattern as PDF/DOCX. An outer
+        timeout abandons the await; it does not stop the build (#345).
         """
-        return await asyncio.to_thread(self._build_epub, book_data, chapters)
+        return await _run_export_build(self._build_epub, book_data, chapters)
 
     def _chapter_to_xhtml(self, chapter: Dict, index: int) -> str:
         """Render a chapter to a complete, well-formed XHTML document.
@@ -756,10 +791,11 @@ class ExportService:
 
         ``multi_file=False`` returns a single ``.md`` file (UTF-8 bytes);
         ``multi_file=True`` returns a ZIP archive with one ``NN-slug.md`` per
-        chapter. Runs in a worker thread so large books don't block the loop and
-        an outer asyncio timeout can cancel — same pattern as PDF/DOCX/EPUB.
+        chapter. Runs on the dedicated export pool so large books don't block
+        the loop — same pattern as PDF/DOCX/EPUB. An outer timeout abandons the
+        await; it does not stop the build (#345).
         """
-        return await asyncio.to_thread(
+        return await _run_export_build(
             self._build_markdown, book_data, chapters, multi_file
         )
 
@@ -978,10 +1014,24 @@ class ExportService:
         try:
             return await asyncio.wait_for(generator, timeout=timeout_seconds)
         except asyncio.TimeoutError as e:
+            # wait_for abandons the await; it cannot stop the worker thread, so
+            # the build runs to completion holding one of EXPORT_MAX_WORKERS
+            # slots after the client has already received its 504. Previously
+            # this happened silently — an operator saw the 504 and no reason for
+            # the throughput drop that followed (#345).
+            logger.warning(
+                "Export timed out after %ss (format=%s, title=%r, chapters=%d). "
+                "The worker thread is NOT cancelled and is still running; it "
+                "will hold 1 of %d export slots until the build finishes.",
+                timeout_seconds,
+                fmt,
+                book_data.get("title", "<untitled>"),
+                len(flattened_chapters),
+                settings.EXPORT_MAX_WORKERS,
+            )
             raise ExportTimeoutError(
-                "Export took too long and was stopped. This usually happens "
-                "with very large books — try exporting fewer chapters, or try "
-                "again in a moment."
+                "Export took too long. This usually happens with very large "
+                "books — try exporting fewer chapters, or try again in a moment."
             ) from e
 
 

--- a/backend/tests/test_services/test_export_service.py
+++ b/backend/tests/test_services/test_export_service.py
@@ -2,11 +2,16 @@
 Test Export Service functionality
 """
 import asyncio
+import logging
+import threading
 import pytest
 from io import BytesIO
 from unittest.mock import patch
+from app.core.config import settings
 from app.services.export_service import (
     export_service,
+    export_executor,
+    EXPORT_THREAD_NAME_PREFIX,
     ExportValidationError,
     ExportTimeoutError,
 )
@@ -543,3 +548,79 @@ class TestTemplatedExport:
         doc = Document(BytesIO(out))
         # Default python-docx letter section, untouched header.
         assert doc.sections[0].header.paragraphs[0].text == ""
+
+
+class TestExportExecutorIsolation:
+    """#345: exports must not be able to starve the AI path.
+
+    ``asyncio.to_thread`` dispatches to the event loop's *default*
+    ThreadPoolExecutor — the same pool ``ai_service`` uses for blocking OpenAI
+    calls. A burst of oversized exports could therefore occupy every worker and
+    queue AI generation behind builds that a 504 has already given up on.
+    Exports now run on their own bounded pool.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pdf_build_runs_on_the_dedicated_export_pool(self):
+        """The build thread must belong to the export pool, not the default one.
+
+        Asserting on the returned bytes would pass either way; the thread the
+        work actually ran on is the thing that keeps AI unblocked, so that is
+        what gets pinned. Default-executor threads are named
+        ``asyncio_%d``/``ThreadPoolExecutor-*``, never ``export_*``.
+        """
+        seen = {}
+
+        def fake_build(*args, **kwargs):
+            seen["thread"] = threading.current_thread().name
+            return b"%PDF-1.4 fake"
+
+        with patch.object(export_service, "_build_pdf", side_effect=fake_build):
+            await export_service.generate_pdf(
+                {"title": "T"}, [{"id": "1", "title": "A", "content": "<p>x</p>"}]
+            )
+
+        assert seen["thread"].startswith(EXPORT_THREAD_NAME_PREFIX), (
+            f"export ran on {seen['thread']!r}; it must run on the dedicated "
+            "export pool or it can starve ai_service's OpenAI calls (#345)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_export_pool_is_bounded(self):
+        """An unbounded pool would defeat the purpose — saturation is the point."""
+        assert export_executor._max_workers == settings.EXPORT_MAX_WORKERS
+        assert settings.EXPORT_MAX_WORKERS >= 1
+
+    @pytest.mark.asyncio
+    async def test_timeout_warns_that_the_thread_keeps_running(self, caplog):
+        """A 504 with no log left an invisible stuck worker (#345).
+
+        The warning is the only signal an operator gets that a slot is still
+        occupied after the client got its error.
+        """
+        book = {
+            "title": "Slow Book",
+            "table_of_contents": {
+                "chapters": [
+                    {"id": "1", "title": "A", "content": "<p>hi</p>", "order": 1}
+                ]
+            },
+        }
+
+        async def slow_pdf(*args, **kwargs):
+            await asyncio.sleep(0.2)
+            return b"%PDF-never"
+
+        with patch.object(export_service, "generate_pdf", side_effect=slow_pdf):
+            with caplog.at_level(logging.WARNING, logger="app.services.export_service"):
+                with pytest.raises(ExportTimeoutError):
+                    await export_service.export_book(
+                        book, format="pdf", timeout_seconds=0.01
+                    )
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, "a timed-out export must leave a warning behind"
+        message = warnings[0].getMessage()
+        assert "pdf" in message
+        # The message must not repeat the old claim that the export was stopped.
+        assert "not cancelled" in message.lower() or "still running" in message.lower()


### PR DESCRIPTION
Closes #345.

## Two problems, one of them worse than the docstrings suggested

`export_book` wraps the build in `asyncio.wait_for`, which abandons the await and raises `ExportTimeoutError` (→ 504) while the CPU-bound reportlab/python-docx build runs to completion. Three docstrings claimed the timeout "actually cancels a runaway export". It cannot — Python cannot kill a running thread.

The real hazard is *where those threads live*. `asyncio.to_thread` dispatches to the event loop's **default** `ThreadPoolExecutor` — the same pool `ai_service` uses to offload blocking OpenAI calls (#175). A burst of oversized exports could occupy every worker in that shared pool, so AI generation queued behind builds whose clients had already given up, while `/health` kept returning 200.

## Fix

Exports now run on their own bounded `ThreadPoolExecutor` via `run_in_executor`. This does not cancel anything — it **contains the blast radius**. `EXPORT_MAX_WORKERS` (new setting, default 2) becomes the number of concurrently-stuck exports it takes to block *further exports*; AI is unaffected either way.

The pool is shut down on lifespan exit with `wait=False, cancel_futures=True`, so queued builds are dropped and a running one can't hold up process shutdown.

A timed-out export now logs a warning naming the format, title, chapter count, and the fact that a still-running build holds a slot. Previously this was silent: an operator saw a 504 and had no explanation for the throughput drop that followed.

All four docstrings are corrected to say what actually happens.

## The test pins the thread, not the bytes

```python
assert seen["thread"].startswith(EXPORT_THREAD_NAME_PREFIX)
```

Asserting that the export returns correct bytes proves nothing about which pool produced them — it would pass identically before and after. The thread the build ran on *is* the fix, so that's what gets pinned.

Mutation check, with `_run_export_build` reverted to `asyncio.to_thread`:

```
E   assert False
E    +  where False = 'asyncio_0'.startswith('export_worker')
```

`asyncio_0` is the default-executor thread — the one `ai_service` shares. The test reports the bug by name.

## Verification

| Check | Result |
|-------|--------|
| Export service tests | 37 passed (3 new) |
| Full backend suite | **1201 passed**, 11 skipped, 0 failed |
| `ruff --select F821 app/` | clean |
| Mutation check on the isolation test | fails as `asyncio_0` without the fix ✅ |
| CodeRabbit | 1 minor, fixed (below) |

## Review correction

CodeRabbit caught my comment overstating the case in the *opposite* direction. I wrote "it does not cancel anything" — but a build still **queued** when the timeout fires genuinely is cancelled, because the executor future hasn't started and `cancel()` takes. Only an already-**running** build can't be stopped.

In a change whose entire point is that the docstrings lied about cancellation, swapping one imprecise claim for another would be a poor trade. Both the comment and the log message are now hedged on that distinction.

## What this does not do

It does not make exports cancellable. Doing that means either a process pool (kill the worker) or cooperative checks inside the reportlab/docx build loops — a much larger change, and not what the issue asks for. The issue asks that a stuck export can't starve the AI path, and that the code stop claiming otherwise. Both are addressed.

`EXPORT_MAX_WORKERS = 2` is a starting value, deliberately below the default executor's size so AI keeps headroom. It's a config knob because the right number depends on the box's cores, and staging is a shared VPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)