### PR TITLE
perf(uploads): push PIL processing and cloud SDK calls off the event loop (#346)

### DIFF
--- a/backend/app/services/cloud_storage_service.py
+++ b/backend/app/services/cloud_storage_service.py
@@ -3,6 +3,7 @@ Cloud storage service for handling file uploads to AWS S3 or Cloudinary.
 Provides a unified interface for cloud storage operations.
 """
 
+import asyncio
 import os
 import uuid
 from pathlib import Path
@@ -61,8 +62,11 @@ class S3StorageService:
             file_ext = Path(filename).suffix.lower()
             unique_key = f"{folder}/{uuid.uuid4().hex}{file_ext}"
 
-            # Upload to S3
-            self.s3_client.put_object(
+            # boto3 is synchronous — a multi-second S3 round-trip inside
+            # `async def` freezes the event loop for every other request on
+            # this worker (#346). Offload it.
+            await asyncio.to_thread(
+                self.s3_client.put_object,
                 Bucket=self.bucket_name,
                 Key=unique_key,
                 Body=file_data,
@@ -88,7 +92,8 @@ class S3StorageService:
             if f"{self.bucket_name}.s3" in url:
                 key = url.split(f"{self.bucket_name}.s3.{self.region}.amazonaws.com/")[-1]
 
-                self.s3_client.delete_object(
+                await asyncio.to_thread(
+                    self.s3_client.delete_object,
                     Bucket=self.bucket_name,
                     Key=key
                 )
@@ -130,8 +135,9 @@ class CloudinaryStorageService:
             file_ext = Path(filename).suffix.lower()
             public_id = f"{folder}/{uuid.uuid4().hex}"
 
-            # Upload to Cloudinary
-            result = self.cloudinary_uploader.upload(
+            # The Cloudinary SDK is synchronous — same offload as S3 (#346).
+            result = await asyncio.to_thread(
+                self.cloudinary_uploader.upload,
                 file_data,
                 public_id=public_id,
                 folder=folder,
@@ -164,7 +170,9 @@ class CloudinaryStorageService:
                 if len(parts) >= 2:
                     public_id = "/".join(parts[1:]).rsplit(".", 1)[0]  # Remove extension
 
-                    result = self.cloudinary_uploader.destroy(public_id)
+                    result = await asyncio.to_thread(
+                        self.cloudinary_uploader.destroy, public_id
+                    )
 
                     if result.get('result') == 'ok':
                         logger.info(f"Deleted image from Cloudinary: {public_id}")

--- a/backend/app/services/file_upload_service.py
+++ b/backend/app/services/file_upload_service.py
@@ -257,12 +257,28 @@ class FileUploadService:
                     folder=f"cover_images/{book_id}"
                 )
 
-                thumbnail_url = await self.cloud_storage.upload_image(
-                    file_data=thumb_bytes,
-                    filename=thumbnail_filename,
-                    content_type=content_type,
-                    folder=f"cover_images/{book_id}/thumbnails"
-                )
+                try:
+                    thumbnail_url = await self.cloud_storage.upload_image(
+                        file_data=thumb_bytes,
+                        filename=thumbnail_filename,
+                        content_type=content_type,
+                        folder=f"cover_images/{book_id}/thumbnails"
+                    )
+                except Exception:
+                    # The two uploads are not atomic. Without this the main
+                    # image stays in the bucket forever while the caller gets a
+                    # 500 and no record of the URL — an orphan nothing will ever
+                    # reference or clean up. Roll it back, but never let the
+                    # cleanup failure mask the upload failure.
+                    try:
+                        await self.cloud_storage.delete_image(image_url)
+                    except Exception:
+                        logger.error(
+                            "Failed to roll back orphaned cover image %s",
+                            image_url,
+                            exc_info=True,
+                        )
+                    raise
             else:
                 # _process_cover_sync already wrote both files.
                 image_url = f"/uploads/cover_images/{unique_filename}"

--- a/backend/app/services/file_upload_service.py
+++ b/backend/app/services/file_upload_service.py
@@ -3,6 +3,7 @@ File upload service for handling book cover images and other file uploads.
 Currently uses local storage, but designed to be easily extended for cloud storage (S3, Cloudinary, etc.)
 """
 
+import asyncio
 import uuid
 from pathlib import Path
 from typing import Optional, Tuple
@@ -65,6 +66,102 @@ def _resolve_local_profile_path(image_url: str) -> Optional[Path]:
     return _resolve_local_path(image_url, PROFILE_IMAGE_URL_PREFIX, PROFILE_PICTURES_DIR)
 
 
+# --- Blocking PIL work, isolated so it can be pushed off the event loop (#346).
+#
+# Decode, LANCZOS resize and save(optimize=True) are CPU-bound and were running
+# inline in `async def`, freezing the loop — on a 2-worker deploy a couple of
+# concurrent uploads stalled health checks and every other request on the
+# worker. Same blocking-in-async class #175 fixed for OpenAI and #345 for
+# exports. Each helper below is synchronous and must be called via
+# `asyncio.to_thread`; the caller awaits it, so the file object is never
+# touched by two threads at once.
+#
+# These go to the loop's DEFAULT executor rather than a dedicated pool like
+# exports got in #345. Uploads are mostly network wait (S3/Cloudinary) with a
+# short encode, which is what that pool is sized for; exports are long,
+# CPU-bound and bursty, which is why they needed isolating.
+
+
+def _validate_image_sync(fileobj) -> Tuple[bool, Optional[str]]:
+    """Decode-verify an upload and reject decompression bombs. Blocking."""
+    try:
+        fileobj.seek(0)
+        image = Image.open(fileobj)
+        width, height = image.size
+        image.verify()
+        fileobj.seek(0)  # Reset after verify
+    except Exception:
+        return False, "Invalid image file"
+
+    if width * height > MAX_IMAGE_PIXELS:
+        return False, "Image dimensions too large"
+
+    return True, None
+
+
+def _prepare_image(fileobj, file_ext: str):
+    """Open an upload and normalise it to RGB when the target format needs it."""
+    fileobj.seek(0)
+    image = Image.open(fileobj)
+    if image.mode in ('RGBA', 'LA', 'P'):
+        rgb_image = Image.new('RGB', image.size, (255, 255, 255))
+        rgb_image.paste(image, mask=image.split()[-1] if image.mode == 'RGBA' else None)
+        image = rgb_image
+    return image
+
+
+def _process_cover_sync(fileobj, file_ext: str, image_path: Path,
+                        thumbnail_path: Path, to_cloud: bool):
+    """Build a cover image + thumbnail. Blocking; call via asyncio.to_thread.
+
+    Returns ``(main_bytes, thumb_bytes, image_format)``. For the local path the
+    files are written here and the two byte payloads come back ``None``.
+    """
+    image = _prepare_image(fileobj, file_ext)
+
+    if image.width > MAX_IMAGE_WIDTH or image.height > MAX_IMAGE_HEIGHT:
+        image.thumbnail((MAX_IMAGE_WIDTH, MAX_IMAGE_HEIGHT), Image.Resampling.LANCZOS)
+
+    thumbnail = image.copy()
+    thumbnail.thumbnail(THUMBNAIL_SIZE, Image.Resampling.LANCZOS)
+
+    image_format = 'JPEG' if file_ext in ['.jpg', '.jpeg'] else 'PNG'
+
+    if to_cloud:
+        main_buffer = BytesIO()
+        thumb_buffer = BytesIO()
+        image.save(main_buffer, format=image_format, quality=85, optimize=True)
+        thumbnail.save(thumb_buffer, format=image_format, quality=85, optimize=True)
+        main_buffer.seek(0)
+        thumb_buffer.seek(0)
+        return main_buffer.read(), thumb_buffer.read(), image_format
+
+    image.save(image_path, quality=85, optimize=True)
+    thumbnail.save(thumbnail_path, quality=85, optimize=True)
+    return None, None, image_format
+
+
+def _process_profile_sync(fileobj, file_ext: str, image_path: Path, to_cloud: bool):
+    """Build an avatar downscaled to fit PROFILE_PICTURE_SIZE. Blocking.
+
+    Returns ``(image_bytes, image_format)``; ``image_bytes`` is ``None`` on the
+    local path, where the file is written here.
+    """
+    image = _prepare_image(fileobj, file_ext)
+    image.thumbnail(PROFILE_PICTURE_SIZE, Image.Resampling.LANCZOS)
+
+    image_format = 'JPEG' if file_ext in ['.jpg', '.jpeg'] else 'PNG'
+
+    if to_cloud:
+        buffer = BytesIO()
+        image.save(buffer, format=image_format, quality=85, optimize=True)
+        buffer.seek(0)
+        return buffer.read(), image_format
+
+    image.save(image_path, quality=85, optimize=True)
+    return None, image_format
+
+
 class FileUploadService:
     """Service for handling file uploads with validation and storage."""
 
@@ -107,20 +204,9 @@ class FileUploadService:
             return False, f"File too large. Maximum size: {MAX_FILE_SIZE // (1024*1024)}MB"
 
         # Validate it's actually an image, and guard against decompression bombs
-        # (a small file that decodes to enormous dimensions).
-        try:
-            file.file.seek(0)
-            image = Image.open(file.file)
-            width, height = image.size
-            image.verify()
-            file.file.seek(0)  # Reset after verify
-        except Exception:
-            return False, "Invalid image file"
-
-        if width * height > MAX_IMAGE_PIXELS:
-            return False, "Image dimensions too large"
-
-        return True, None
+        # (a small file that decodes to enormous dimensions). PIL work is
+        # blocking, so it goes to a worker thread (#346).
+        return await asyncio.to_thread(_validate_image_sync, file.file)
 
     async def process_and_save_cover_image(
         self,
@@ -151,58 +237,34 @@ class FileUploadService:
         thumbnail_path = COVER_IMAGES_DIR / thumbnail_filename
 
         try:
-            # Save and process the main image
-            file.file.seek(0)
-            image = Image.open(file.file)
-
-            # Convert RGBA to RGB if necessary (for JPEG)
-            if image.mode in ('RGBA', 'LA', 'P'):
-                rgb_image = Image.new('RGB', image.size, (255, 255, 255))
-                rgb_image.paste(image, mask=image.split()[-1] if image.mode == 'RGBA' else None)
-                image = rgb_image
-
-            # Resize if too large
-            if image.width > MAX_IMAGE_WIDTH or image.height > MAX_IMAGE_HEIGHT:
-                image.thumbnail((MAX_IMAGE_WIDTH, MAX_IMAGE_HEIGHT), Image.Resampling.LANCZOS)
-
-            # Create thumbnail
-            thumbnail = image.copy()
-            thumbnail.thumbnail(THUMBNAIL_SIZE, Image.Resampling.LANCZOS)
+            # All decode/resize/encode work happens on a worker thread so the
+            # event loop stays free to serve other requests (#346).
+            main_bytes, thumb_bytes, image_format = await asyncio.to_thread(
+                _process_cover_sync,
+                file.file,
+                file_ext,
+                image_path,
+                thumbnail_path,
+                bool(self.cloud_storage),
+            )
 
             if self.cloud_storage:
-                # Upload to cloud storage
-                # Convert images to bytes
-                main_buffer = BytesIO()
-                thumb_buffer = BytesIO()
-
-                image_format = 'JPEG' if file_ext in ['.jpg', '.jpeg'] else 'PNG'
-                image.save(main_buffer, format=image_format, quality=85, optimize=True)
-                thumbnail.save(thumb_buffer, format=image_format, quality=85, optimize=True)
-
-                main_buffer.seek(0)
-                thumb_buffer.seek(0)
-
-                # Upload both images
                 content_type = f"image/{image_format.lower()}"
                 image_url = await self.cloud_storage.upload_image(
-                    file_data=main_buffer.read(),
+                    file_data=main_bytes,
                     filename=unique_filename,
                     content_type=content_type,
                     folder=f"cover_images/{book_id}"
                 )
 
                 thumbnail_url = await self.cloud_storage.upload_image(
-                    file_data=thumb_buffer.read(),
+                    file_data=thumb_bytes,
                     filename=thumbnail_filename,
                     content_type=content_type,
                     folder=f"cover_images/{book_id}/thumbnails"
                 )
             else:
-                # Save to local storage
-                image.save(image_path, quality=85, optimize=True)
-                thumbnail.save(thumbnail_path, quality=85, optimize=True)
-
-                # Return local URLs
+                # _process_cover_sync already wrote both files.
                 image_url = f"/uploads/cover_images/{unique_filename}"
                 thumbnail_url = f"/uploads/cover_images/{thumbnail_filename}"
 
@@ -268,31 +330,24 @@ class FileUploadService:
         image_path = PROFILE_PICTURES_DIR / unique_filename
 
         try:
-            file.file.seek(0)
-            image = Image.open(file.file)
-
-            # Convert to RGB if necessary (for JPEG)
-            if image.mode in ('RGBA', 'LA', 'P'):
-                rgb_image = Image.new('RGB', image.size, (255, 255, 255))
-                rgb_image.paste(image, mask=image.split()[-1] if image.mode == 'RGBA' else None)
-                image = rgb_image
-
-            # Downscale to at most 400x400, preserving aspect ratio
-            image.thumbnail(PROFILE_PICTURE_SIZE, Image.Resampling.LANCZOS)
+            # Blocking PIL work goes to a worker thread (#346).
+            image_bytes, image_format = await asyncio.to_thread(
+                _process_profile_sync,
+                file.file,
+                file_ext,
+                image_path,
+                bool(self.cloud_storage),
+            )
 
             if self.cloud_storage:
-                buffer = BytesIO()
-                image_format = 'JPEG' if file_ext in ['.jpg', '.jpeg'] else 'PNG'
-                image.save(buffer, format=image_format, quality=85, optimize=True)
-                buffer.seek(0)
                 return await self.cloud_storage.upload_image(
-                    file_data=buffer.read(),
+                    file_data=image_bytes,
                     filename=unique_filename,
                     content_type=f"image/{image_format.lower()}",
                     folder=f"profile_pictures/{user_id}",
                 )
 
-            image.save(image_path, quality=85, optimize=True)
+            # _process_profile_sync already wrote the file.
             return f"{PROFILE_IMAGE_URL_PREFIX}{unique_filename}"
 
         except Exception:

--- a/backend/tests/test_services/test_upload_async_offload.py
+++ b/backend/tests/test_services/test_upload_async_offload.py
@@ -1,0 +1,210 @@
+"""#346: image processing and cloud SDK calls must not block the event loop.
+
+``process_and_save_*`` ran PIL decode/LANCZOS-resize/``save(optimize=True)``
+straight inside ``async def``, and ``cloud_storage_service`` called synchronous
+boto3/Cloudinary SDKs the same way. On a 2-worker deploy a couple of concurrent
+uploads (multi-second S3 round-trip plus a PIL encode) stalled health checks and
+every other request on that worker.
+
+These tests assert the *event loop stayed responsive* while the blocking work
+ran. Asserting only on the returned URL would pass identically before and after
+the fix — the whole defect is that the loop froze, not that the result was
+wrong.
+"""
+import asyncio
+import time
+from io import BytesIO
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi import UploadFile
+from PIL import Image
+
+from app.services import file_upload_service as fus
+from app.services.file_upload_service import FileUploadService
+
+
+def _make_upload(name="cover.jpg", ctype="image/jpeg", size=(600, 900)):
+    img = Image.new("RGB", size, color="red")
+    buf = BytesIO()
+    img.save(buf, format="JPEG")
+    buf.seek(0)
+    mock = Mock(spec=UploadFile)
+    mock.filename = name
+    mock.content_type = ctype
+    mock.file = buf
+    return mock
+
+
+async def _count_ticks_while(coro, tick=0.005):
+    """Run ``coro`` while a heartbeat counts loop iterations.
+
+    If the awaited work blocks the loop, the heartbeat never gets scheduled and
+    the count stays at 0. That count is the assertion.
+    """
+    ticks = 0
+
+    async def heartbeat():
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(tick)
+            ticks += 1
+
+    beat = asyncio.create_task(heartbeat())
+    try:
+        result = await coro
+    finally:
+        beat.cancel()
+        try:
+            await beat
+        except asyncio.CancelledError:
+            pass
+    return result, ticks
+
+
+BLOCKING_SECONDS = 0.15
+
+
+class TestImageProcessingOffload:
+    @pytest.mark.asyncio
+    async def test_cover_processing_keeps_the_loop_responsive(self, tmp_path):
+        """A slow PIL encode must not freeze the loop."""
+        service = FileUploadService()
+        service.cloud_storage = None
+
+        real = fus._process_cover_sync
+
+        def slow(*args, **kwargs):
+            time.sleep(BLOCKING_SECONDS)  # stand-in for a large LANCZOS + encode
+            return real(*args, **kwargs)
+
+        with patch.object(fus, "_process_cover_sync", side_effect=slow):
+            with patch.object(fus, "COVER_IMAGES_DIR", tmp_path):
+                (_, ticks) = await _count_ticks_while(
+                    service.process_and_save_cover_image(_make_upload(), "book1")
+                )
+
+        assert ticks > 0, (
+            "the event loop was blocked for the whole encode — health checks and "
+            "every other request on this worker would have stalled (#346)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_profile_processing_keeps_the_loop_responsive(self, tmp_path):
+        service = FileUploadService()
+        service.cloud_storage = None
+
+        real = fus._process_profile_sync
+
+        def slow(*args, **kwargs):
+            time.sleep(BLOCKING_SECONDS)
+            return real(*args, **kwargs)
+
+        with patch.object(fus, "_process_profile_sync", side_effect=slow):
+            with patch.object(fus, "PROFILE_PICTURES_DIR", tmp_path):
+                (_, ticks) = await _count_ticks_while(
+                    service.process_and_save_profile_picture(_make_upload(), "user1")
+                )
+
+        assert ticks > 0
+
+    @pytest.mark.asyncio
+    async def test_validation_keeps_the_loop_responsive(self):
+        """Validation decodes the image too — same blocking class."""
+        service = FileUploadService()
+        real = fus._validate_image_sync
+
+        def slow(*args, **kwargs):
+            time.sleep(BLOCKING_SECONDS)
+            return real(*args, **kwargs)
+
+        with patch.object(fus, "_validate_image_sync", side_effect=slow):
+            ((ok, _), ticks) = await _count_ticks_while(
+                service.validate_image_upload(_make_upload())
+            )
+
+        assert ok is True
+        assert ticks > 0
+
+
+class TestCloudStorageOffload:
+    @pytest.mark.asyncio
+    async def test_s3_upload_keeps_the_loop_responsive(self):
+        """boto3 is synchronous; a multi-second S3 round-trip must not freeze the loop."""
+        from app.services.cloud_storage_service import S3StorageService
+
+        service = S3StorageService.__new__(S3StorageService)
+        service.bucket_name = "b"
+        service.region = "us-east-1"
+        service.ClientError = Exception
+        service.s3_client = Mock()
+        service.s3_client.put_object = Mock(
+            side_effect=lambda **kw: time.sleep(BLOCKING_SECONDS)
+        )
+
+        (url, ticks) = await _count_ticks_while(
+            service.upload_image(b"data", "a.jpg", "image/jpeg")
+        )
+
+        assert url.startswith("https://b.s3.us-east-1.amazonaws.com/")
+        assert ticks > 0, "the S3 round-trip blocked the event loop (#346)"
+
+    @pytest.mark.asyncio
+    async def test_s3_delete_keeps_the_loop_responsive(self):
+        from app.services.cloud_storage_service import S3StorageService
+
+        service = S3StorageService.__new__(S3StorageService)
+        service.bucket_name = "b"
+        service.region = "us-east-1"
+        service.ClientError = Exception
+        service.s3_client = Mock()
+        service.s3_client.delete_object = Mock(
+            side_effect=lambda **kw: time.sleep(BLOCKING_SECONDS)
+        )
+
+        url = "https://b.s3.us-east-1.amazonaws.com/cover_images/x.jpg"
+        (ok, ticks) = await _count_ticks_while(service.delete_image(url))
+
+        assert ok is True
+        assert ticks > 0
+
+    @pytest.mark.asyncio
+    async def test_cloudinary_upload_keeps_the_loop_responsive(self):
+        from app.services.cloud_storage_service import CloudinaryStorageService
+
+        service = CloudinaryStorageService.__new__(CloudinaryStorageService)
+        uploader = Mock()
+
+        def slow_upload(*a, **kw):
+            time.sleep(BLOCKING_SECONDS)
+            return {"secure_url": "https://res.cloudinary.com/x/image/upload/v1/a.jpg"}
+
+        uploader.upload = Mock(side_effect=slow_upload)
+        service.cloudinary_uploader = uploader
+
+        (url, ticks) = await _count_ticks_while(
+            service.upload_image(b"data", "a.jpg", "image/jpeg")
+        )
+
+        assert url.endswith("a.jpg")
+        assert ticks > 0
+
+    @pytest.mark.asyncio
+    async def test_cloudinary_destroy_keeps_the_loop_responsive(self):
+        from app.services.cloud_storage_service import CloudinaryStorageService
+
+        service = CloudinaryStorageService.__new__(CloudinaryStorageService)
+        uploader = Mock()
+
+        def slow_destroy(*a, **kw):
+            time.sleep(BLOCKING_SECONDS)
+            return {"result": "ok"}
+
+        uploader.destroy = Mock(side_effect=slow_destroy)
+        service.cloudinary_uploader = uploader
+
+        url = "https://res.cloudinary.com/demo/image/upload/v1234/cover_images/a.jpg"
+        (ok, ticks) = await _count_ticks_while(service.delete_image(url))
+
+        assert ok is True
+        assert ticks > 0

--- a/backend/tests/test_services/test_upload_async_offload.py
+++ b/backend/tests/test_services/test_upload_async_offload.py
@@ -208,3 +208,50 @@ class TestCloudStorageOffload:
 
         assert ok is True
         assert ticks > 0
+
+
+class TestCoverUploadRollback:
+    """A failed thumbnail upload must not orphan the main image.
+
+    The two uploads are sequential and not atomic. Pre-existing gap, fixed here
+    because #346 rewrote this exact block: without a rollback the main image
+    stays in the bucket forever while the caller gets a 500 and never learns
+    the URL, so nothing will ever reference or clean it up.
+    """
+
+    @pytest.mark.asyncio
+    async def test_main_image_is_deleted_when_the_thumbnail_upload_fails(self):
+        from unittest.mock import AsyncMock
+
+        service = FileUploadService()
+        cloud = Mock()
+        cloud.upload_image = AsyncMock(
+            side_effect=["https://cdn/main.jpg", RuntimeError("S3 exploded")]
+        )
+        cloud.delete_image = AsyncMock(return_value=True)
+        service.cloud_storage = cloud
+
+        with pytest.raises(Exception):
+            await service.process_and_save_cover_image(_make_upload(), "book1")
+
+        cloud.delete_image.assert_awaited_once_with("https://cdn/main.jpg")
+
+    @pytest.mark.asyncio
+    async def test_rollback_failure_does_not_mask_the_upload_failure(self):
+        """If cleanup also fails, the caller must still see the original error."""
+        from unittest.mock import AsyncMock
+
+        service = FileUploadService()
+        cloud = Mock()
+        cloud.upload_image = AsyncMock(
+            side_effect=["https://cdn/main.jpg", RuntimeError("S3 exploded")]
+        )
+        cloud.delete_image = AsyncMock(side_effect=RuntimeError("delete also failed"))
+        service.cloud_storage = cloud
+
+        with pytest.raises(Exception) as exc:
+            await service.process_and_save_cover_image(_make_upload(), "book1")
+
+        # The handler converts to a 500; what matters is that the delete failure
+        # did not replace or swallow the real cause.
+        assert "delete also failed" not in str(exc.value)


### PR DESCRIPTION
Closes #346.

## Problem

`process_and_save_cover_image`, `process_and_save_profile_picture` and `validate_image_upload` ran PIL decode / LANCZOS resize / `save(optimize=True)` inline inside `async def`, and `cloud_storage_service` called synchronous boto3 `put_object`/`delete_object` and Cloudinary `upload`/`destroy` the same way. Nothing yields, so on a 2-worker deploy a couple of concurrent uploads — a multi-second S3 round-trip plus an encode — stalled health checks and every other request on that worker. Same blocking-in-async class #175 fixed for OpenAI and #345 for exports.

## Fix

Blocking PIL work is extracted into module-level sync helpers (`_validate_image_sync`, `_process_cover_sync`, `_process_profile_sync`) invoked via `asyncio.to_thread` — mirroring `export_service`'s existing sync `_build_*` / async-wrapper split. They take the file object rather than bytes, and the caller awaits, so it's never touched by two threads at once. The four cloud SDK calls are wrapped directly.

`validate_image_upload` was not named in the issue but decodes the image too, so it had the same defect.

## Why the default executor here, when #345 gave exports their own pool

Deliberate, not an oversight — and worth stating since I just argued the opposite two PRs ago.

Exports are long, CPU-bound and bursty, with a 120s budget; a handful can occupy the shared pool and starve `ai_service`, which is why they needed isolating. Uploads are mostly **network wait** with a short encode, capped at 5MB by `MAX_FILE_SIZE`. That's precisely the workload the default pool (`min(32, cpu+4)`) is sized for, and a third pool would be config surface bought with speculation. If upload volume ever changes that calculus, #345's pattern is the ready-made escalation.

## Tests assert the loop stayed alive, not that the URL was right

A heartbeat task counts loop iterations while the blocking work runs; the count is the assertion:

```python
assert ticks > 0, "the event loop was blocked for the whole encode ..."
```

Checking the returned URL would pass identically before and after — the defect was never a wrong result, only a frozen loop.

**Mutation check** — reverting each offload individually drops the heartbeat to 0 and turns exactly the matching test red:

```
FAILED ... test_cover_processing_keeps_the_loop_responsive
FAILED ... test_validation_keeps_the_loop_responsive
FAILED ... test_s3_upload_keeps_the_loop_responsive
```

Seven tests cover: cover processing, profile processing, validation, S3 upload, S3 delete, Cloudinary upload, Cloudinary destroy.

## Bonus fix from review: orphaned cover images

CodeRabbit flagged that a failed **thumbnail** upload leaves the already-uploaded **main** image in the bucket. Verified pre-existing — `main` has the same two sequential uploads with no rollback — but it lives in the exact block this PR rewrote, so it's fixed here rather than filed: the caller gets a 500 and never learns the URL, so nothing would ever reference or clean that object up.

The rollback is itself wrapped, so a failing delete is logged and never replaces the upload error the caller actually needs to see. Two tests cover both paths.

## Verification

| Check | Result |
|-------|--------|
| New offload + rollback tests | 9 passed |
| Pre-existing upload/storage tests | 50 passed, unchanged |
| Full backend suite | **1210 passed**, 11 skipped, 0 failed |
| `ruff --select F821` | clean |
| `ruff --select F401` | 3 findings, all identical on `main` (pre-existing unused imports) |
| Mutation check | each reverted offload fails its test ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)