### PR TITLE
fix(voice): release the mic on unmount, stop advertising unsupported dictation, humanize errors (#348)

### DIFF
--- a/frontend/src/__tests__/components/VoiceTextInput.test.tsx
+++ b/frontend/src/__tests__/components/VoiceTextInput.test.tsx
@@ -135,10 +135,16 @@ describe('VoiceTextInput Component', () => {
       // Wait for recognition to start
       expect(mockRecognition.start).toHaveBeenCalled();
 
-      // Wait for error to appear
+      // A real failure still surfaces — but as actionable copy, not the raw
+      // code. #348 replaced "Error recording audio: network" because echoing the
+      // API's code tells the user nothing about what to do. getAllByText because
+      // the message renders in both the banner and the sr-only live region.
       await waitFor(() => {
-        expect(screen.getByText('Error recording audio: network')).toBeInTheDocument();
+        expect(
+          screen.getAllByText(/needs an internet connection/i).length
+        ).toBeGreaterThan(0);
       }, { timeout: 2000 });
+      expect(screen.queryByText(/Error recording audio/i)).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/app/dashboard/books/[bookId]/summary/page.tsx
+++ b/frontend/src/app/dashboard/books/[bookId]/summary/page.tsx
@@ -11,6 +11,11 @@ import {
   countSummaryCharacters,
   getSummaryReadinessError,
 } from '@/lib/constants/summary-readiness';
+import {
+  describeSpeechError,
+  isSpeechRecognitionSupported,
+  SPEECH_UNSUPPORTED_MESSAGE,
+} from '@/lib/voice/speechRecognitionErrors';
 
 export default function BookSummaryPage() {
   const router = useRouter();
@@ -20,6 +25,12 @@ export default function BookSummaryPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [isListening, setIsListening] = useState(false);
   const [error, setError] = useState('');
+  // Advertised capability must match reality: this button used to render enabled
+  // in Firefox/Safari and over plain HTTP, and only failed on click (#348).
+  const [voiceSupported, setVoiceSupported] = useState(false);
+  // Interim results were thrown away, so nothing showed until a phrase
+  // finalised and the surface looked frozen while listening.
+  const [interimTranscript, setInterimTranscript] = useState('');
   const saveTimeout = useRef<NodeJS.Timeout | null>(null);
   const lastSaved = useRef('');
   const [summaryHistory, setSummaryHistory] = useState<unknown[]>([]);
@@ -76,11 +87,35 @@ export default function BookSummaryPage() {
   // Speech recognition setup
   const recognitionRef = useRef<SpeechRecognition | null>(null);
 
+  useEffect(() => {
+    setVoiceSupported(isSpeechRecognitionSupported());
+  }, []);
+
+  // Release the microphone if this page unmounts mid-dictation (#348).
+  // Handlers are detached first so stop()'s onend cannot setState after unmount.
+  useEffect(() => {
+    return () => {
+      const recognition = recognitionRef.current;
+      if (!recognition) {
+        return;
+      }
+      recognition.onresult = null;
+      recognition.onerror = null;
+      recognition.onend = null;
+      try {
+        recognition.stop();
+      } catch {
+        // Already stopped — nothing to release.
+      }
+      recognitionRef.current = null;
+    };
+  }, []);
+
   const startListening = () => {
     const SpeechRecognitionCtor =
       (window.SpeechRecognition || window.webkitSpeechRecognition) as typeof SpeechRecognition | undefined;
-    if (!SpeechRecognitionCtor) {
-      setError('Speech recognition is not supported in your browser.');
+    if (!voiceSupported || !SpeechRecognitionCtor) {
+      setError(SPEECH_UNSUPPORTED_MESSAGE);
       return;
     }
     setError('');
@@ -91,21 +126,34 @@ export default function BookSummaryPage() {
     recognition.lang = 'en-US';
     recognition.onresult = (event: SpeechRecognitionEvent) => {
       let transcript = '';
+      let interim = '';
       for (let i = event.resultIndex; i < event.results.length; ++i) {
         if (event.results[i].isFinal) {
           transcript += event.results[i][0].transcript;
+        } else {
+          // Surface in-progress speech so the page shows something while
+          // listening instead of appearing frozen until a phrase finalises.
+          interim += event.results[i][0].transcript;
         }
       }
+      setInterimTranscript(interim);
       if (transcript) {
         setSummary(prev => (prev ? prev + ' ' : '') + transcript.trim());
       }
     };
     recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
-      setError('Error occurred in recognition: ' + event.error);
+      // Benign codes (no-speech/aborted) end the session silently; the rest get
+      // actionable copy rather than the raw code (#348).
+      const message = describeSpeechError(event.error);
+      if (message) {
+        setError(message);
+      }
       setIsListening(false);
+      setInterimTranscript('');
     };
     recognition.onend = () => {
       setIsListening(false);
+      setInterimTranscript('');
     };
     recognitionRef.current = recognition;
     recognition.start();
@@ -119,6 +167,7 @@ export default function BookSummaryPage() {
       recognitionRef.current.stop();
       recognitionRef.current = null;
     }
+    setInterimTranscript('');
     setIsListening(false);
   };
 
@@ -159,8 +208,13 @@ export default function BookSummaryPage() {
           Describe your book's main concepts and structure. This summary will be used to generate a Table of Contents.
         </p>
       </div>
+      {/* role="alert" so a screen reader announces a dictation failure instead of
+          leaving it silently on screen (#348). */}
       {error && (
-        <div className="p-4 mb-6 rounded-lg bg-red-900/20 border border-red-700 text-red-400">
+        <div
+          role="alert"
+          className="p-4 mb-6 rounded-lg bg-red-900/20 border border-red-700 text-red-400"
+        >
           {error}
         </div>
       )}
@@ -170,26 +224,34 @@ export default function BookSummaryPage() {
             <div className="flex justify-between items-center mb-2">
               <label className="text-muted-foreground" htmlFor="summary">Book Summary</label>
               <div className="flex gap-2">
-                <button
-                  type="button"
-                  onClick={startListening}
-                  disabled={isListening}
-                  className={`px-3 py-1 rounded-md text-sm ${
-                    isListening
-                      ? 'bg-red-600 text-white'
-                      : 'bg-secondary hover:bg-secondary/80 text-secondary-foreground'
-                  }`}
-                >
-                  {isListening ? 'Listening...' : '🎤 Voice Input'}
-                </button>
-                {isListening && (
-                  <button
-                    type="button"
-                    onClick={stopListening}
-                    className="px-3 py-1 rounded-md text-sm bg-secondary hover:bg-secondary/80 text-secondary-foreground border border-border"
-                  >
-                    Stop
-                  </button>
+                {/* Only offered where it can actually work — previously this
+                    rendered enabled in Firefox/Safari and over plain HTTP, and
+                    failed only once clicked (#348). */}
+                {voiceSupported && (
+                  <>
+                    <button
+                      type="button"
+                      onClick={startListening}
+                      disabled={isListening}
+                      aria-pressed={isListening}
+                      className={`px-3 py-1 rounded-md text-sm ${
+                        isListening
+                          ? 'bg-red-600 text-white'
+                          : 'bg-secondary hover:bg-secondary/80 text-secondary-foreground'
+                      }`}
+                    >
+                      {isListening ? 'Listening...' : '🎤 Voice Input'}
+                    </button>
+                    {isListening && (
+                      <button
+                        type="button"
+                        onClick={stopListening}
+                        className="px-3 py-1 rounded-md text-sm bg-secondary hover:bg-secondary/80 text-secondary-foreground border border-border"
+                      >
+                        Stop
+                      </button>
+                    )}
+                  </>
                 )}
               </div>
             </div>
@@ -202,6 +264,31 @@ export default function BookSummaryPage() {
               placeholder="Describe your book's main concepts, structure, and key points that should be organized into chapters..."
               required
             ></textarea>
+
+            {/* Dictation status, announced politely. A voice-only affordance with
+                no live region gives a screen-reader user no way to know whether
+                the mic is live (#348) — mirrors VoiceTextInput. */}
+            <div role="status" aria-live="polite" className="sr-only">
+              {isListening ? 'Recording started - speak now' : ''}
+            </div>
+
+            {/* In-progress speech, so the page visibly responds while listening
+                instead of staying blank until a phrase finalises. */}
+            {isListening && interimTranscript && (
+              <div
+                className="mt-2 text-sm italic text-muted-foreground"
+                data-testid="summary-interim-transcript"
+              >
+                {interimTranscript}
+              </div>
+            )}
+
+            {!voiceSupported && (
+              <div className="mt-2 text-xs text-muted-foreground">
+                {SPEECH_UNSUPPORTED_MESSAGE}
+              </div>
+            )}
+
             <div className="flex justify-between text-xs text-muted-foreground mt-1">
               <span>{countSummaryWords(summary)} / {SUMMARY_MIN_WORDS} words</span>
               <span>{countSummaryCharacters(summary)} / {SUMMARY_MIN_CHARACTERS} characters</span>

--- a/frontend/src/components/chapters/VoiceTextInput.tsx
+++ b/frontend/src/components/chapters/VoiceTextInput.tsx
@@ -111,6 +111,13 @@ export function VoiceTextInput({
   // stop() fires onend, which would otherwise call setState on an unmounted
   // component.
   useEffect(() => {
+    // Reset on every mount, not just the first. StrictMode double-invokes
+    // effects in development (mount → cleanup → mount), so a flag only ever set
+    // to true latches after that first cleanup — and startRecording's
+    // unmounted-guard would then abort every recording for the rest of the
+    // session. The component is very much mounted here.
+    unmountedRef.current = false;
+
     return () => {
       unmountedRef.current = true;
       const recognition = recognitionRef.current;

--- a/frontend/src/components/chapters/VoiceTextInput.tsx
+++ b/frontend/src/components/chapters/VoiceTextInput.tsx
@@ -327,6 +327,13 @@ export function VoiceTextInput({
       console.error('Failed to start recording:', err);
       setError('Failed to access microphone. Please check permissions.');
       releaseMicStream();
+      // The handle is assigned just before start(), so a throw from start()
+      // lands here with a dead recognizer still stored — and no onend/onerror
+      // will fire to clear it. Left behind, the guard above would brick every
+      // later Start. This is the last writer of recognitionRef without a
+      // clearer; all five exits now release both the stream and the handle.
+      recognitionRef.current = null;
+      setIsRecording(false);
     } finally {
       startingRef.current = false;
     }

--- a/frontend/src/components/chapters/VoiceTextInput.tsx
+++ b/frontend/src/components/chapters/VoiceTextInput.tsx
@@ -136,6 +136,26 @@ export function VoiceTextInput({
     setCurrentMode(mode);
   }, [mode]);
 
+  // Every path that ends a dictation session must run this, not just the ones
+  // the user drives. Recognition can end on its own (onend) or fail (onerror),
+  // and neither releases the getUserMedia tracks that actually hold the
+  // microphone — so leaving either out keeps the recording indicator lit with no
+  // control left to turn it off (#348).
+  const releaseMicStream = useCallback(() => {
+    const stream = micStreamRef.current;
+    if (!stream) {
+      return;
+    }
+    stream.getTracks().forEach((track) => {
+      try {
+        track.stop();
+      } catch {
+        // Already ended.
+      }
+    });
+    micStreamRef.current = null;
+  }, []);
+
   // Initialize speech recognition
   const initializeSpeechRecognition = useCallback(() => {
     if (!isSupported) return null;
@@ -215,16 +235,20 @@ export function VoiceTextInput({
         console.error('Speech recognition error:', code);
         setError(message);
       }
+      releaseMicStream();
       setIsRecording(false);
     };
 
     recognition.onend = () => {
+      // Recognition can end without the user asking — a service timeout, or the
+      // browser deciding the utterance finished. The mic must go with it.
+      releaseMicStream();
       setIsRecording(false);
       setInterimTranscript('');
     };
 
     return recognition;
-  }, [isSupported, onChange]);
+  }, [isSupported, onChange, releaseMicStream]);
 
   const toggleMode = () => {
     const newMode = currentMode === 'text' ? 'voice' : 'text';
@@ -246,8 +270,11 @@ export function VoiceTextInput({
     }
 
     try {
-      // Request microphone permission, keeping the stream so its tracks can be
-      // released again (see micStreamRef).
+      // Release any stream still held from a previous attempt before acquiring
+      // another; overwriting the ref would orphan the old tracks for the page's
+      // lifetime with no handle left to stop them.
+      releaseMicStream();
+      // Keep the stream so its tracks can be released again (see micStreamRef).
       micStreamRef.current = await navigator.mediaDevices.getUserMedia({ audio: true });
 
       setError(null);
@@ -260,21 +287,6 @@ export function VoiceTextInput({
       console.error('Failed to start recording:', err);
       setError('Failed to access microphone. Please check permissions.');
     }
-  };
-
-  const releaseMicStream = () => {
-    const stream = micStreamRef.current;
-    if (!stream) {
-      return;
-    }
-    stream.getTracks().forEach((track) => {
-      try {
-        track.stop();
-      } catch {
-        // Already ended.
-      }
-    });
-    micStreamRef.current = null;
   };
 
   const stopRecording = () => {

--- a/frontend/src/components/chapters/VoiceTextInput.tsx
+++ b/frontend/src/components/chapters/VoiceTextInput.tsx
@@ -71,6 +71,12 @@ export function VoiceTextInput({
   const [isSupported, setIsSupported] = useState(false);
 
   const recognitionRef = useRef<SpeechRecognition | null>(null);
+  // getUserMedia hands back a live MediaStream. Its tracks keep the microphone
+  // open — and the browser's recording indicator lit — until something calls
+  // stop() on each one; recognition.stop() does not do it. The stream used to be
+  // requested and thrown away, so the mic stayed live for the life of the page,
+  // even after the user pressed Stop (#348).
+  const micStreamRef = useRef<MediaStream | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   // Mirror the latest `value` prop so the long-lived onresult handler reads the
@@ -98,18 +104,30 @@ export function VoiceTextInput({
   useEffect(() => {
     return () => {
       const recognition = recognitionRef.current;
-      if (!recognition) {
-        return;
+      if (recognition) {
+        recognition.onresult = null;
+        recognition.onerror = null;
+        recognition.onend = null;
+        try {
+          recognition.stop();
+        } catch {
+          // Already stopped/destroyed — nothing to release.
+        }
+        recognitionRef.current = null;
       }
-      recognition.onresult = null;
-      recognition.onerror = null;
-      recognition.onend = null;
-      try {
-        recognition.stop();
-      } catch {
-        // Already stopped/destroyed — nothing to release.
+      // Stopping recognition is not enough on its own — the getUserMedia tracks
+      // are what hold the microphone open.
+      const stream = micStreamRef.current;
+      if (stream) {
+        stream.getTracks().forEach((track) => {
+          try {
+            track.stop();
+          } catch {
+            // Already ended.
+          }
+        });
+        micStreamRef.current = null;
       }
-      recognitionRef.current = null;
     };
   }, []);
 
@@ -228,8 +246,9 @@ export function VoiceTextInput({
     }
 
     try {
-      // Request microphone permission
-      await navigator.mediaDevices.getUserMedia({ audio: true });
+      // Request microphone permission, keeping the stream so its tracks can be
+      // released again (see micStreamRef).
+      micStreamRef.current = await navigator.mediaDevices.getUserMedia({ audio: true });
 
       setError(null);
       const recognition = initializeSpeechRecognition();
@@ -243,11 +262,27 @@ export function VoiceTextInput({
     }
   };
 
+  const releaseMicStream = () => {
+    const stream = micStreamRef.current;
+    if (!stream) {
+      return;
+    }
+    stream.getTracks().forEach((track) => {
+      try {
+        track.stop();
+      } catch {
+        // Already ended.
+      }
+    });
+    micStreamRef.current = null;
+  };
+
   const stopRecording = () => {
     if (recognitionRef.current) {
       recognitionRef.current.stop();
       recognitionRef.current = null;
     }
+    releaseMicStream();
     setIsRecording(false);
     setInterimTranscript('');
   };

--- a/frontend/src/components/chapters/VoiceTextInput.tsx
+++ b/frontend/src/components/chapters/VoiceTextInput.tsx
@@ -10,6 +10,10 @@ import {
   Square01Icon
 } from '@hugeicons/core-free-icons';
 import { cn } from '@/lib/utils';
+import {
+  describeSpeechError,
+  isSpeechRecognitionSupported,
+} from '@/lib/voice/speechRecognitionErrors';
 
 type InputMode = 'text' | 'voice';
 
@@ -80,8 +84,33 @@ export function VoiceTextInput({
 
   // Check for speech recognition support
   useEffect(() => {
-    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
-    setIsSupported(!!SpeechRecognition);
+    setIsSupported(isSpeechRecognitionSupported());
+  }, []);
+
+  // Release the microphone if this unmounts mid-recording (#348). Without this,
+  // navigating away while dictating left recognition running and the browser's
+  // recording indicator lit — the user has no control left to stop it.
+  //
+  // Empty deps so it runs only on unmount, and it reads the ref rather than
+  // state so it cannot capture a stale recorder. Handlers are detached first:
+  // stop() fires onend, which would otherwise call setState on an unmounted
+  // component.
+  useEffect(() => {
+    return () => {
+      const recognition = recognitionRef.current;
+      if (!recognition) {
+        return;
+      }
+      recognition.onresult = null;
+      recognition.onerror = null;
+      recognition.onend = null;
+      try {
+        recognition.stop();
+      } catch {
+        // Already stopped/destroyed — nothing to release.
+      }
+      recognitionRef.current = null;
+    };
   }, []);
 
   // Update mode when prop changes
@@ -159,8 +188,15 @@ export function VoiceTextInput({
     };
 
     recognition.onerror = (event: ErrorEvent) => {
-      console.error('Speech recognition error:', event.error);
-      setError(`Error recording audio: ${event.error || 'Unknown error'}`);
+      // no-speech/aborted are routine (a silent window, or the user stopping),
+      // so they end the session without an error banner. Everything else gets
+      // copy that says what to do rather than echoing the raw code (#348).
+      const code = (event as unknown as { error?: string }).error;
+      const message = describeSpeechError(code);
+      if (message) {
+        console.error('Speech recognition error:', code);
+        setError(message);
+      }
       setIsRecording(false);
     };
 

--- a/frontend/src/components/chapters/VoiceTextInput.tsx
+++ b/frontend/src/components/chapters/VoiceTextInput.tsx
@@ -77,6 +77,15 @@ export function VoiceTextInput({
   // requested and thrown away, so the mic stayed live for the life of the page,
   // even after the user pressed Stop (#348).
   const micStreamRef = useRef<MediaStream | null>(null);
+  // getUserMedia is async, which opens two windows where a stream can be
+  // acquired with nothing left to release it (#348):
+  //   - two Start clicks before the first promise resolves: both pass the
+  //     release-then-acquire guard while micStreamRef is still null, and the
+  //     second overwrites the first, orphaning its tracks;
+  //   - unmount while the promise is pending: cleanup runs against a null ref,
+  //     then the stream arrives and is held by a component that no longer exists.
+  const startingRef = useRef(false);
+  const unmountedRef = useRef(false);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   // Mirror the latest `value` prop so the long-lived onresult handler reads the
@@ -103,6 +112,7 @@ export function VoiceTextInput({
   // component.
   useEffect(() => {
     return () => {
+      unmountedRef.current = true;
       const recognition = recognitionRef.current;
       if (recognition) {
         recognition.onresult = null;
@@ -269,13 +279,36 @@ export function VoiceTextInput({
       return;
     }
 
+    // Ignore a second Start while one is still in flight; the button stays
+    // enabled until onstart fires, so a double-click is easy to land.
+    if (startingRef.current || recognitionRef.current) {
+      return;
+    }
+    startingRef.current = true;
+
     try {
       // Release any stream still held from a previous attempt before acquiring
       // another; overwriting the ref would orphan the old tracks for the page's
       // lifetime with no handle left to stop them.
       releaseMicStream();
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+
+      // The await above is a suspension point: this component may have unmounted
+      // while permission was pending, in which case the cleanup already ran and
+      // nothing will ever release this stream. Hand it back immediately.
+      if (unmountedRef.current) {
+        stream.getTracks().forEach((track) => {
+          try {
+            track.stop();
+          } catch {
+            // Already ended.
+          }
+        });
+        return;
+      }
+
       // Keep the stream so its tracks can be released again (see micStreamRef).
-      micStreamRef.current = await navigator.mediaDevices.getUserMedia({ audio: true });
+      micStreamRef.current = stream;
 
       setError(null);
       const recognition = initializeSpeechRecognition();
@@ -286,6 +319,9 @@ export function VoiceTextInput({
     } catch (err) {
       console.error('Failed to start recording:', err);
       setError('Failed to access microphone. Please check permissions.');
+      releaseMicStream();
+    } finally {
+      startingRef.current = false;
     }
   };
 

--- a/frontend/src/components/chapters/VoiceTextInput.tsx
+++ b/frontend/src/components/chapters/VoiceTextInput.tsx
@@ -246,13 +246,20 @@ export function VoiceTextInput({
         setError(message);
       }
       releaseMicStream();
+      // Clear the handle too: startRecording's re-entrancy guard checks it, so
+      // leaving a dead recognizer here would make every later Start a silent
+      // no-op and strand voice input until unmount.
+      recognitionRef.current = null;
       setIsRecording(false);
     };
 
     recognition.onend = () => {
       // Recognition can end without the user asking — a service timeout, or the
-      // browser deciding the utterance finished. The mic must go with it.
+      // browser deciding the utterance finished. The mic must go with it, and so
+      // must the handle: startRecording's guard checks it, and onend fires
+      // routinely, so holding a dead recognizer here would brick every restart.
       releaseMicStream();
+      recognitionRef.current = null;
       setIsRecording(false);
       setInterimTranscript('');
     };

--- a/frontend/src/components/chapters/__tests__/VoiceTextInputCleanup.test.tsx
+++ b/frontend/src/components/chapters/__tests__/VoiceTextInputCleanup.test.tsx
@@ -6,6 +6,7 @@
  * mid-dictation left recognition running with the browser's recording indicator
  * lit, and the control that would have stopped it was gone.
  */
+import { StrictMode } from 'react';
 import { render, screen, act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { VoiceTextInput } from '@/components/chapters/VoiceTextInput';
@@ -431,5 +432,32 @@ describe('VoiceTextInput survives a failing start (#348)', () => {
     expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(2);
 
     consoleSpy.mockRestore();
+  });
+});
+
+describe('VoiceTextInput under StrictMode (#348)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    installRecognition();
+  });
+
+  it('still records after StrictMode double-invokes the effects', async () => {
+    // StrictMode runs mount -> cleanup -> mount in development, which is exactly
+    // Next.js's default for `next dev`. A flag only ever set to true in cleanup
+    // latches on that first teardown, and the unmounted-guard in startRecording
+    // then aborts every recording — dictation broken for the whole dev session
+    // while passing every non-StrictMode test.
+    installMicStream();
+    render(
+      <StrictMode>
+        <VoiceTextInput value="" mode="voice" onChange={jest.fn()} />
+      </StrictMode>
+    );
+
+    await startRecording();
+
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalled();
+    // Reached the recognizer, not aborted at the guard.
+    expect(TrackedRecognition.instances.at(-1)?.started).toBe(true);
   });
 });

--- a/frontend/src/components/chapters/__tests__/VoiceTextInputCleanup.test.tsx
+++ b/frontend/src/components/chapters/__tests__/VoiceTextInputCleanup.test.tsx
@@ -350,3 +350,46 @@ describe('VoiceTextInput async-window leaks (#348)', () => {
     expect(tracks[0].stop).toHaveBeenCalled();
   });
 });
+
+describe('VoiceTextInput can restart after a browser-driven end (#348)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    installRecognition();
+  });
+
+  it.each(['onend', 'onerror'])(
+    'allows a new recording after %s ends the session',
+    async (event) => {
+      // The re-entrancy guard checks recognitionRef, so a handler that ends the
+      // session without clearing it turns every later Start into a silent no-op
+      // — dictation dead until the component unmounts. onend fires routinely
+      // (pause, timeout), so this is the common path, not an edge case.
+      installMicStream();
+      const user = userEvent.setup();
+      render(<VoiceTextInput value="" mode="voice" onChange={jest.fn()} />);
+
+      await startRecording();
+      expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        const recognition = TrackedRecognition.instances.at(-1);
+        if (event === 'onend') {
+          recognition?.onend?.();
+        } else {
+          recognition?.onerror?.({ error: 'no-speech' });
+        }
+      });
+
+      // The control is back...
+      const start = await screen.findByRole('button', {
+        name: /start voice recording/i,
+      });
+      await act(async () => {
+        await user.click(start);
+      });
+
+      // ...and actually does something.
+      expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(2);
+    }
+  );
+});

--- a/frontend/src/components/chapters/__tests__/VoiceTextInputCleanup.test.tsx
+++ b/frontend/src/components/chapters/__tests__/VoiceTextInputCleanup.test.tsx
@@ -278,3 +278,75 @@ describe('VoiceTextInput releases the mic on every session end (#348)', () => {
     expect(secondTrack.stop).toHaveBeenCalled();
   });
 });
+
+describe('VoiceTextInput async-window leaks (#348)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    installRecognition();
+  });
+
+  /** A getUserMedia whose resolution we control, to hold the await open. */
+  function installDeferredMic(count: number) {
+    const tracks = Array.from({ length: count }, () => ({
+      kind: 'audio',
+      stop: jest.fn(),
+      enabled: true,
+    }));
+    const resolvers: Array<() => void> = [];
+    let call = 0;
+    (navigator as unknown as Record<string, unknown>).mediaDevices = {
+      getUserMedia: jest.fn().mockImplementation(() => {
+        const track = tracks[call++];
+        return new Promise((resolve) => {
+          resolvers.push(() =>
+            resolve({ getTracks: () => [track], getAudioTracks: () => [track] })
+          );
+        });
+      }),
+      enumerateDevices: jest.fn().mockResolvedValue([]),
+    };
+    return { tracks, resolvers };
+  }
+
+  it('ignores a second Start while the first is still awaiting permission', async () => {
+    // Both clicks would otherwise pass the release-then-acquire guard while
+    // micStreamRef is still null, and the second stream would overwrite the
+    // first — orphaning its tracks with no handle left to stop them.
+    const { resolvers } = installDeferredMic(2);
+    const user = userEvent.setup();
+    render(<VoiceTextInput value="" mode="voice" onChange={jest.fn()} />);
+
+    const start = screen.getByRole('button', { name: /start voice recording/i });
+    await act(async () => {
+      await user.click(start);
+      await user.click(start);
+    });
+
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolvers[0]?.();
+    });
+  });
+
+  it('releases a stream that arrives after the component unmounted', async () => {
+    // The await is a suspension point: cleanup can run against a null ref and
+    // then the stream shows up, held by a component that no longer exists.
+    const { tracks, resolvers } = installDeferredMic(1);
+    const user = userEvent.setup();
+    const { unmount } = render(
+      <VoiceTextInput value="" mode="voice" onChange={jest.fn()} />
+    );
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /start voice recording/i }));
+    });
+
+    unmount();
+
+    await act(async () => {
+      resolvers[0]?.();
+    });
+
+    expect(tracks[0].stop).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/chapters/__tests__/VoiceTextInputCleanup.test.tsx
+++ b/frontend/src/components/chapters/__tests__/VoiceTextInputCleanup.test.tsx
@@ -14,6 +14,8 @@ import { VoiceTextInput } from '@/components/chapters/VoiceTextInput';
 // SpeechRecognition the component constructs from window.
 class TrackedRecognition {
   static instances: TrackedRecognition[] = [];
+  /** When set, the next start() throws — models a recognizer refusing to run. */
+  static failNextStart = false;
 
   onresult: ((e: unknown) => void) | null = null;
   onerror: ((e: unknown) => void) | null = null;
@@ -32,6 +34,10 @@ class TrackedRecognition {
   }
 
   start = jest.fn(() => {
+    if (TrackedRecognition.failNextStart) {
+      TrackedRecognition.failNextStart = false;
+      throw new Error('start failed');
+    }
     this.started = true;
     this.onstart?.();
   });
@@ -50,6 +56,7 @@ class TrackedRecognition {
 
 function installRecognition() {
   TrackedRecognition.instances = [];
+  TrackedRecognition.failNextStart = false;
   (window as unknown as Record<string, unknown>).SpeechRecognition = TrackedRecognition;
   (window as unknown as Record<string, unknown>).webkitSpeechRecognition = TrackedRecognition;
 }
@@ -392,4 +399,37 @@ describe('VoiceTextInput can restart after a browser-driven end (#348)', () => {
       expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(2);
     }
   );
+});
+
+describe('VoiceTextInput survives a failing start (#348)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    installRecognition();
+  });
+
+  it('can start again after recognition.start() throws', async () => {
+    // start() is called immediately after the handle is stored, so a throw here
+    // leaves a dead recognizer that no handler will ever clear — the same brick
+    // as the onend/onerror case, reached by a different route.
+    installMicStream();
+    const user = userEvent.setup();
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<VoiceTextInput value="" mode="voice" onChange={jest.fn()} />);
+
+    TrackedRecognition.failNextStart = true;
+    await startRecording();
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
+
+    // The retry must actually reach the microphone again, not just re-render a
+    // button that does nothing.
+    await act(async () => {
+      await user.click(
+        await screen.findByRole('button', { name: /start voice recording/i })
+      );
+    });
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(2);
+
+    consoleSpy.mockRestore();
+  });
 });

--- a/frontend/src/components/chapters/__tests__/VoiceTextInputCleanup.test.tsx
+++ b/frontend/src/components/chapters/__tests__/VoiceTextInputCleanup.test.tsx
@@ -54,6 +54,23 @@ function installRecognition() {
   (window as unknown as Record<string, unknown>).webkitSpeechRecognition = TrackedRecognition;
 }
 
+/**
+ * Replace getUserMedia with a stream whose track stop() we can observe.
+ *
+ * This is the part that actually holds the microphone: recognition.stop() does
+ * not release a MediaStream, so a component that requests one and drops it keeps
+ * the mic (and the browser's recording indicator) live regardless.
+ */
+function installMicStream() {
+  const track = { kind: 'audio', stop: jest.fn(), enabled: true };
+  const stream = { getTracks: () => [track], getAudioTracks: () => [track] };
+  (navigator as unknown as Record<string, unknown>).mediaDevices = {
+    getUserMedia: jest.fn().mockResolvedValue(stream),
+    enumerateDevices: jest.fn().mockResolvedValue([]),
+  };
+  return track;
+}
+
 async function startRecording() {
   const user = userEvent.setup();
   await act(async () => {
@@ -152,5 +169,44 @@ describe('VoiceTextInput error copy (#348)', () => {
     });
     // And never the raw code.
     expect(screen.queryByText(/not-allowed/)).not.toBeInTheDocument();
+  });
+});
+
+describe('VoiceTextInput releases the getUserMedia stream (#348)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    installRecognition();
+  });
+
+  it('stops the microphone track on unmount', async () => {
+    const track = installMicStream();
+    const { unmount } = render(
+      <VoiceTextInput value="" mode="voice" onChange={jest.fn()} />
+    );
+
+    await startRecording();
+    expect(track.stop).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(track.stop).toHaveBeenCalled();
+  });
+
+  it('stops the microphone track when the user presses Stop', async () => {
+    // The worse half of the bug: the stream outlived an explicit stop, so the
+    // recording indicator stayed lit while the user sat on the page believing
+    // dictation had ended.
+    const track = installMicStream();
+    const user = userEvent.setup();
+    render(<VoiceTextInput value="" mode="voice" onChange={jest.fn()} />);
+
+    await startRecording();
+    expect(track.stop).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /stop voice recording/i }));
+    });
+
+    expect(track.stop).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/chapters/__tests__/VoiceTextInputCleanup.test.tsx
+++ b/frontend/src/components/chapters/__tests__/VoiceTextInputCleanup.test.tsx
@@ -210,3 +210,71 @@ describe('VoiceTextInput releases the getUserMedia stream (#348)', () => {
     expect(track.stop).toHaveBeenCalled();
   });
 });
+
+describe('VoiceTextInput releases the mic on every session end (#348)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    installRecognition();
+  });
+
+  it('releases the stream when recognition errors', async () => {
+    // A network/permission failure ends the session. Without a release here the
+    // recording indicator stays lit after the error banner appears, and the Stop
+    // button is gone because isRecording went false.
+    const track = installMicStream();
+    render(<VoiceTextInput value="" mode="voice" onChange={jest.fn()} />);
+    await startRecording();
+
+    await act(async () => {
+      TrackedRecognition.instances.at(-1)?.onerror?.({ error: 'network' });
+    });
+
+    expect(track.stop).toHaveBeenCalled();
+  });
+
+  it('releases the stream when recognition ends on its own', async () => {
+    // A service timeout or end-of-utterance fires onend without the user asking.
+    const track = installMicStream();
+    render(<VoiceTextInput value="" mode="voice" onChange={jest.fn()} />);
+    await startRecording();
+
+    await act(async () => {
+      TrackedRecognition.instances.at(-1)?.onend?.();
+    });
+
+    expect(track.stop).toHaveBeenCalled();
+  });
+
+  it('does not orphan the previous stream when recording is restarted', async () => {
+    // Overwriting micStreamRef without releasing would leave the first stream's
+    // tracks live for the page's lifetime with no handle left to stop them.
+    const firstTrack = { kind: 'audio', stop: jest.fn(), enabled: true };
+    const secondTrack = { kind: 'audio', stop: jest.fn(), enabled: true };
+    const streams = [
+      { getTracks: () => [firstTrack], getAudioTracks: () => [firstTrack] },
+      { getTracks: () => [secondTrack], getAudioTracks: () => [secondTrack] },
+    ];
+    let call = 0;
+    (navigator as unknown as Record<string, unknown>).mediaDevices = {
+      getUserMedia: jest.fn().mockImplementation(() => Promise.resolve(streams[call++])),
+      enumerateDevices: jest.fn().mockResolvedValue([]),
+    };
+
+    const user = userEvent.setup();
+    render(<VoiceTextInput value="" mode="voice" onChange={jest.fn()} />);
+
+    await startRecording();
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /stop voice recording/i }));
+    });
+    expect(firstTrack.stop).toHaveBeenCalled();
+
+    // Second session: the first stream must already be gone, and the second must
+    // be the one now held.
+    await startRecording();
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /stop voice recording/i }));
+    });
+    expect(secondTrack.stop).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/chapters/__tests__/VoiceTextInputCleanup.test.tsx
+++ b/frontend/src/components/chapters/__tests__/VoiceTextInputCleanup.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * #348: the microphone must be released when the editor unmounts, and routine
+ * recognition events must not surface as errors.
+ *
+ * The unmount case is a privacy defect, not a tidiness one: navigating away
+ * mid-dictation left recognition running with the browser's recording indicator
+ * lit, and the control that would have stopped it was gone.
+ */
+import { render, screen, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { VoiceTextInput } from '@/components/chapters/VoiceTextInput';
+
+// A recognizer that records whether it was stopped, standing in for the real
+// SpeechRecognition the component constructs from window.
+class TrackedRecognition {
+  static instances: TrackedRecognition[] = [];
+
+  onresult: ((e: unknown) => void) | null = null;
+  onerror: ((e: unknown) => void) | null = null;
+  onend: (() => void) | null = null;
+  onstart: (() => void) | null = null;
+  onspeechend: (() => void) | null = null;
+  continuous = false;
+  interimResults = false;
+  lang = 'en-US';
+
+  stopped = false;
+  started = false;
+
+  constructor() {
+    TrackedRecognition.instances.push(this);
+  }
+
+  start = jest.fn(() => {
+    this.started = true;
+    this.onstart?.();
+  });
+
+  stop = jest.fn(() => {
+    this.stopped = true;
+    // The real API fires onend on stop(); the component must have detached its
+    // handlers before unmount-stop or this would setState after unmount.
+    this.onend?.();
+  });
+
+  abort = jest.fn(() => {
+    this.stopped = true;
+  });
+}
+
+function installRecognition() {
+  TrackedRecognition.instances = [];
+  (window as unknown as Record<string, unknown>).SpeechRecognition = TrackedRecognition;
+  (window as unknown as Record<string, unknown>).webkitSpeechRecognition = TrackedRecognition;
+}
+
+async function startRecording() {
+  const user = userEvent.setup();
+  await act(async () => {
+    await user.click(screen.getByRole('button', { name: /start voice recording/i }));
+  });
+}
+
+describe('VoiceTextInput microphone lifecycle (#348)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    installRecognition();
+  });
+
+  it('releases the microphone when unmounted mid-recording', async () => {
+    const { unmount } = render(
+      <VoiceTextInput value="" mode="voice" onChange={jest.fn()} />
+    );
+
+    await startRecording();
+    const recognition = TrackedRecognition.instances.at(-1);
+    expect(recognition?.started).toBe(true);
+    expect(recognition?.stopped).toBe(false);
+
+    unmount();
+
+    expect(recognition?.stopped).toBe(true);
+  });
+
+  it('detaches handlers before stopping, so unmount cannot setState', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { unmount } = render(
+      <VoiceTextInput value="" mode="voice" onChange={jest.fn()} />
+    );
+
+    await startRecording();
+    const recognition = TrackedRecognition.instances.at(-1);
+
+    unmount();
+
+    // stop() fires onend; if it were still attached React would warn about an
+    // update on an unmounted component.
+    expect(recognition?.onend).toBeNull();
+    expect(recognition?.onresult).toBeNull();
+    expect(
+      errorSpy.mock.calls.some((c) => String(c[0]).includes('unmounted'))
+    ).toBe(false);
+    errorSpy.mockRestore();
+  });
+
+  it('does not stop anything when it never recorded', () => {
+    const { unmount } = render(
+      <VoiceTextInput value="" mode="voice" onChange={jest.fn()} />
+    );
+    unmount();
+    expect(TrackedRecognition.instances).toHaveLength(0);
+  });
+});
+
+describe('VoiceTextInput error copy (#348)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    installRecognition();
+  });
+
+  it.each(['no-speech', 'aborted'])(
+    'shows no error banner for the routine %s event',
+    async (code) => {
+      render(<VoiceTextInput value="" mode="voice" onChange={jest.fn()} />);
+      await startRecording();
+      const recognition = TrackedRecognition.instances.at(-1);
+
+      await act(async () => {
+        recognition?.onerror?.({ error: code });
+      });
+
+      // The old code rendered "Error recording audio: no-speech" — a red banner
+      // for a silent pause, which teaches users to ignore the error region.
+      expect(screen.queryByText(/error recording audio/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(new RegExp(code, 'i'))).not.toBeInTheDocument();
+    }
+  );
+
+  it('gives actionable guidance when permission is denied', async () => {
+    render(<VoiceTextInput value="" mode="voice" onChange={jest.fn()} />);
+    await startRecording();
+    const recognition = TrackedRecognition.instances.at(-1);
+
+    await act(async () => {
+      recognition?.onerror?.({ error: 'not-allowed' });
+    });
+
+    // getAllByText, not getByText: the copy appears twice by design — in the
+    // visible banner and in the sr-only aria-live status.
+    await waitFor(() => {
+      expect(screen.getAllByText(/allow microphone access/i).length).toBeGreaterThan(0);
+    });
+    // And never the raw code.
+    expect(screen.queryByText(/not-allowed/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/voice/__tests__/speechRecognitionErrors.test.ts
+++ b/frontend/src/lib/voice/__tests__/speechRecognitionErrors.test.ts
@@ -1,0 +1,92 @@
+import {
+  isBenignSpeechError,
+  describeSpeechError,
+  isSpeechRecognitionSupported,
+} from '../speechRecognitionErrors';
+
+describe('isBenignSpeechError', () => {
+  // These two fire in normal use — a silent listening window, or the user
+  // stopping/navigating. Treating them as failures is what made working
+  // dictation look broken (#348).
+  it.each(['no-speech', 'aborted'])('treats %s as benign', (code) => {
+    expect(isBenignSpeechError(code)).toBe(true);
+  });
+
+  it.each(['not-allowed', 'audio-capture', 'network', 'service-not-allowed'])(
+    'treats %s as a real error',
+    (code) => {
+      expect(isBenignSpeechError(code)).toBe(false);
+    }
+  );
+
+  it('handles a missing code', () => {
+    expect(isBenignSpeechError(undefined)).toBe(false);
+  });
+});
+
+describe('describeSpeechError', () => {
+  it.each(['no-speech', 'aborted'])('returns null for benign code %s', (code) => {
+    expect(describeSpeechError(code)).toBeNull();
+  });
+
+  it.each([
+    ['not-allowed', /allow microphone access/i],
+    ['service-not-allowed', /allow microphone access/i],
+    ['audio-capture', /no microphone was found/i],
+    ['network', /internet connection/i],
+    ['language-not-supported', /not available for this language/i],
+  ])('gives actionable copy for %s', (code, pattern) => {
+    expect(describeSpeechError(code)).toMatch(pattern as RegExp);
+  });
+
+  it('never leaks the raw code to the user', () => {
+    // The old behaviour was `Error recording audio: ${event.error}`.
+    for (const code of [
+      'not-allowed',
+      'audio-capture',
+      'network',
+      'language-not-supported',
+      'bad-grammar',
+      'some-future-code',
+    ]) {
+      expect(describeSpeechError(code)).not.toContain(code);
+    }
+  });
+
+  it('falls back to actionable copy for an unknown code', () => {
+    expect(describeSpeechError('totally-new-code')).toMatch(/try again/i);
+  });
+});
+
+describe('isSpeechRecognitionSupported', () => {
+  const original = {
+    SpeechRecognition: (window as never)['SpeechRecognition'],
+    webkitSpeechRecognition: (window as never)['webkitSpeechRecognition'],
+    mediaDevices: navigator.mediaDevices,
+  };
+
+  afterEach(() => {
+    (window as never)['SpeechRecognition'] = original.SpeechRecognition;
+    (window as never)['webkitSpeechRecognition'] = original.webkitSpeechRecognition;
+    // jest.setup.ts defines mediaDevices as writable but NOT configurable, so
+    // assign rather than redefine.
+    (navigator as unknown as Record<string, unknown>).mediaDevices = original.mediaDevices;
+  });
+
+  it('is true when a constructor and getUserMedia are both present', () => {
+    expect(isSpeechRecognitionSupported()).toBe(true);
+  });
+
+  it('is false without either constructor (Firefox)', () => {
+    delete (window as never)['SpeechRecognition'];
+    delete (window as never)['webkitSpeechRecognition'];
+    expect(isSpeechRecognitionSupported()).toBe(false);
+  });
+
+  it('is false without getUserMedia (insecure context)', () => {
+    // Chrome over plain HTTP exposes the constructor but cannot reach the mic,
+    // so a constructor check alone advertises a capability that does not work.
+    (navigator as unknown as Record<string, unknown>).mediaDevices = undefined;
+    expect(isSpeechRecognitionSupported()).toBe(false);
+  });
+});

--- a/frontend/src/lib/voice/speechRecognitionErrors.ts
+++ b/frontend/src/lib/voice/speechRecognitionErrors.ts
@@ -86,7 +86,14 @@ export function isSpeechRecognitionSupported(): boolean {
   return Boolean(navigator?.mediaDevices?.getUserMedia);
 }
 
-/** Guidance shown in place of the dictation control when it cannot work. */
+/**
+ * Guidance shown in place of the dictation control when it cannot work.
+ *
+ * Deliberately says nothing about *which* field or where it sits: this module is
+ * shared by the chapter editor and the summary page, so copy naming one surface
+ * ("type your summary below") would be wrong on the other the moment a second
+ * caller appeared.
+ */
 export const SPEECH_UNSUPPORTED_MESSAGE =
-  'Dictation is not available in this browser. Chrome or Edge support it over ' +
-  'HTTPS; you can still type your summary below.';
+  'Dictation is not available in this browser. Chrome and Edge support it over ' +
+  'HTTPS; you can still type instead.';

--- a/frontend/src/lib/voice/speechRecognitionErrors.ts
+++ b/frontend/src/lib/voice/speechRecognitionErrors.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared interpretation of Web Speech API error codes (#348).
+ *
+ * Both dictation surfaces — the chapter editor's VoiceTextInput and the book
+ * summary page — used to render the raw code straight to the user
+ * ("Error recording audio: no-speech"). Two problems with that:
+ *
+ *  - `no-speech` and `aborted` are routine. The API fires `no-speech` whenever a
+ *    listening window passes without audio, and `aborted` when the user stops or
+ *    navigates. Surfacing them as red errors makes working dictation look
+ *    broken, which trains people to ignore the error region entirely.
+ *  - `not-allowed` is the one code the user can actually act on, and a bare
+ *    "not-allowed" tells them nothing about how.
+ *
+ * Kept as a plain module rather than a hook so both surfaces share one mapping;
+ * they have quite different component shapes but identical error semantics.
+ */
+
+/**
+ * Codes that mean "nothing happened", not "something went wrong". Callers should
+ * clear any in-progress state but show no error.
+ */
+const BENIGN_CODES = new Set(['no-speech', 'aborted']);
+
+export function isBenignSpeechError(code: string | undefined): boolean {
+  return BENIGN_CODES.has(code ?? '');
+}
+
+/**
+ * User-facing copy for a speech-recognition error code.
+ *
+ * Each message names what to do, not just what failed. Returns null for benign
+ * codes so a caller can pass the result straight to its error state.
+ */
+export function describeSpeechError(code: string | undefined): string | null {
+  if (isBenignSpeechError(code)) {
+    return null;
+  }
+
+  switch (code) {
+    case 'not-allowed':
+    case 'service-not-allowed':
+      return (
+        'Microphone access is blocked. Allow microphone access for this site in ' +
+        'your browser settings, then start dictation again.'
+      );
+    case 'audio-capture':
+      return (
+        'No microphone was found. Check that one is connected and not in use by ' +
+        'another app, then try again.'
+      );
+    case 'network':
+      return (
+        'Dictation needs an internet connection to transcribe speech. Check your ' +
+        'connection and try again.'
+      );
+    case 'language-not-supported':
+      return 'Dictation is not available for this language in your browser.';
+    case 'bad-grammar':
+      // Not reachable without a grammar list, but the API can emit it.
+      return 'Dictation could not process the audio. Try again.';
+    default:
+      return 'Dictation stopped unexpectedly. Try again.';
+  }
+}
+
+/**
+ * Whether this browser/context can do speech recognition at all.
+ *
+ * Must run in an effect, never during render: the constructors live on `window`,
+ * and a server render would report every browser unsupported. Also false in an
+ * insecure context, where Chrome exposes the constructor but refuses the mic.
+ */
+export function isSpeechRecognitionSupported(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  const ctor =
+    (window as unknown as { SpeechRecognition?: unknown }).SpeechRecognition ??
+    (window as unknown as { webkitSpeechRecognition?: unknown }).webkitSpeechRecognition;
+  if (!ctor) {
+    return false;
+  }
+  // getUserMedia is absent in insecure contexts, where recognition cannot work
+  // even though the constructor is present.
+  return Boolean(navigator?.mediaDevices?.getUserMedia);
+}
+
+/** Guidance shown in place of the dictation control when it cannot work. */
+export const SPEECH_UNSUPPORTED_MESSAGE =
+  'Dictation is not available in this browser. Chrome or Edge support it over ' +
+  'HTTPS; you can still type your summary below.';


### PR DESCRIPTION
Closes #348.

## 1. The stuck-live microphone — worse than the issue described

The issue reports that no unmount cleanup calls `recognition.stop()`, so navigating away mid-dictation leaves the mic live. True, and fixed. But review surfaced a second source that my first pass missed, and it is the more serious one:

```ts
// before
await navigator.mediaDevices.getUserMedia({ audio: true });   // result discarded
```

That `MediaStream`'s audio tracks are what actually hold the microphone open, and **`recognition.stop()` does not touch them.** The stream was requested and dropped on the floor, so the mic stayed live for the life of the page — *including after the user pressed Stop*. The recording indicator stayed lit while they sat there believing dictation had ended.

Both surfaces now stop recognition on unmount (reading the ref, not state, so they cannot capture a stale recorder; handlers detached first because `stop()` fires `onend`, which would otherwise `setState` after unmount), and `VoiceTextInput` holds the stream in a ref and stops its tracks on **both** paths — explicit stop and unmount.

## 2. False capability advertisement

The summary page's "🎤 Voice Input" button rendered enabled in Firefox/Safari and over plain HTTP, failing only once clicked. It is now gated on a probe that requires `navigator.mediaDevices.getUserMedia` as well as the constructor — **Chrome over plain HTTP exposes `SpeechRecognition` but cannot reach the mic**, so a constructor check alone still advertises something that does not work. Unsupported browsers get guidance instead of a dead button.

## 3. Raw error codes

Both surfaces rendered the API's code straight through — `Error recording audio: no-speech`. `no-speech` fires whenever a listening window passes without audio, and `aborted` whenever the user stops or navigates, so **routine use painted red banners**, which is how you train people to ignore the error region entirely. Those two are now suppressed; everything else maps to copy that says what to do, with `not-allowed` explaining where to grant permission.

Shared as `src/lib/voice/speechRecognitionErrors.ts` rather than duplicated — the two components have very different shapes but identical error semantics.

## 4. Summary surface accessibility

It had no live region at all: a voice-only affordance a screen-reader user could not monitor. Added an `aria-live` status, `role="alert"` on the error banner, `aria-pressed` on the toggle, and display of interim results — which were already being computed and then discarded, so the page looked frozen while listening. Mirrors what `VoiceTextInput` already did.

## Tests

Assertions target the device, not the state: `track.stop()` on a mocked stream, because the track is the thing holding the mic. Asserting `isRecording === false` would have passed throughout the entire bug.

**Mutation checks:**

| Mutation | Result |
|---|---|
| Delete the unmount effect | ✕ both mic-release tests fail |
| Remove track release from the stop path only | ✕ stop test fails, unmount test still passes |

The second one matters: it shows the two release paths are independently guarded rather than one covering for the other.

Plus 19 tests on the shared error module, including that no mapped message ever contains the raw code it came from.

## One pre-existing test updated

`VoiceTextInput.test.tsx` asserted the old copy verbatim — `'Error recording audio: network'` — which is the behaviour this issue exists to remove. Updated to the new intent, and strengthened: it now also asserts the raw code is absent. The test's purpose (a real failure still surfaces to the user) is unchanged.

## Verification

| Check | Result |
|-------|--------|
| Full frontend suite (coverage) | **130/130 suites, 2271 passed**, thresholds met |
| `tsc --noEmit` | clean |
| `npm run lint` | 0 errors |
| CodeRabbit | 2 findings, both fixed — one was the `getUserMedia` leak above |

🤖 Generated with [Claude Code](https://claude.com/claude-code)