### PR TITLE
fix(a11y): label the question field, announce save status, fix dark-mode contrast (#349)

### DIFF
--- a/frontend/src/app/dashboard/books/[bookId]/summary/page.tsx
+++ b/frontend/src/app/dashboard/books/[bookId]/summary/page.tsx
@@ -255,6 +255,10 @@ export default function BookSummaryPage() {
                 )}
               </div>
             </div>
+            {/* aria-invalid tells assistive tech the field is in an error
+                state, and aria-describedby points at the message explaining why
+                — previously the readiness error was visible text with nothing
+                associating it to the field (#349). */}
             <textarea
               id="summary"
               value={summary}
@@ -263,6 +267,8 @@ export default function BookSummaryPage() {
               className="w-full bg-background border border-border rounded-md py-2 px-3 text-foreground"
               placeholder="Describe your book's main concepts, structure, and key points that should be organized into chapters..."
               required
+              aria-invalid={Boolean(inputError)}
+              aria-describedby={inputError ? 'summary-input-error summary-help' : 'summary-help'}
             ></textarea>
 
             {/* Dictation status, announced politely. A voice-only affordance with
@@ -294,7 +300,17 @@ export default function BookSummaryPage() {
               <span>{countSummaryCharacters(summary)} / {SUMMARY_MIN_CHARACTERS} characters</span>
             </div>
             {inputError && (
-              <div className="text-red-400 text-xs mt-1">{inputError}</div>
+              // Polite, not alert: this fires on every keystroke while the
+              // summary is below the minimum, and an assertive region would
+              // interrupt the user continuously as they type.
+              <div
+                id="summary-input-error"
+                role="status"
+                aria-live="polite"
+                className="text-red-400 text-xs mt-1"
+              >
+                {inputError}
+              </div>
             )}
             <div id="summary-help" className="text-xs text-muted-foreground mt-2">
               <div>Guidelines: Aim for 1-3 paragraphs. Include the main idea, genre, and any key themes or characters. At least {SUMMARY_MIN_WORDS} words and {SUMMARY_MIN_CHARACTERS} characters are required to generate a table of contents — the more detail you give, the better the result.</div>

--- a/frontend/src/components/BookCreationWizard.tsx
+++ b/frontend/src/components/BookCreationWizard.tsx
@@ -150,7 +150,7 @@ export function BookCreationWizard({ isOpen, onOpenChange, onSuccess }: BookCrea
                       disabled={isSubmitting}
                     />
                   </FormControl>
-                  <FormDescription className="text-muted-foreground dark:text-gray-500">
+                  <FormDescription className="text-muted-foreground dark:text-gray-400">
                     Provide a short summary or description of your book project.
                   </FormDescription>
                   <FormMessage className="text-destructive dark:text-red-400" />
@@ -172,7 +172,7 @@ export function BookCreationWizard({ isOpen, onOpenChange, onSuccess }: BookCrea
                       disabled={isSubmitting}
                     />
                   </FormControl>
-                  <FormDescription className="text-muted-foreground dark:text-gray-500">
+                  <FormDescription className="text-muted-foreground dark:text-gray-400">
                     Optional: Add a URL to your book&apos;s cover image.
                   </FormDescription>
                   <FormMessage className="text-destructive dark:text-red-400" />

--- a/frontend/src/components/chapters/ChapterEditor.tsx
+++ b/frontend/src/components/chapters/ChapterEditor.tsx
@@ -33,6 +33,7 @@ import bookClient from '@/lib/api/bookClient';
 import { HugeiconsIcon } from '@hugeicons/react';
 import {
   CheckmarkCircle01Icon,
+  AlertCircleIcon,
   Loading03Icon
 } from '@hugeicons/core-free-icons';
 import { usePerformanceTracking } from '@/hooks/usePerformanceTracking';
@@ -465,8 +466,14 @@ export function ChapterEditor({
           </div>
         </div>
       )}
+      {/* role="alert": a failed autosave means the user's writing may exist only
+          in the localStorage backup. That is worth interrupting for, and it was
+          previously announced not at all (#349). */}
       {error && (
-        <div className="bg-destructive/10 border border-destructive/20 text-destructive px-4 py-2 text-sm">
+        <div
+          role="alert"
+          className="bg-destructive/10 border border-destructive/20 text-destructive px-4 py-2 text-sm"
+        >
           {error}
         </div>
       )}
@@ -600,7 +607,9 @@ export function ChapterEditor({
             aria-live="polite"
             className="flex items-center gap-2"
             data-testid="save-status-indicator"
-            data-save-status={isSaving ? 'saving' : lastSaved ? 'saved' : 'idle'}
+            data-save-status={
+              isSaving ? 'saving' : error ? 'error' : lastSaved ? 'saved' : 'idle'
+            }
           >
             {isSaving && (
               <span className="text-xs text-muted-foreground flex items-center gap-1">
@@ -608,13 +617,23 @@ export function ChapterEditor({
                 Saving...
               </span>
             )}
-            {!isSaving && lastSaved && (
+            {/* `error` is checked before `lastSaved` because lastSaved survives
+                from the previous successful save: without this the region
+                announced "Saved 14:32" during a failure, which is both a stale
+                success and the opposite of what happened. */}
+            {!isSaving && error && (
+              <span className="text-xs text-destructive flex items-center gap-1">
+                <HugeiconsIcon icon={AlertCircleIcon} size={12} />
+                Not saved
+              </span>
+            )}
+            {!isSaving && !error && lastSaved && (
               <span className="text-xs text-green-600 dark:text-green-400 flex items-center gap-1">
                 <HugeiconsIcon icon={CheckmarkCircle01Icon} size={12} />
                 Saved {lastSaved.toLocaleTimeString()}
               </span>
             )}
-            {!isSaving && !lastSaved && (
+            {!isSaving && !error && !lastSaved && (
               <span className="text-xs text-muted-foreground">
                 Not saved yet
               </span>

--- a/frontend/src/components/chapters/ChapterEditor.tsx
+++ b/frontend/src/components/chapters/ChapterEditor.tsx
@@ -592,7 +592,12 @@ export function ChapterEditor({
           <span className="text-sm text-foreground">
             {editor?.storage.characterCount.characters() ?? 0} characters
           </span>
+          {/* Autosave result is otherwise a purely visual cue. Polite so it
+              never interrupts typing — which is precisely what the user is
+              doing when the 3s autosave fires (#349). */}
           <div
+            role="status"
+            aria-live="polite"
             className="flex items-center gap-2"
             data-testid="save-status-indicator"
             data-save-status={isSaving ? 'saving' : lastSaved ? 'saved' : 'idle'}

--- a/frontend/src/components/chapters/__tests__/ChapterEditorSaveStatusA11y.test.tsx
+++ b/frontend/src/components/chapters/__tests__/ChapterEditorSaveStatusA11y.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * #349: an autosave failure must be announced, and must not be reported as a
+ * success.
+ *
+ * `lastSaved` survives from the previous successful save, so the footer kept
+ * rendering "Saved 14:32" while the save was failing. Once that footer became a
+ * polite live region, it announced a stale success — and the failure message
+ * itself had no `role="alert"`, so the actual outcome was announced nowhere.
+ * A screen-reader user was told the opposite of what happened.
+ */
+import { render, screen, act, waitFor } from '@testing-library/react';
+import { ChapterEditor } from '@/components/chapters/ChapterEditor';
+import bookClient from '@/lib/api/bookClient';
+
+jest.mock('@/lib/api/bookClient', () => ({
+  __esModule: true,
+  default: {
+    getChapterContent: jest.fn(),
+    saveChapterContent: jest.fn(),
+  },
+}));
+
+const mockClient = bookClient as unknown as {
+  getChapterContent: jest.Mock;
+  saveChapterContent: jest.Mock;
+};
+
+describe('ChapterEditor save status announcements (#349)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockClient.getChapterContent.mockResolvedValue({ content: '<p>hi</p>' });
+  });
+
+  it('announces a save failure through an alert', async () => {
+    mockClient.saveChapterContent.mockRejectedValue(new Error('network down'));
+
+    await act(async () => {
+      render(<ChapterEditor bookId="b1" chapterId="c1" chapterTitle="Ch" />);
+    });
+
+    await act(async () => {
+      screen.getByRole('button', { name: /^save$/i }).click();
+    });
+
+    await waitFor(() => {
+      // Assertive, because the writing may now exist only in the local backup.
+      expect(screen.getByRole('alert')).toHaveTextContent(/failed to save/i);
+    });
+  });
+
+  it('does not keep reporting the previous success while a save is failing', async () => {
+    mockClient.saveChapterContent
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('network down'));
+
+    await act(async () => {
+      render(<ChapterEditor bookId="b1" chapterId="c1" chapterTitle="Ch" />);
+    });
+
+    const save = screen.getByRole('button', { name: /^save$/i });
+
+    // First save succeeds, so lastSaved is populated.
+    await act(async () => {
+      save.click();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('save-status-indicator')).toHaveAttribute(
+        'data-save-status',
+        'saved'
+      );
+    });
+
+    // Second save fails. The status region must not still say "Saved <time>".
+    await act(async () => {
+      save.click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('save-status-indicator')).toHaveAttribute(
+        'data-save-status',
+        'error'
+      );
+    });
+    expect(screen.getByTestId('save-status-indicator')).not.toHaveTextContent(/^Saved /);
+  });
+});

--- a/frontend/src/components/chapters/questions/QuestionDisplay.tsx
+++ b/frontend/src/components/chapters/questions/QuestionDisplay.tsx
@@ -526,18 +526,27 @@ export default function QuestionDisplay({
             aria-label="Your response to the question"
           />
 
+          {/*
+            Single always-mounted live region (#349). A region inserted at the
+            same moment as its text is frequently not announced at all — the
+            screen reader has to be observing the node before it mutates. The
+            visual indicators below are aria-hidden so the same status is not
+            read twice.
+          */}
+          <div role="status" aria-live="polite" className="sr-only">
+            {saveStatus === 'saving' && 'Your response is being stored'}
+            {saveStatus === 'saved' && 'Your response was stored successfully'}
+            {saveStatus === 'error' && 'Your response could not be stored'}
+            {saveStatus === 'queued' && 'Your response will be retried'}
+            {!isOnline && ' You are working offline'}
+            {wasOffline && ' Your connection is back'}
+          </div>
+
           {/* Save status and error with visual indicators */}
           <div className="flex items-center justify-between">
             {/* Save status indicator */}
             {saveStatus !== 'idle' && (
-              // Autosave outcome is otherwise a purely visual cue — a screen
-              // reader user gets no signal that their answer was stored, or
-              // wasn't (#349). Polite: it must not interrupt typing.
-              <div
-                role="status"
-                aria-live="polite"
-                className="flex items-center gap-2 text-xs"
-              >
+              <div className="flex items-center gap-2 text-xs" aria-hidden="true">
                 {saveStatus === 'saving' && (
                   <>
                     <HugeiconsIcon icon={Loading03Icon} size={16} className="animate-spin text-blue-600" />
@@ -567,11 +576,7 @@ export default function QuestionDisplay({
 
             {/* Offline indicator */}
             {!isOnline && (
-              <div
-                role="status"
-                aria-live="polite"
-                className="flex items-center gap-2 text-xs text-amber-600"
-              >
+              <div className="flex items-center gap-2 text-xs text-amber-600" aria-hidden="true">
                 <HugeiconsIcon icon={WifiOff01Icon} size={16} />
                 <span>Offline mode</span>
               </div>
@@ -579,11 +584,7 @@ export default function QuestionDisplay({
 
             {/* Reconnected notification */}
             {wasOffline && (
-              <div
-                role="status"
-                aria-live="polite"
-                className="flex items-center gap-2 text-xs text-green-600"
-              >
+              <div className="flex items-center gap-2 text-xs text-green-600" aria-hidden="true">
                 <HugeiconsIcon icon={CheckmarkCircle01Icon} size={16} />
                 <span>Connection restored</span>
               </div>
@@ -592,13 +593,11 @@ export default function QuestionDisplay({
 
           {/* Error message with retry button */}
           {saveError && (
-            // role="alert" (assertive): the user's answer may not have been
-            // saved, which is worth interrupting for.
-            <div
-              role="alert"
-              className="flex items-center justify-between bg-red-50 dark:bg-red-900/10 p-3 rounded-md"
-            >
-              <p className="text-xs text-red-600 flex-1">{saveError}</p>
+            <div className="flex items-center justify-between bg-red-50 dark:bg-red-900/10 p-3 rounded-md">
+              {/* role="alert" on the message only: scoping it to the container
+                  would put the Retry button inside an assertive region, so its
+                  label gets announced as part of the alert. */}
+              <p role="alert" className="text-xs text-red-600 flex-1">{saveError}</p>
               {saveStatus === 'error' && retryCount < 3 && (
                 <Button
                   variant="outline"

--- a/frontend/src/components/chapters/questions/QuestionDisplay.tsx
+++ b/frontend/src/components/chapters/questions/QuestionDisplay.tsx
@@ -530,7 +530,14 @@ export default function QuestionDisplay({
           <div className="flex items-center justify-between">
             {/* Save status indicator */}
             {saveStatus !== 'idle' && (
-              <div className="flex items-center gap-2 text-xs">
+              // Autosave outcome is otherwise a purely visual cue — a screen
+              // reader user gets no signal that their answer was stored, or
+              // wasn't (#349). Polite: it must not interrupt typing.
+              <div
+                role="status"
+                aria-live="polite"
+                className="flex items-center gap-2 text-xs"
+              >
                 {saveStatus === 'saving' && (
                   <>
                     <HugeiconsIcon icon={Loading03Icon} size={16} className="animate-spin text-blue-600" />
@@ -560,7 +567,11 @@ export default function QuestionDisplay({
 
             {/* Offline indicator */}
             {!isOnline && (
-              <div className="flex items-center gap-2 text-xs text-amber-600">
+              <div
+                role="status"
+                aria-live="polite"
+                className="flex items-center gap-2 text-xs text-amber-600"
+              >
                 <HugeiconsIcon icon={WifiOff01Icon} size={16} />
                 <span>Offline mode</span>
               </div>
@@ -568,7 +579,11 @@ export default function QuestionDisplay({
 
             {/* Reconnected notification */}
             {wasOffline && (
-              <div className="flex items-center gap-2 text-xs text-green-600">
+              <div
+                role="status"
+                aria-live="polite"
+                className="flex items-center gap-2 text-xs text-green-600"
+              >
                 <HugeiconsIcon icon={CheckmarkCircle01Icon} size={16} />
                 <span>Connection restored</span>
               </div>
@@ -577,7 +592,12 @@ export default function QuestionDisplay({
 
           {/* Error message with retry button */}
           {saveError && (
-            <div className="flex items-center justify-between bg-red-50 dark:bg-red-900/10 p-3 rounded-md">
+            // role="alert" (assertive): the user's answer may not have been
+            // saved, which is worth interrupting for.
+            <div
+              role="alert"
+              className="flex items-center justify-between bg-red-50 dark:bg-red-900/10 p-3 rounded-md"
+            >
               <p className="text-xs text-red-600 flex-1">{saveError}</p>
               {saveStatus === 'error' && retryCount < 3 && (
                 <Button

--- a/frontend/src/components/toc/ClarifyingQuestions.tsx
+++ b/frontend/src/components/toc/ClarifyingQuestions.tsx
@@ -157,14 +157,14 @@ export default function ClarifyingQuestions({ questions, onSubmit, isLoading, bo
               Auto-save failed — your latest answers may not be saved
             </div>
           ) : lastSaved ? (
-            <div className="flex items-center text-green-400">
+            <div role="status" aria-live="polite" className="flex items-center text-green-400">
               <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3 mr-2" viewBox="0 0 20 20" fill="currentColor">
                 <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
               </svg>
               Auto-saved
             </div>
           ) : (
-            <div className="text-gray-500">
+            <div className="text-gray-400">
               Responses will be saved automatically
             </div>
           )}
@@ -199,11 +199,19 @@ export default function ClarifyingQuestions({ questions, onSubmit, isLoading, bo
         </div>
       ) : (
         <div className="bg-gray-900 border border-gray-700 rounded-lg p-6 mb-6">
-          <h3 className="text-gray-100 font-medium mb-4 text-lg">
+          <h2
+            id="clarifying-question-prompt"
+            className="text-gray-100 font-medium mb-4 text-lg"
+          >
             {currentQuestion}
-          </h3>
+          </h2>
 
+          {/* The question itself is the field's label. Placeholder text is not
+              an accessible name — it disappears on input and is skipped by some
+              screen readers, so this field previously announced as unlabelled
+              (#349). */}
           <textarea
+            aria-labelledby="clarifying-question-prompt"
             value={responses[currentQuestionIndex] || ''}
             onChange={(e) => handleResponseChange(currentQuestionIndex, e.target.value)}
             placeholder="Type your answer here..."
@@ -261,7 +269,7 @@ export default function ClarifyingQuestions({ questions, onSubmit, isLoading, bo
 
       {/* Questions overview */}
       <div className="bg-gray-900 border border-gray-700 rounded-lg p-4">
-        <h4 className="text-gray-300 font-medium mb-3">Question Overview</h4>
+        <h3 className="text-gray-300 font-medium mb-3">Question Overview</h3>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
           {questions.map((_, index) => (
             <button

--- a/frontend/src/components/toc/ClarifyingQuestions.tsx
+++ b/frontend/src/components/toc/ClarifyingQuestions.tsx
@@ -149,7 +149,17 @@ export default function ClarifyingQuestions({ questions, onSubmit, isLoading, bo
           insertion is itself the trigger, so the failure branch keeps its own.)
         */}
         <div role="status" aria-live="polite" className="sr-only">
-          {isSaving ? 'Saving your answers' : lastSaved ? 'Answers auto-saved' : ''}
+          {/* Precedence must mirror the visual branches below. Checking
+              lastSaved before saveError announced "auto-saved" at the very
+              moment the alert announced failure, because lastSaved survives
+              from the previous successful save. */}
+          {isSaving
+            ? 'Saving your answers'
+            : saveError
+              ? ''
+              : lastSaved
+                ? 'Answers auto-saved'
+                : ''}
         </div>
 
         {/* Auto-save status */}

--- a/frontend/src/components/toc/ClarifyingQuestions.tsx
+++ b/frontend/src/components/toc/ClarifyingQuestions.tsx
@@ -142,10 +142,20 @@ export default function ClarifyingQuestions({ questions, onSubmit, isLoading, bo
           Help us create the best table of contents by answering a few questions about your book.
         </p>
 
+        {/*
+          One always-mounted polite region (#349). A role="status" node inserted
+          at the same instant as its text is often never announced — the reader
+          must already be observing it. (role="alert" below is different:
+          insertion is itself the trigger, so the failure branch keeps its own.)
+        */}
+        <div role="status" aria-live="polite" className="sr-only">
+          {isSaving ? 'Saving your answers' : lastSaved ? 'Answers auto-saved' : ''}
+        </div>
+
         {/* Auto-save status */}
         <div className="mt-3 flex items-center text-sm">
           {isSaving ? (
-            <div className="flex items-center text-blue-400">
+            <div className="flex items-center text-blue-400" aria-hidden="true">
               <div className="animate-spin rounded-full h-3 w-3 border-t-2 border-b-2 border-blue-400 mr-2"></div>
               Saving...
             </div>
@@ -157,7 +167,7 @@ export default function ClarifyingQuestions({ questions, onSubmit, isLoading, bo
               Auto-save failed — your latest answers may not be saved
             </div>
           ) : lastSaved ? (
-            <div role="status" aria-live="polite" className="flex items-center text-green-400">
+            <div className="flex items-center text-green-400" aria-hidden="true">
               <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3 mr-2" viewBox="0 0 20 20" fill="currentColor">
                 <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
               </svg>
@@ -199,12 +209,12 @@ export default function ClarifyingQuestions({ questions, onSubmit, isLoading, bo
         </div>
       ) : (
         <div className="bg-gray-900 border border-gray-700 rounded-lg p-6 mb-6">
-          <h2
+          <h3
             id="clarifying-question-prompt"
             className="text-gray-100 font-medium mb-4 text-lg"
           >
             {currentQuestion}
-          </h2>
+          </h3>
 
           {/* The question itself is the field's label. Placeholder text is not
               an accessible name — it disappears on input and is skipped by some

--- a/frontend/src/components/toc/ErrorDisplay.tsx
+++ b/frontend/src/components/toc/ErrorDisplay.tsx
@@ -33,7 +33,7 @@ export default function ErrorDisplay({ error, onRetry, statusCode }: ErrorDispla
             Upgrade Plan
           </a>
 
-          <p className="text-gray-500 text-sm mt-6 max-w-md mx-auto">
+          <p className="text-gray-400 text-sm mt-6 max-w-md mx-auto">
             Contact support if you believe this is a mistake.
           </p>
         </div>

--- a/frontend/src/components/toc/TocGenerating.tsx
+++ b/frontend/src/components/toc/TocGenerating.tsx
@@ -62,7 +62,7 @@ export default function TocGenerating() {
                   )}
                 </div>
                 <span className={`text-sm ${
-                  index <= currentStep ? 'text-gray-300' : 'text-gray-500'
+                  index <= currentStep ? 'text-gray-300' : 'text-gray-400'
                 }`}>
                   {step}
                 </span>

--- a/frontend/src/components/toc/TocReview.tsx
+++ b/frontend/src/components/toc/TocReview.tsx
@@ -201,7 +201,7 @@ function ChapterItem({ chapter, index, isExpanded, onToggle, expandedChapters, t
               <p className="text-gray-400 text-sm mt-1">{chapter.description}</p>
             )}
             {chapter.word_count && (
-              <div className="flex items-center gap-2 text-xs text-gray-500 mt-1">
+              <div className="flex items-center gap-2 text-xs text-gray-400 mt-1">
                 <span>{chapter.word_count} words</span>
                 {chapter.estimated_reading_time && (
                   <>

--- a/frontend/src/components/toc/TocSidebar.tsx
+++ b/frontend/src/components/toc/TocSidebar.tsx
@@ -73,7 +73,7 @@ function TocItem({ chapter, level, isActive, isExpanded, onToggle, onSelect, act
 
         {/* Word Count Badge */}
         {chapter.word_count > 0 && (
-          <span className="text-xs text-gray-500 bg-gray-800 px-1.5 py-0.5 rounded">
+          <span className="text-xs text-gray-400 bg-gray-800 px-1.5 py-0.5 rounded">
             {chapter.word_count}w
           </span>
         )}
@@ -128,7 +128,7 @@ export function TocSidebar({
   if (!tocData || !tocData.chapters || tocData.chapters.length === 0) {
     return (
       <div className={cn("w-64 border-r border-gray-800 bg-gray-900", className)}>
-        <div className="p-4 text-center text-gray-500">
+        <div className="p-4 text-center text-gray-400">
           <HugeiconsIcon icon={BookOpen01Icon} size={32} className="mx-auto mb-2 opacity-50" aria-hidden="true" />
           <p className="text-sm">No chapters available</p>
         </div>
@@ -174,11 +174,11 @@ export function TocSidebar({
         <div className="grid grid-cols-2 gap-2 text-xs">
           <div className="text-center">
             <div className="text-lg font-bold text-gray-100">{tocData.total_chapters}</div>
-            <div className="text-gray-500">Chapters</div>
+            <div className="text-gray-400">Chapters</div>
           </div>
           <div className="text-center">
             <div className="text-lg font-bold text-gray-100">{tocData.estimated_pages}</div>
-            <div className="text-gray-500">Pages</div>
+            <div className="text-gray-400">Pages</div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/toc/__tests__/ClarifyingQuestionsA11y.test.tsx
+++ b/frontend/src/components/toc/__tests__/ClarifyingQuestionsA11y.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * #349: the clarifying-questions answer field must have an accessible name.
+ *
+ * It had only a placeholder. Placeholder text is not an accessible name — it
+ * vanishes the moment the user types, and several screen readers skip it
+ * entirely — so the field announced as unlabelled and a user could not tell
+ * which question they were answering.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import ClarifyingQuestions from '../ClarifyingQuestions';
+
+expect.extend(toHaveNoViolations);
+
+// The component loads any previously-saved answers on mount and shows a loading
+// state until that settles.
+jest.mock('@/lib/api/bookClient', () => ({
+  bookClient: {
+    getQuestionResponses: jest.fn().mockResolvedValue({ responses: [] }),
+    saveQuestionResponses: jest.fn().mockResolvedValue({}),
+  },
+}));
+
+const QUESTIONS = [
+  'What is the central argument of your book?',
+  'Who is the intended reader?',
+];
+
+function renderQuestions() {
+  return render(
+    <ClarifyingQuestions
+      questions={QUESTIONS}
+      onSubmit={jest.fn()}
+      isLoading={false}
+      bookId="book-1"
+    />
+  );
+}
+
+describe('ClarifyingQuestions accessibility', () => {
+  it('names the answer field after the question being asked', async () => {
+    renderQuestions();
+
+    // The accessible name must be the question itself, not "Type your answer
+    // here..." — that is what tells the user what they are answering.
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: QUESTIONS[0] })).toBeInTheDocument();
+    });
+  });
+
+  it('has no axe violations', async () => {
+    const { container } = renderQuestions();
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: QUESTIONS[0] })).toBeInTheDocument();
+    });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/frontend/src/components/toc/__tests__/ClarifyingQuestionsA11y.test.tsx
+++ b/frontend/src/components/toc/__tests__/ClarifyingQuestionsA11y.test.tsx
@@ -56,3 +56,28 @@ describe('ClarifyingQuestions accessibility', () => {
     expect(await axe(container)).toHaveNoViolations();
   });
 });
+
+describe('ClarifyingQuestions save announcements', () => {
+  it('does not announce success while a save failure is showing', async () => {
+    // lastSaved survives from the previous successful save, so a naive
+    // lastSaved-first ternary announced "Answers auto-saved" at the same instant
+    // the alert announced failure — two contradictory messages from one event.
+    const { bookClient } = jest.requireMock('@/lib/api/bookClient');
+    bookClient.getQuestionResponses.mockResolvedValueOnce({
+      responses: [{ question: QUESTIONS[0], answer: 'a previous answer' }],
+    });
+    bookClient.saveQuestionResponses.mockRejectedValueOnce(new Error('nope'));
+
+    const { container } = renderQuestions();
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: QUESTIONS[0] })).toBeInTheDocument();
+    });
+
+    const announcer = container.querySelector('[role="status"].sr-only');
+    expect(announcer).toBeTruthy();
+    // Whatever it says, it must never claim success at the same time as an alert.
+    if (screen.queryByRole('alert')) {
+      expect(announcer?.textContent ?? '').not.toMatch(/auto-saved/i);
+    }
+  });
+});


### PR DESCRIPTION
Closes #349.

## Scope note: two of the four ACs were already delivered

- **AC1 (render the fixed EditorToolbar, delete the inline copy)** — done in **#347**. That PR found `EditorToolbar.tsx` sitting unreferenced with #50's accessibility tests attached, and wired it in. Landing it is what put `role="toolbar"`, per-button `aria-label`/`aria-pressed`, and 44px touch targets on live code for the first time.
- **AC3, in part** — done in **#348**: the summary error banner is `role="alert"` and dictation status is a live region.

What remained is below.

## Labelling

The clarifying-questions answer field had only a placeholder. **Placeholder text is not an accessible name** — it disappears the moment the user types, and several screen readers skip it — so the field announced as unlabelled and the user couldn't tell which question they were answering. Now labelled by the question heading via `aria-labelledby`.

## Save status was purely visual

`QuestionDisplay`'s autosave indicator and `ChapterEditor`'s footer status are now announced. A save *failure* is `role="alert"` — a possibly-unsaved answer is worth interrupting for — while a routine "Saved" during typing is polite.

The summary textarea now carries `aria-invalid` and `aria-describedby` pointing at both its readiness error and its help text; the error was previously visible text with nothing associating it to the field. Polite rather than assertive, since it re-evaluates on **every keystroke** and an alert would interrupt continuously.

## Contrast

`text-gray-500` on `gray-800` is ~2.7:1. Raised to `gray-400` (~5:1) where it's body text on a dark surface — 8 occurrences across the TOC components and `BookCreationWizard`'s dark-mode override.

**Deliberately not changed**, after checking each of the 26 occurrences rather than sweeping:
- **Disabled controls** (`disabled:text-gray-500` ×2) — WCAG 1.4.3 explicitly exempts inactive components, and the dimming *is* the affordance.
- **Auth pages** — already carry `dark:text-gray-400` overrides, so they're fine in the mode that matters.
- **Icons** — non-text, governed by the 3:1 rule, and all accompanied by text labels.
- **Generic theme-token components** (`text-muted-foreground` et al) — need a theme-wide audit, not a spot fix.

A blanket find-and-replace would have been wrong in at least the first two categories.

## Review round: live regions that would never have announced

CodeRabbit caught that my live regions were **mounted together with their content**. That's the classic way to get silence — a screen reader must already be observing a `role="status"` node to notice it mutate, so inserting region and text in the same commit frequently announces nothing at all. The feature I added would have been decorative.

Both surfaces now keep one always-mounted `sr-only` announcer, with the visual indicators `aria-hidden` so the status isn't read twice. `role="alert"` is left inserted-on-demand on the failure branch, because for alerts insertion *is* the trigger.

The announcer wording is intentionally distinct from the visual labels ("Your response could not be stored" vs "Save failed") — that keeps existing `getByText` queries unambiguous, and full sentences read better than terse visual chips.

`role="alert"` also moved off the error *container* onto the message itself: the container holds the Retry button, whose label was being announced as part of the alert.

## A correction to my own change

My first commit promoted the question prompt `h3` → `h2`, claiming the wizard's `h1` was followed directly by an `h3`. **That was wrong.** The component renders its own `h2` section header, so the question belongs *under* it at `h3` — my change made it a sibling of its own section.

The real violation was only the `h4` "Question Overview", which renders in a branch where the question `h3` does not, so it followed the `h2` directly. The `h4` → `h3` fix was sufficient; the `h2` promotion is reverted. Settled by running axe both ways rather than reasoning about the markup.

## Verification

| Check | Result |
|-------|--------|
| Full frontend suite (coverage) | **131/131 suites, 2282 passed**, thresholds met |
| `tsc --noEmit` | clean |
| `npm run lint` | 0 errors |
| axe on ClarifyingQuestions | no violations |
| Mutation check | removing `aria-labelledby` fails both new tests, including axe |

🤖 Generated with [Claude Code](https://claude.com/claude-code)