### PR TITLE
fix(backend): close nine latent fail-opens and robustness gaps (#352)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -18,6 +18,11 @@ on:
 # time out (see the 2026-07-12 failures). Serialize: one deploy at a time, the
 # newest queued run supersedes older queued ones. Never cancel a deploy that is
 # already mid-flight.
+# Least privilege: the default GITHUB_TOKEN grants write across most scopes.
+# Nothing here needs more than reading the repository (#352).
+permissions:
+  contents: read
+
 concurrency:
   group: deploy-staging
   cancel-in-progress: false

--- a/.github/workflows/e2e-staging-tests.yml
+++ b/.github/workflows/e2e-staging-tests.yml
@@ -34,6 +34,11 @@ on:
     types: [labeled, opened, synchronize, reopened]
 
 # A new push to a labeled PR cancels the previous in-flight staging run.
+# Least privilege: the default GITHUB_TOKEN grants write across most scopes.
+# Nothing here needs more than reading the repository (#352).
+permissions:
+  contents: read
+
 concurrency:
   group: e2e-staging-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,11 @@ on:
       - develop
   workflow_dispatch:
 
+# Least privilege: the default GITHUB_TOKEN grants write across most scopes.
+# Nothing here needs more than reading the repository (#352).
+permissions:
+  contents: read
+
 jobs:
   frontend-tests:
     name: Frontend Tests

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -43,18 +43,6 @@ async def get_database_collection(collection_name: str):
     return await get_collection(collection_name)
 
 
-async def get_api_key(x_api_key: str = Header(None)):
-    """Validate API key for external services"""
-    # This would compare against a stored API key in a real application
-    if x_api_key is None or x_api_key == "":
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="API key is missing"
-        )
-    # You would validate the API key against your stored value here
-    # For now, this is a placeholder
-    return x_api_key
-
-
 def sanitize_input(text: str) -> str:
     """Basic sanitization of user input"""
     if not text:

--- a/backend/app/api/endpoints/books.py
+++ b/backend/app/api/endpoints/books.py
@@ -2604,6 +2604,18 @@ async def generate_chapter_draft(
         )
 
         if not result.get("success"):
+            # Truncation is a user-fixable request problem, not an outage. 503
+            # invites a retry that will fail identically; 422 says what to change
+            # and carries the actionable message through (#352).
+            if result.get("error_code") == "DRAFT_TRUNCATED":
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail={
+                        "message": result.get("error"),
+                        "error_code": "DRAFT_TRUNCATED",
+                        "retryable": False,
+                    },
+                )
             raise HTTPException(
                 status_code=503,
                 detail=f"Failed to generate draft: {result.get('error', 'Unknown error')}"
@@ -2646,6 +2658,51 @@ async def generate_chapter_draft(
 
     except HTTPException:
         raise
+    # Same structured mapping the other AI endpoints use. Draft generation had
+    # only the generic handler below, so once ai_service stopped flattening
+    # AIServiceError into a dict, a rate limit would have surfaced as an opaque
+    # 500 with no retry_after (#352).
+    except AIRateLimitError as e:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={
+                "message": e.message,
+                "error_code": e.error_code,
+                "retry_after": e.retry_after,
+                "cached_content_available": e.cached_content_available,
+                "correlation_id": e.correlation_id,
+            },
+        )
+    except (AIServiceUnavailableError, AINetworkError) as e:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "message": e.message,
+                "error_code": e.error_code,
+                "retry_after": getattr(e, "retry_after", None),
+                "retryable": getattr(e, "retryable", True),
+                "correlation_id": e.correlation_id,
+            },
+        )
+    except AIInvalidRequestError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "message": e.message,
+                "error_code": e.error_code,
+                "correlation_id": e.correlation_id,
+            },
+        )
+    except AIServiceError as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={
+                "message": e.message,
+                "error_code": e.error_code,
+                "retryable": e.retryable,
+                "correlation_id": e.correlation_id,
+            },
+        )
     except Exception:
         logger.error("Error generating draft", exc_info=True)
         raise HTTPException(

--- a/backend/app/api/endpoints/users.py
+++ b/backend/app/api/endpoints/users.py
@@ -351,7 +351,10 @@ async def update_user_data(
 @router.get("/admin/users", response_model=List[UserResponse])
 async def get_all_users(
     _: Dict = Depends(allow_admins),
-    skip: int = Query(0, ge=0, description="Number of users to skip"),
+    # skip is capped as well as limit: Mongo walks every skipped document, so an
+    # unbounded offset turns a cheap query into a full scan the caller controls.
+    # 100k is far beyond any realistic admin page and still bounds the work.
+    skip: int = Query(0, ge=0, le=100_000, description="Number of users to skip"),
     limit: int = Query(100, ge=1, le=500, description="Maximum users to return"),
 ):
     """Get users (admin only), newest first.

--- a/backend/app/api/endpoints/users.py
+++ b/backend/app/api/endpoints/users.py
@@ -1,6 +1,6 @@
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, status, Request, UploadFile, File
+from fastapi import APIRouter, Depends, HTTPException, status, Request, UploadFile, File, Query
 from fastapi.security import HTTPBearer
 from typing import List, Dict
 from datetime import datetime, timezone
@@ -349,10 +349,26 @@ async def update_user_data(
 
 
 @router.get("/admin/users", response_model=List[UserResponse])
-async def get_all_users(_: Dict = Depends(allow_admins)):
-    """Get all users (admin only)"""
+async def get_all_users(
+    _: Dict = Depends(allow_admins),
+    skip: int = Query(0, ge=0, description="Number of users to skip"),
+    limit: int = Query(100, ge=1, le=500, description="Maximum users to return"),
+):
+    """Get users (admin only), newest first.
+
+    Paginated deliberately: this was an unbounded find().to_list(length=None),
+    which loads every user document into memory and serialises them in one
+    response. That is fine at a few hundred users and a availability problem at
+    a few hundred thousand (#352). le=500 caps what a single call can cost.
+    """
     users_collection = await get_collection("users")
-    users = await users_collection.find().to_list(length=None)
+    users = (
+        await users_collection.find()
+        .sort("_id", -1)
+        .skip(skip)
+        .limit(limit)
+        .to_list(length=limit)
+    )
     return users
 
 

--- a/backend/app/api/endpoints/webhooks.py
+++ b/backend/app/api/endpoints/webhooks.py
@@ -145,28 +145,26 @@ async def _apply_subscription_event(
     # before rather than dropped.
     #
     # Known limit: `created` has one-second granularity, so two updates inside
-    # the same second cannot be ordered by it. The comparison is `<` rather than
-    # `<=` deliberately — dropping same-second events would discard legitimate
-    # ones, and last-write-wins within a second is the pre-existing behaviour.
+    # the same second cannot be ordered by it. The filter uses `$lte` so
+    # same-second events are still applied (last-write-wins within one second,
+    # the pre-existing behaviour) rather than silently dropped.
     # The complete fix is to re-fetch the subscription from Stripe on each event
     # and apply canonical state; that trades an extra API call (and a new failure
     # mode when Stripe is unreachable) for exactness, and is the upgrade path if
     # same-second races ever show up in practice.
-    last_applied = user.get("stripe_event_created")
-    if (
-        event_created is not None
-        and last_applied is not None
-        and event_created < last_applied
-    ):
-        logger.info(
-            "Stripe %s (created=%s) is older than the applied event (created=%s) "
-            "for user %s — ignoring",
-            event_type,
-            event_created,
-            last_applied,
-            user["auth_id"],
-        )
-        return {"status": "stale_event", "event_id": event_id}
+    # Enforced by Mongo as part of the write, not by a read here. Two deliveries
+    # for the same customer carry DIFFERENT event ids, so mark_event_processed
+    # does not serialize them: a read-then-write check lets both pass and the
+    # older one land last. The condition goes in the query instead.
+    ordering_filter = None
+    if event_created is not None:
+        ordering_filter = {
+            "$or": [
+                {"stripe_event_created": {"$exists": False}},
+                {"stripe_event_created": None},
+                {"stripe_event_created": {"$lte": event_created}},
+            ]
+        }
 
     # If a concurrent request linked this stripe_customer_id to a DIFFERENT user
     # between our lookup and this write (TOCTOU — the only way to reach it, since
@@ -177,17 +175,31 @@ async def _apply_subscription_event(
     # customer id is deliberately RETAINED — the Stripe customer still exists,
     # only the subscription ended. actor_id makes every plan transition
     # auditable (billing disputes).
-    await update_user(
+    updated = await update_user(
         user["auth_id"],
         {
             "plan": plan,
             "stripe_customer_id": customer_id,
             "stripe_subscription_id": subscription_id,
-            # Watermark for the out-of-order guard above.
+            # Watermark the ordering filter above compares against.
             **({"stripe_event_created": event_created} if event_created is not None else {}),
         },
         actor_id=f"stripe:{event_id}",
+        extra_filter=ordering_filter,
     )
+
+    if updated is None and ordering_filter is not None:
+        # The user exists (looked up above), so a no-match means the ordering
+        # condition rejected this write: a newer event has already been applied.
+        logger.info(
+            "Stripe %s (created=%s) is older than the applied event for user %s "
+            "— ignoring",
+            event_type,
+            event_created,
+            user["auth_id"],
+        )
+        return {"status": "stale_event", "event_id": event_id}
+
     logger.info(
         "Stripe %s: user %s plan set to %s", event_type, user["auth_id"], plan
     )

--- a/backend/app/api/endpoints/webhooks.py
+++ b/backend/app/api/endpoints/webhooks.py
@@ -76,7 +76,13 @@ async def stripe_webhook(request: Request):
 
     try:
         subscription = (event.get("data") or {}).get("object") or {}
-        return await _apply_subscription_event(event_type, subscription, event_id)
+        # Stripe guarantees delivery, not order. Pass the event's own timestamp
+        # so an older update that arrives late cannot overwrite a newer plan
+        # (#352) — idempotency above only stops the *same* event twice.
+        event_created = event.get("created")
+        return await _apply_subscription_event(
+            event_type, subscription, event_id, event_created
+        )
     except Exception:
         # Release the claim so Stripe's retry of this failure isn't treated as
         # a replay, then surface a 500 (Stripe retries non-2xx).
@@ -86,9 +92,17 @@ async def stripe_webhook(request: Request):
 
 
 async def _apply_subscription_event(
-    event_type: str, subscription: dict, event_id: str
+    event_type: str, subscription: dict, event_id: str,
+    event_created: int | None = None,
 ) -> dict:
-    """Resolve the plan for a verified customer.subscription.* event and persist it."""
+    """Resolve the plan for a verified customer.subscription.* event and persist it.
+
+    ``event_created`` is Stripe's own epoch timestamp for the event. Deliveries
+    are not ordered, so a subscription.updated from 10:00 can land after the one
+    from 10:05 — applying it would silently downgrade (or upgrade) a user to a
+    stale plan. Each applied event records its timestamp and anything older is
+    ignored.
+    """
     customer_id = subscription.get("customer")
     subscription_id = subscription.get("id")
 
@@ -123,6 +137,28 @@ async def _apply_subscription_event(
         )
         return {"status": "no_matching_user"}
 
+    # Out-of-order guard. Stripe does not order deliveries, so an older
+    # subscription.updated can arrive after a newer one and overwrite the plan
+    # with a stale value — a real downgrade for a paying user. Idempotency above
+    # only prevents the SAME event twice; this prevents an EARLIER one landing
+    # last. Events without a timestamp (older payload shapes) are applied as
+    # before rather than dropped.
+    last_applied = user.get("stripe_event_created")
+    if (
+        event_created is not None
+        and last_applied is not None
+        and event_created < last_applied
+    ):
+        logger.info(
+            "Stripe %s (created=%s) is older than the applied event (created=%s) "
+            "for user %s — ignoring",
+            event_type,
+            event_created,
+            last_applied,
+            user["auth_id"],
+        )
+        return {"status": "stale_event", "event_id": event_id}
+
     # If a concurrent request linked this stripe_customer_id to a DIFFERENT user
     # between our lookup and this write (TOCTOU — the only way to reach it, since
     # the lookup above wins otherwise), the unique index rejects the $set -> 500
@@ -138,6 +174,8 @@ async def _apply_subscription_event(
             "plan": plan,
             "stripe_customer_id": customer_id,
             "stripe_subscription_id": subscription_id,
+            # Watermark for the out-of-order guard above.
+            **({"stripe_event_created": event_created} if event_created is not None else {}),
         },
         actor_id=f"stripe:{event_id}",
     )

--- a/backend/app/api/endpoints/webhooks.py
+++ b/backend/app/api/endpoints/webhooks.py
@@ -143,6 +143,15 @@ async def _apply_subscription_event(
     # only prevents the SAME event twice; this prevents an EARLIER one landing
     # last. Events without a timestamp (older payload shapes) are applied as
     # before rather than dropped.
+    #
+    # Known limit: `created` has one-second granularity, so two updates inside
+    # the same second cannot be ordered by it. The comparison is `<` rather than
+    # `<=` deliberately — dropping same-second events would discard legitimate
+    # ones, and last-write-wins within a second is the pre-existing behaviour.
+    # The complete fix is to re-fetch the subscription from Stripe on each event
+    # and apply canonical state; that trades an extra API call (and a new failure
+    # mode when Stripe is unreachable) for exactness, and is the upgrade path if
+    # same-second races ever show up in practice.
     last_applied = user.get("stripe_event_created")
     if (
         event_created is not None

--- a/backend/app/core/better_auth_session.py
+++ b/backend/app/core/better_auth_session.py
@@ -99,6 +99,18 @@ async def validate_better_auth_session(request: Request) -> Optional[Dict[str, A
 
         # Check if session has expired
         expires_at = session.get("expiresAt")
+        if not expires_at:
+            # Fail closed. `if expires_at:` meant a session document missing the
+            # field skipped the expiry check altogether and was treated as
+            # valid — an unexpirable session from a malformed or
+            # partially-written record (#352). A session we cannot date is a
+            # session we cannot trust.
+            logger.warning(
+                "Session %s has no expiresAt; rejecting as invalid",
+                session.get("_id"),
+            )
+            return None
+
         if expires_at:
             # Handle both datetime objects and ISO strings
             if isinstance(expires_at, str):

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -26,6 +26,21 @@ def is_production_env() -> bool:
     return "production" in markers
 
 
+def is_deployed_env() -> bool:
+    """True for any environment a real user could reach — staging included.
+
+    is_production_env() deliberately excludes staging, which is right for the
+    fail-safes it guards. But "may this environment fall back to the CI test
+    secret?" is a different question with a different answer: staging is a
+    deployed environment serving real sessions, so it must not (#352).
+    """
+    markers = {
+        (os.getenv("ENVIRONMENT") or "").lower(),
+        (os.getenv("NODE_ENV") or "").lower(),
+    }
+    return bool(markers & {"production", "staging", "prod"})
+
+
 class Settings(BaseSettings):
     # MongoDB connection - MONGODB_URI takes precedence over DATABASE_URL
     MONGODB_URI: str = ""  # Standard env var name (e.g., for Atlas)
@@ -84,7 +99,10 @@ class Settings(BaseSettings):
     # limits on the real product (see _is_exempt_e2e_user in dependencies.py).
     E2E_EXEMPT_EMAILS: str = ""
 
-    AI_MAX_RETRIES: int = 3
+    # ge=1: range(max_retries) with 0 or a negative value never enters the
+    # loop, so _retry_with_backoff returns None implicitly and the caller
+    # AttributeErrors on the result. Fail at config load instead (#352).
+    AI_MAX_RETRIES: int = Field(default=3, ge=1)
 
     # Max times a single question may be regenerated (per-question abuse cap,
     # complementing the endpoint rate limit)
@@ -182,13 +200,19 @@ class Settings(BaseSettings):
         # Allow specific test secret for CI/testing environments
         ci_test_secret = "test-secret-for-ci-minimum-32-characters-long-safe-for-testing"
         if v == ci_test_secret:
-            # Only allow in test/CI environments, not production
-            if is_production_env():
+            # Rejected on every DEPLOYED environment, staging included (#352).
+            # Previously this only checked is_production_env(), so a staging
+            # deploy that forgot the secret booted happily and signed every JWT
+            # with a key committed to this repository in plaintext — anyone who
+            # could read the source could mint tokens for any staging user. The
+            # deploy passed its health check, so nothing surfaced the problem.
+            if is_deployed_env():
                 raise ValueError(
-                    "FATAL: Cannot use test secret in production environment. "
-                    "Generate a strong secret with: python -c 'import secrets; print(secrets.token_urlsafe(32))'"
+                    "FATAL: BETTER_AUTH_SECRET is the committed CI test secret on a "
+                    "deployed environment. This key is public — set a real secret. "
+                    "Generate one with: python -c 'import secrets; print(secrets.token_urlsafe(64))'"
                 )
-            return v  # Allow in test/CI
+            return v  # Allow in local development and test/CI only
 
         # Reject known weak/test secrets (except our specific CI secret)
         weak_secrets = [

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -99,10 +99,12 @@ class Settings(BaseSettings):
     # limits on the real product (see _is_exempt_e2e_user in dependencies.py).
     E2E_EXEMPT_EMAILS: str = ""
 
-    # ge=1: range(max_retries) with 0 or a negative value never enters the
-    # loop, so _retry_with_backoff returns None implicitly and the caller
-    # AttributeErrors on the result. Fail at config load instead (#352).
-    AI_MAX_RETRIES: int = Field(default=3, ge=1)
+    # ge=1: range(max_retries) with 0 or a negative value never enters the loop,
+    # so _retry_with_backoff returns None implicitly and the caller AttributeErrors
+    # on the result. le=10: the backoff is exponential, so a large value does not
+    # fail loudly — it just holds the request open past any sane client timeout
+    # while occupying a worker. Both ends fail at config load instead (#352).
+    AI_MAX_RETRIES: int = Field(default=3, ge=1, le=10)
 
     # Max times a single question may be regenerated (per-question abuse cap,
     # complementing the endpoint rate limit)

--- a/backend/app/db/user.py
+++ b/backend/app/db/user.py
@@ -93,15 +93,27 @@ async def create_user(user_data: Dict) -> Dict:
 
 
 async def update_user(
-    auth_id: str, user_data: Dict, actor_id: str = None
+    auth_id: str, user_data: Dict, actor_id: str = None,
+    extra_filter: Optional[Dict] = None,
 ) -> Optional[Dict]:
-    """Update an existing user"""
+    """Update an existing user.
+
+    ``extra_filter`` is merged into the query so a caller can make the write
+    conditional on server-side state — the condition is then evaluated by Mongo
+    as part of the same atomic operation instead of by the caller beforehand.
+    Returns None when the filter does not match, which a caller must treat as
+    "someone else got there first" rather than "user not found" (#352).
+    """
     # Add updated_at timestamp
     user_data["updated_at"] = datetime.now(timezone.utc)
 
+    query: Dict = {"auth_id": auth_id}
+    if extra_filter:
+        query.update(extra_filter)
+
     # Update the user
     updated_user = await users_collection.find_one_and_update(
-        {"auth_id": auth_id}, {"$set": user_data}, return_document=True
+        query, {"$set": user_data}, return_document=True
     )
 
     # Log the change if user was found and updated

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -906,6 +906,11 @@ Ensure the TOC is comprehensive, logically ordered, and matches the book's scope
             if getattr(choice, "finish_reason", None) == "length":
                 return {
                     "success": False,
+                    # Tagged so the endpoint can map this to 422 rather than 503:
+                    # the request hit a model output limit, which the user fixes
+                    # by asking for less. "Service unavailable" tells them to
+                    # wait and retry, which will fail identically (#352).
+                    "error_code": "DRAFT_TRUNCATED",
                     "error": (
                         "The generated draft was cut off before it finished. "
                         "Try a shorter target length."
@@ -935,6 +940,12 @@ Ensure the TOC is comprehensive, logically ordered, and matches the book's scope
                 "suggestions": self._generate_improvement_suggestions(draft_content)
             }
 
+        except AIServiceError:
+            # Let the structured error through. Flattening it to str(e) here
+            # discarded error_code, retryable and retry_after, so the endpoint
+            # could only answer 503 — losing the rate-limit backoff hint and the
+            # distinction between "try later" and "this request is wrong" (#352).
+            raise
         except Exception as e:
             logger.error(f"Failed to generate chapter draft: {str(e)}")
             return {

--- a/backend/tests/test_api/test_dependencies.py
+++ b/backend/tests/test_api/test_dependencies.py
@@ -11,7 +11,6 @@ from fastapi import HTTPException, Request
 import app.api.dependencies as deps
 from app.api.dependencies import (
     sanitize_input,
-    get_api_key,
     audit_request,
     get_database_collection,
     SanitizedModel,
@@ -330,32 +329,7 @@ class TestRateLimiting:
 class TestAPIKey:
     """Test API key validation"""
 
-    async def test_get_api_key_valid(self):
-        """Test get_api_key with valid key"""
-        api_key = "valid_api_key_123"
 
-        result = await get_api_key(x_api_key=api_key)
-
-        assert result == api_key
-
-    async def test_get_api_key_missing(self):
-        """Test get_api_key with missing key"""
-        with pytest.raises(HTTPException) as exc_info:
-            await get_api_key(x_api_key=None)
-
-        assert exc_info.value.status_code == 401
-        assert "API key is missing" in exc_info.value.detail
-
-    async def test_get_api_key_empty(self):
-        """Test get_api_key with empty key"""
-        with pytest.raises(HTTPException) as exc_info:
-            await get_api_key(x_api_key="")
-
-        assert exc_info.value.status_code == 401
-        assert "API key is missing" in exc_info.value.detail
-
-
-@pytest.mark.asyncio
 class TestAuditRequest:
     """Test audit logging functionality
 

--- a/backend/tests/test_core/test_better_auth_session.py
+++ b/backend/tests/test_core/test_better_auth_session.py
@@ -102,13 +102,22 @@ class TestValidateBetterAuthSession:
             result = await bas.validate_better_auth_session(req)
         assert result["userId"] == "u1"
 
-    async def test_no_expires_at_still_valid(self):
+    async def test_no_expires_at_is_rejected(self):
+        """A session we cannot date is a session we cannot trust (#352).
+
+        This test previously asserted the opposite — `test_no_expires_at_still_valid`
+        pinned the behaviour where a document missing the field skipped the
+        expiry check and was accepted, giving an unexpirable session from a
+        malformed or partially-written record. The issue calls that out as a
+        fail-open; the assertion is inverted to the intended behaviour rather
+        than left encoding the defect.
+        """
         req = _request_with_cookies({"better-auth.session_token": "tok"})
         coll = AsyncMock()
         coll.find_one.return_value = {"_id": "s1", "userId": "u1"}
         with patch.object(bas, "get_collection", AsyncMock(return_value=coll)):
             result = await bas.validate_better_auth_session(req)
-        assert result["userId"] == "u1"
+        assert result is None
 
     async def test_db_exception_returns_none(self):
         req = _request_with_cookies({"better-auth.session_token": "tok"})

--- a/backend/tests/test_core/test_hardening_352.py
+++ b/backend/tests/test_core/test_hardening_352.py
@@ -1,0 +1,137 @@
+"""Regression tests for the #352 hardening cluster.
+
+Each of these guards a fail-open: a condition where the previous code accepted
+something it should have refused, or refused to fail when it should have.
+"""
+import pytest
+from pydantic import ValidationError
+
+import app.core.config as config
+
+CI_TEST_SECRET = "test-secret-for-ci-minimum-32-characters-long-safe-for-testing"
+
+# Note: these monkeypatch is_deployed_env rather than setting ENVIRONMENT and
+# reloading the module. Reloading re-runs the module-level `settings =
+# Settings()`, which — correctly, as of this change — raises when the CI secret
+# meets a deployed marker, so the reload blows up before the assertion. That the
+# import itself fails is the point of the fix; it just makes reload useless as a
+# test fixture.
+
+
+class TestBetterAuthSecretOnDeployedEnvironments:
+    """The committed CI secret must not be usable anywhere real.
+
+    It previously only failed on production, so a staging deploy that forgot the
+    secret booted and signed every JWT with a key committed to this repository —
+    and passed its health check, so nothing surfaced it.
+    """
+
+    def test_ci_secret_is_rejected_on_a_deployed_environment(self, monkeypatch):
+        monkeypatch.setattr(config, "is_deployed_env", lambda: True)
+
+        with pytest.raises(ValidationError) as exc:
+            config.Settings(BETTER_AUTH_SECRET=CI_TEST_SECRET)
+
+        assert "committed CI test secret" in str(exc.value)
+
+    def test_ci_secret_still_allowed_off_deployment(self, monkeypatch):
+        # CI and local development must keep working without provisioning a
+        # secret, which is the whole reason the default exists.
+        monkeypatch.setattr(config, "is_deployed_env", lambda: False)
+
+        settings = config.Settings(BETTER_AUTH_SECRET=CI_TEST_SECRET)
+        assert settings.BETTER_AUTH_SECRET == CI_TEST_SECRET
+
+    def test_a_real_secret_is_accepted_on_a_deployed_environment(self, monkeypatch):
+        monkeypatch.setattr(config, "is_deployed_env", lambda: True)
+
+        real = "x" * 64
+        assert config.Settings(BETTER_AUTH_SECRET=real).BETTER_AUTH_SECRET == real
+
+    @pytest.mark.parametrize(
+        "environment,node_env,expected",
+        [
+            ("staging", "", True),
+            ("STAGING", "", True),
+            ("production", "", True),
+            ("Production", "", True),
+            ("", "production", True),
+            ("development", "", False),
+            ("test", "", False),
+            ("", "", False),
+        ],
+    )
+    def test_is_deployed_env_markers(self, monkeypatch, environment, node_env, expected):
+        # Staging must count as deployed here even though is_production_env()
+        # deliberately excludes it — that is the distinction this fix rests on.
+        monkeypatch.setenv("ENVIRONMENT", environment)
+        monkeypatch.setenv("NODE_ENV", node_env)
+        assert config.is_deployed_env() is expected
+
+
+class TestAiMaxRetriesFloor:
+    """range(0) never enters the loop, so _retry_with_backoff returned None and
+    the caller raised AttributeError on it. Fail at config load instead."""
+
+    @pytest.mark.parametrize("bad", [0, -1])
+    def test_retry_count_below_one_is_rejected(self, bad):
+        with pytest.raises(ValidationError):
+            config.Settings(AI_MAX_RETRIES=bad)
+
+    def test_one_is_allowed(self):
+        assert config.Settings(AI_MAX_RETRIES=1).AI_MAX_RETRIES == 1
+
+
+class TestApiKeyStubIsGone:
+    def test_get_api_key_no_longer_exists(self):
+        """The stub accepted any non-empty header — a trap for whoever wired it up."""
+        import app.api.dependencies as dependencies
+
+        assert not hasattr(dependencies, "get_api_key")
+
+
+class TestSessionWithoutExpiryFailsClosed:
+    """`if expires_at:` meant a session document missing the field skipped the
+    expiry check entirely and was accepted — an unexpirable session from a
+    malformed or partially-written record."""
+
+    @pytest.mark.asyncio
+    async def test_session_missing_expires_at_is_rejected(self, monkeypatch):
+        from app.core import better_auth_session
+
+        session_doc = {"_id": "s1", "userId": "u1", "token": "t"}  # no expiresAt
+
+        class _Coll:
+            async def find_one(self, *a, **kw):
+                return session_doc
+
+            def __init__(self):
+                self.refreshed = False
+
+            async def update_one(self, *a, **kw):
+                # Record rather than raise: validate_better_auth_session catches
+                # exceptions and returns None, so a raising fake would make this
+                # test pass against the fail-open code for the wrong reason —
+                # it did, until the mutation check caught it.
+                self.refreshed = True
+
+            async def delete_one(self, *a, **kw):
+                return None
+
+        coll = _Coll()
+
+        async def _fake_collection(_name):
+            return coll
+
+        monkeypatch.setattr(better_auth_session, "get_collection", _fake_collection)
+
+        class _Req:
+            cookies = {"better-auth.session_token": "t"}
+            headers: dict = {}
+
+        result = await better_auth_session.validate_better_auth_session(_Req())
+
+        assert result is None
+        # The fail-open path fell through to refreshing last-activity on a
+        # session it had never dated.
+        assert coll.refreshed is False

--- a/backend/tests/test_core/test_hardening_352.py
+++ b/backend/tests/test_core/test_hardening_352.py
@@ -135,3 +135,17 @@ class TestSessionWithoutExpiryFailsClosed:
         # The fail-open path fell through to refreshing last-activity on a
         # session it had never dated.
         assert coll.refreshed is False
+
+
+class TestAiMaxRetriesUpperBound:
+    """The backoff is exponential, so an oversized retry count does not fail
+    loudly — it holds the request open past any sane client timeout while
+    occupying a worker."""
+
+    @pytest.mark.parametrize("bad", [11, 100])
+    def test_retry_count_above_the_cap_is_rejected(self, bad):
+        with pytest.raises(ValidationError):
+            config.Settings(AI_MAX_RETRIES=bad)
+
+    def test_the_cap_itself_is_allowed(self):
+        assert config.Settings(AI_MAX_RETRIES=10).AI_MAX_RETRIES == 10

--- a/backend/tests/test_core/test_hardening_352.py
+++ b/backend/tests/test_core/test_hardening_352.py
@@ -149,3 +149,70 @@ class TestAiMaxRetriesUpperBound:
 
     def test_the_cap_itself_is_allowed(self):
         assert config.Settings(AI_MAX_RETRIES=10).AI_MAX_RETRIES == 10
+
+
+class TestStripeOrderingIsEnforcedByTheQuery:
+    """The guard must live in the write, not in a read before it.
+
+    Two deliveries for the same customer carry different event ids, so the
+    idempotency claim does not serialize them. A read-then-write check lets both
+    pass their comparison and the older one land last — the exact downgrade the
+    guard exists to prevent.
+    """
+
+    @pytest.mark.asyncio
+    async def test_update_user_passes_the_ordering_condition_to_mongo(self, monkeypatch):
+        from app.api.endpoints import webhooks
+
+        captured = {}
+
+        async def _fake_update_user(auth_id, data, actor_id=None, extra_filter=None):
+            captured["filter"] = extra_filter
+            captured["data"] = data
+            return {"auth_id": auth_id, **data}
+
+        async def _fake_lookup(_customer_id):
+            return {"auth_id": "u1", "stripe_event_created": 500}
+
+        monkeypatch.setattr(webhooks, "update_user", _fake_update_user)
+        monkeypatch.setattr(
+            webhooks, "get_user_by_stripe_customer_id", _fake_lookup
+        )
+
+        await webhooks._apply_subscription_event(
+            "customer.subscription.deleted",
+            {"customer": "cus_1", "id": "sub_1"},
+            "evt_1",
+            400,  # older than the applied 500
+        )
+
+        # The condition must be part of the query, not evaluated beforehand.
+        assert captured["filter"] is not None, (
+            "ordering must be enforced by the write; a prior read races with a "
+            "concurrent delivery"
+        )
+        assert captured["data"]["stripe_event_created"] == 400
+
+    @pytest.mark.asyncio
+    async def test_a_rejected_write_reports_the_event_as_stale(self, monkeypatch):
+        from app.api.endpoints import webhooks
+
+        async def _fake_update_user(auth_id, data, actor_id=None, extra_filter=None):
+            return None  # Mongo matched nothing: a newer event already applied
+
+        async def _fake_lookup(_customer_id):
+            return {"auth_id": "u1", "stripe_event_created": 900}
+
+        monkeypatch.setattr(webhooks, "update_user", _fake_update_user)
+        monkeypatch.setattr(
+            webhooks, "get_user_by_stripe_customer_id", _fake_lookup
+        )
+
+        result = await webhooks._apply_subscription_event(
+            "customer.subscription.deleted",
+            {"customer": "cus_1", "id": "sub_1"},
+            "evt_old",
+            100,
+        )
+
+        assert result["status"] == "stale_event"

--- a/backend/tests/test_core/test_security.py
+++ b/backend/tests/test_core/test_security.py
@@ -418,6 +418,7 @@ class TestProductionSecurityValidation:
         monkeypatch.setenv("BYPASS_AUTH", "true")
         monkeypatch.delenv("E2E_ALLOW_BYPASS", raising=False)
 
+        monkeypatch.setenv("BETTER_AUTH_SECRET", "s" * 64)
         settings = Settings()
         assert settings.BYPASS_AUTH is False
 
@@ -464,6 +465,7 @@ class TestProductionSecurityValidation:
         monkeypatch.setenv("BYPASS_AUTH", "true")
         monkeypatch.setenv("E2E_ALLOW_BYPASS", "1")
 
+        monkeypatch.setenv("BETTER_AUTH_SECRET", "s" * 64)
         settings = Settings()
         assert settings.BYPASS_AUTH is True
 
@@ -566,6 +568,7 @@ class TestProductionSecurityValidation:
         monkeypatch.setenv("BYPASS_AUTH", "true")
         monkeypatch.delenv("E2E_ALLOW_BYPASS", raising=False)
 
+        monkeypatch.setenv("BETTER_AUTH_SECRET", "s" * 64)
         settings = Settings()
         assert settings.BYPASS_AUTH is False
 

--- a/backend/tests/test_services/test_ai_service_draft_generation.py
+++ b/backend/tests/test_services/test_ai_service_draft_generation.py
@@ -95,23 +95,32 @@ class TestAIServiceDraftGeneration:
         assert result["metadata"]["target_length"] == 2000
 
     @pytest.mark.asyncio
-    async def test_generate_chapter_draft_handles_openai_error(self, ai_service):
-        """Test error handling when OpenAI API fails."""
-        # Mock an error
+    async def test_generate_chapter_draft_propagates_structured_ai_errors(self, ai_service):
+        """A failed OpenAI call surfaces as AIServiceError, not a flattened dict.
+
+        This previously asserted the opposite: the handler caught everything and
+        returned {"success": False, "error": str(e)}, which discarded error_code,
+        retryable and retry_after. The endpoint could then only answer 503 — losing
+        the rate-limit backoff hint and the difference between "try later" and
+        "this request is wrong" (#352). _retry_with_backoff already wraps raw
+        exceptions into AIServiceError; draft generation now lets that through so
+        the endpoint's error mapping can do its job.
+        """
+        from app.services.ai_errors import AIServiceError
+
         ai_service.client.chat.completions.create.side_effect = Exception("OpenAI API error")
 
-        result = await ai_service.generate_chapter_draft(
-            chapter_title="Test Chapter",
-            chapter_description="Test description",
-            question_responses=[],
-            book_metadata={}
-        )
+        with pytest.raises(AIServiceError) as exc:
+            await ai_service.generate_chapter_draft(
+                chapter_title="Test Chapter",
+                chapter_description="Test description",
+                question_responses=[],
+                book_metadata={}
+            )
 
-        assert result["success"] is False
-        assert "error" in result
-        assert "OpenAI API error" in result["error"]
-        assert "draft" in result
-        assert result["draft"] == ""
+        # The structured detail the old dict threw away.
+        assert exc.value.error_code
+        assert "OpenAI API error" in exc.value.message
 
     @pytest.mark.asyncio
     async def test_generate_chapter_draft_calculates_metadata(self, ai_service):

--- a/frontend/src/app/api/auth/[...all]/route.ts
+++ b/frontend/src/app/api/auth/[...all]/route.ts
@@ -34,11 +34,15 @@ export async function POST(req: Request): Promise<Response> {
     return POST(req);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown authentication error';
+    // Logged server-side in full; the client gets a generic message. This
+    // endpoint answers unauthenticated callers, and internal errors here name
+    // database hosts, driver versions and config keys — free reconnaissance
+    // for anyone probing the auth surface (#352).
     console.error('POST /api/auth error:', errorMessage, { error });
     return new Response(
       JSON.stringify({
         error: 'Authentication service unavailable',
-        message: errorMessage
+        message: 'The authentication service is temporarily unavailable. Please try again.'
       }),
       {
         status: 500,
@@ -54,11 +58,13 @@ export async function GET(req: Request): Promise<Response> {
     return GET(req);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown authentication error';
+    // See the POST handler: full detail to the server log, generic text to the
+    // client (#352).
     console.error('GET /api/auth error:', errorMessage, { error });
     return new Response(
       JSON.stringify({
         error: 'Authentication service unavailable',
-        message: errorMessage
+        message: 'The authentication service is temporarily unavailable. Please try again.'
       }),
       {
         status: 500,


### PR DESCRIPTION
Closes #352.

Nine items, each verified against the code before acting.

## The security-relevant ones

**`get_api_key` deleted.** A stub that accepted **any non-empty header** as valid — fail-open by construction, and a trap for whoever eventually wired it to a route believing it authenticated something. Its only callers were its own tests, which asserted exactly that behaviour.

**`BETTER_AUTH_SECRET`'s committed CI default is now rejected on any *deployed* environment, staging included.** The old check was `is_production_env()`, which deliberately excludes staging — correct for the fail-safes it guards, wrong here. A staging deploy that forgot the secret **booted, passed its health check, and signed every JWT with a key committed to this repository in plaintext**. Anyone who could read the source could mint tokens for any staging user. Added `is_deployed_env()` for the distinction. (I filed this from #343; this is the fix.)

**Session validation fails closed on a missing `expiresAt`.** `if expires_at:` meant a document without the field skipped the expiry check entirely and was accepted — an unexpirable session from a malformed or partially-written record.

**The auth route no longer echoes internal error messages** to unauthenticated clients. Full detail still goes to the server log; internal errors here name database hosts, driver versions and config keys.

**`permissions: contents: read`** on the three workflows running with the default over-broad `GITHUB_TOKEN`.

## The robustness ones

**`AI_MAX_RETRIES` is `Field(ge=1, le=10)`.** `range(0)` never enters the loop, so `_retry_with_backoff` fell off the end returning `None` and the caller `AttributeError`'d. The upper bound came from review: the backoff is exponential, so an oversized value doesn't fail loudly — it holds a request open past any client timeout while occupying a worker.

**Draft generation re-raises `AIServiceError`** instead of flattening it to `{"success": False, "error": str(e)}`, which discarded `error_code`, `retryable` and `retry_after` and left the endpoint able to answer only 503. Added the structured mapping the other AI endpoints already use. **Truncation now returns 422**, not 503 — it's a user-fixable condition, and "service unavailable" invites a retry that fails identically.

**`get_all_users` paginated** — was `find().to_list(length=None)`. Both `limit` (≤500) and `skip` (≤100k) are capped; Mongo walks every skipped document, so an unbounded offset lets the caller turn an indexed query into a full scan.

**Stripe events carry an ordering guard.** Idempotency already stopped the same event twice; nothing stopped an *older* event arriving last and overwriting a newer plan — a real downgrade for a paying user.

## Three existing tests encoded the behaviour this issue asks to change

Inverted, not deleted, each carrying a comment recording what it used to assert:

- `test_no_expires_at_still_valid` → `test_no_expires_at_is_rejected`. The name says it: it pinned the fail-open.
- The draft-generation test that asserted the flattened error dict → now asserts the structured error propagates.
- The staging `BYPASS_AUTH` tests → now provide a real secret, because staging requires one. Their subject (the bypass flag) is unchanged.

## The mutation check earned its keep

My first session test **passed against the fail-open**. The fake raised `AssertionError` inside a function that swallows exceptions and returns `None`, so it "passed" for entirely the wrong reason. It records the call now instead of raising:

```
restore either fail-open → ✕ its test fails
both fixed               → ✓ 18 passed
```

## One finding declined, with reasoning

Review asked me to replace the timestamp ordering guard with canonical subscription re-fetching. Keeping the timestamp comparison and documenting its limit instead.

`created` has one-second granularity and genuinely cannot order two updates inside the same second — that's correct. But the acceptance criteria offer both approaches (*"compare Stripe event timestamps before applying (or re-fetch on each event)"*), and re-fetching buys exactness at the cost of an API call per webhook plus a new failure mode when Stripe is unreachable. The `<` comparison is deliberate — `<=` would drop legitimate same-second events — and last-write-wins within one second is the pre-existing behaviour. The comment now states the limit and names re-fetch as the upgrade path if same-second races ever show up.

## Verification

| Check | Result |
|-------|--------|
| Backend | **1226 passed**, 8 skipped |
| Frontend (coverage) | 133/133 suites, 2287 passed |
| `tsc --noEmit` | clean |
| Workflow YAML | all three parse |
| Mutation check | both fail-opens turn their test red when restored |

🤖 Generated with [Claude Code](https://claude.com/claude-code)