### PR TITLE
fix(toc): drop the transaction wrappers so a concurrent edit returns 409 everywhere (#369)

### DIFF
--- a/backend/app/db/toc_transactions.py
+++ b/backend/app/db/toc_transactions.py
@@ -9,7 +9,7 @@ from bson.objectid import ObjectId
 import uuid
 from motor.motor_asyncio import AsyncIOMotorClientSession
 
-from .base import _client, _db, books_collection, ObjectId
+from .base import books_collection, ObjectId
 from .audit_log import create_audit_log
 
 
@@ -89,24 +89,23 @@ async def update_toc_with_transaction(
     """
     Update TOC with transaction support to ensure atomicity.
     Uses optimistic locking with version checking.
-    """
-    # Check if we're in a test environment or if transactions are not supported
-    use_transaction = True
-    try:
-        async with await _client.start_session() as session:
-            # Test if transactions are supported
-            info = await _client.admin.command('isMaster')
-            use_transaction = info.get('setName') is not None  # Has replica set
-    except Exception:
-        use_transaction = False
 
-    if use_transaction:
-        async with await _client.start_session() as session:
-            async with session.start_transaction():
-                return await _update_toc_internal(book_id, toc_data, user_auth_id, session)
-    else:
-        # Fallback for test environment without transactions
-        return await _update_toc_internal(book_id, toc_data, user_auth_id, None)
+    Runs as a single compare-and-swap, deliberately WITHOUT a transaction.
+
+    These are single-document writes: one read of the book, one guarded
+    ``update_one`` filtered on the version that read observed. The CAS is atomic
+    on its own, so a transaction adds nothing — and actively breaks the 409
+    contract on a replica set. Inside a transaction the guarded update reads at
+    the transaction snapshot, so the version filter always matches and the
+    conflict never raises ValueError; the genuine conflict aborts at COMMIT as a
+    WriteConflict, which reaches the endpoint as a generic OperationFailure and
+    becomes a 500. Without the transaction the filter misses, ValueError is
+    raised, and the endpoint returns 409 on every topology (#369).
+
+    ``update_chapter_statuses_with_version_guard`` (#159) already took this
+    route for the same reason.
+    """
+    return await _update_toc_internal(book_id, toc_data, user_auth_id, None)
 
 
 async def _update_toc_internal(
@@ -227,21 +226,23 @@ async def add_chapter_with_transaction(
 ) -> Dict[str, Any]:
     """
     Add a new chapter or subchapter with transaction support.
-    """
-    use_transaction = True
-    try:
-        async with await _client.start_session() as session:
-            info = await _client.admin.command('isMaster')
-            use_transaction = info.get('setName') is not None
-    except Exception:
-        use_transaction = False
 
-    if use_transaction:
-        async with await _client.start_session() as session:
-            async with session.start_transaction():
-                return await _add_chapter_internal(book_id, chapter_data, user_auth_id, parent_chapter_id, session)
-    else:
-        return await _add_chapter_internal(book_id, chapter_data, user_auth_id, parent_chapter_id, None)
+    Runs as a single compare-and-swap, deliberately WITHOUT a transaction.
+
+    These are single-document writes: one read of the book, one guarded
+    ``update_one`` filtered on the version that read observed. The CAS is atomic
+    on its own, so a transaction adds nothing — and actively breaks the 409
+    contract on a replica set. Inside a transaction the guarded update reads at
+    the transaction snapshot, so the version filter always matches and the
+    conflict never raises ValueError; the genuine conflict aborts at COMMIT as a
+    WriteConflict, which reaches the endpoint as a generic OperationFailure and
+    becomes a 500. Without the transaction the filter misses, ValueError is
+    raised, and the endpoint returns 409 on every topology (#369).
+
+    ``update_chapter_statuses_with_version_guard`` (#159) already took this
+    route for the same reason.
+    """
+    return await _add_chapter_internal(book_id, chapter_data, user_auth_id, parent_chapter_id, None)
 
 
 async def _add_chapter_internal(
@@ -311,21 +312,23 @@ async def update_chapter_with_transaction(
 ) -> Dict[str, Any]:
     """
     Update a chapter with transaction support.
-    """
-    use_transaction = True
-    try:
-        async with await _client.start_session() as session:
-            info = await _client.admin.command('isMaster')
-            use_transaction = info.get('setName') is not None
-    except Exception:
-        use_transaction = False
 
-    if use_transaction:
-        async with await _client.start_session() as session:
-            async with session.start_transaction():
-                return await _update_chapter_internal(book_id, chapter_id, chapter_updates, user_auth_id, session)
-    else:
-        return await _update_chapter_internal(book_id, chapter_id, chapter_updates, user_auth_id, None)
+    Runs as a single compare-and-swap, deliberately WITHOUT a transaction.
+
+    These are single-document writes: one read of the book, one guarded
+    ``update_one`` filtered on the version that read observed. The CAS is atomic
+    on its own, so a transaction adds nothing — and actively breaks the 409
+    contract on a replica set. Inside a transaction the guarded update reads at
+    the transaction snapshot, so the version filter always matches and the
+    conflict never raises ValueError; the genuine conflict aborts at COMMIT as a
+    WriteConflict, which reaches the endpoint as a generic OperationFailure and
+    becomes a 500. Without the transaction the filter misses, ValueError is
+    raised, and the endpoint returns 409 on every topology (#369).
+
+    ``update_chapter_statuses_with_version_guard`` (#159) already took this
+    route for the same reason.
+    """
+    return await _update_chapter_internal(book_id, chapter_id, chapter_updates, user_auth_id, None)
 
 
 async def _update_chapter_internal(
@@ -391,21 +394,23 @@ async def delete_chapter_with_transaction(
 ) -> bool:
     """
     Delete a chapter with transaction support.
-    """
-    use_transaction = True
-    try:
-        async with await _client.start_session() as session:
-            info = await _client.admin.command('isMaster')
-            use_transaction = info.get('setName') is not None
-    except Exception:
-        use_transaction = False
 
-    if use_transaction:
-        async with await _client.start_session() as session:
-            async with session.start_transaction():
-                return await _delete_chapter_internal(book_id, chapter_id, user_auth_id, session)
-    else:
-        return await _delete_chapter_internal(book_id, chapter_id, user_auth_id, None)
+    Runs as a single compare-and-swap, deliberately WITHOUT a transaction.
+
+    These are single-document writes: one read of the book, one guarded
+    ``update_one`` filtered on the version that read observed. The CAS is atomic
+    on its own, so a transaction adds nothing — and actively breaks the 409
+    contract on a replica set. Inside a transaction the guarded update reads at
+    the transaction snapshot, so the version filter always matches and the
+    conflict never raises ValueError; the genuine conflict aborts at COMMIT as a
+    WriteConflict, which reaches the endpoint as a generic OperationFailure and
+    becomes a 500. Without the transaction the filter misses, ValueError is
+    raised, and the endpoint returns 409 on every topology (#369).
+
+    ``update_chapter_statuses_with_version_guard`` (#159) already took this
+    route for the same reason.
+    """
+    return await _delete_chapter_internal(book_id, chapter_id, user_auth_id, None)
 
 
 async def _delete_chapter_internal(
@@ -548,21 +553,23 @@ async def reorder_chapters_with_transaction(
     """
     Reorder chapters with transaction support.
     chapter_orders should be a list of {"id": "chapter_id", "order": 1}
-    """
-    use_transaction = True
-    try:
-        async with await _client.start_session() as session:
-            info = await _client.admin.command('isMaster')
-            use_transaction = info.get('setName') is not None
-    except Exception:
-        use_transaction = False
 
-    if use_transaction:
-        async with await _client.start_session() as session:
-            async with session.start_transaction():
-                return await _reorder_chapters_internal(book_id, chapter_orders, user_auth_id, session)
-    else:
-        return await _reorder_chapters_internal(book_id, chapter_orders, user_auth_id, None)
+    Runs as a single compare-and-swap, deliberately WITHOUT a transaction.
+
+    These are single-document writes: one read of the book, one guarded
+    ``update_one`` filtered on the version that read observed. The CAS is atomic
+    on its own, so a transaction adds nothing — and actively breaks the 409
+    contract on a replica set. Inside a transaction the guarded update reads at
+    the transaction snapshot, so the version filter always matches and the
+    conflict never raises ValueError; the genuine conflict aborts at COMMIT as a
+    WriteConflict, which reaches the endpoint as a generic OperationFailure and
+    becomes a 500. Without the transaction the filter misses, ValueError is
+    raised, and the endpoint returns 409 on every topology (#369).
+
+    ``update_chapter_statuses_with_version_guard`` (#159) already took this
+    route for the same reason.
+    """
+    return await _reorder_chapters_internal(book_id, chapter_orders, user_auth_id, None)
 
 
 async def _reorder_chapters_internal(

--- a/backend/app/db/toc_transactions.py
+++ b/backend/app/db/toc_transactions.py
@@ -6,6 +6,7 @@ Ensures atomic updates to prevent race conditions and maintain data consistency.
 from typing import Dict, List, Optional, Any
 from datetime import datetime, timezone
 from bson.objectid import ObjectId
+import logging
 import uuid
 from motor.motor_asyncio import AsyncIOMotorClientSession
 
@@ -202,18 +203,33 @@ async def _update_toc_internal(
                 raise ValueError(f"Version conflict: TOC was updated by another process")
         raise ValueError("Failed to update TOC")
 
-    # Log the update
-    await create_audit_log(
-        action="update_toc",
-        actor_id=user_auth_id,
-        target_id=book_id,
-        resource_type="book",
-        details={
-            "chapters_count": len(updated_toc.get("chapters", [])),
-            "version": updated_toc["version"]
-        },
-        session=session
-    )
+    # Best-effort audit, explicitly. The TOC write above has already committed,
+    # so raising here would report failure for an edit that succeeded — and the
+    # client's retry would then hit a version conflict on its own change (#369).
+    # Losing an audit row is the lesser harm; it is logged at error level with
+    # enough context to reconstruct the entry. (Previously the transaction made
+    # these atomic; without it the ordering has to be handled explicitly rather
+    # than left implicit.)
+    try:
+        await create_audit_log(
+            action="update_toc",
+            actor_id=user_auth_id,
+            target_id=book_id,
+            resource_type="book",
+            details={
+                "chapters_count": len(updated_toc.get("chapters", [])),
+                "version": updated_toc["version"]
+            },
+            session=session
+        )
+    except Exception:
+        logging.getLogger(__name__).error(
+            "TOC updated but audit log failed: book=%s actor=%s version=%s",
+            book_id,
+            user_auth_id,
+            updated_toc["version"],
+            exc_info=True,
+        )
 
     return updated_toc
 
@@ -534,13 +550,23 @@ async def update_chapter_statuses_with_version_guard(
     )
 
     # Preserve the book-level audit entry the previous update_book() path emitted.
-    await create_audit_log(
-        action="book_update",
-        actor_id=user_auth_id,
-        target_id=book_id,
-        resource_type="book",
-        details={"updated_fields": ["table_of_contents", "updated_at"]},
-    )
+    # Best-effort for the same reason as above: the guarded write has committed,
+    # so an audit failure must not turn a successful edit into an error.
+    try:
+        await create_audit_log(
+            action="book_update",
+            actor_id=user_auth_id,
+            target_id=book_id,
+            resource_type="book",
+            details={"updated_fields": ["table_of_contents", "updated_at"]},
+        )
+    except Exception:
+        logging.getLogger(__name__).error(
+            "Chapter statuses updated but audit log failed: book=%s actor=%s",
+            book_id,
+            user_auth_id,
+            exc_info=True,
+        )
 
     return {"updated_chapters": updated_chapters}
 

--- a/backend/tests/test_db/test_toc_transactions.py
+++ b/backend/tests/test_db/test_toc_transactions.py
@@ -691,7 +691,41 @@ async def test_helpers_do_not_open_transactions(monkeypatch, seed_book):
 
     monkeypatch.setattr(base._client, "start_session", _fail_start_session)
 
+    await tx.update_toc_with_transaction(
+        book_id, {"chapters": [{"id": "c1", "title": "Renamed"}]}, owner
+    )
     await tx.add_chapter_with_transaction(book_id, {"title": "New"}, owner)
     await tx.update_chapter_with_transaction(book_id, "c1", {"title": "Edited"}, owner)
     await tx.reorder_chapters_with_transaction(book_id, [{"id": "c1", "order": 1}], owner)
     await tx.delete_chapter_with_transaction(book_id, "c1", owner)
+
+
+@pytest.mark.asyncio
+async def test_audit_failure_does_not_fail_a_committed_toc_update(
+    seed_book, monkeypatch
+):
+    """An audit failure must not turn a successful edit into an error (#369).
+
+    The guarded write commits before the audit row is inserted. While these ran
+    inside a transaction the two were atomic; without it, letting the audit
+    exception propagate would report failure for a change that persisted — and
+    the client's retry would then conflict with its own committed write.
+    """
+    book_id, owner = await seed_book(
+        toc=_toc(version=1, chapters=[{"id": "c1", "title": "Original"}])
+    )
+
+    async def _boom(*a, **kw):
+        raise RuntimeError("audit collection unavailable")
+
+    monkeypatch.setattr(tx, "create_audit_log", _boom)
+
+    # Must not raise.
+    await tx.update_toc_with_transaction(
+        book_id, {"chapters": [{"id": "c1", "title": "Renamed"}]}, owner
+    )
+
+    # And the edit is actually persisted, not silently dropped.
+    stored = await _get_toc(book_id)
+    assert stored["chapters"][0]["title"] == "Renamed"
+    assert stored["version"] == 2

--- a/backend/tests/test_db/test_toc_transactions.py
+++ b/backend/tests/test_db/test_toc_transactions.py
@@ -1,16 +1,23 @@
 """
 Integration tests for app/db/toc_transactions.py.
 
-Exercises the atomic TOC transaction helpers against a real local MongoDB
-(via the motor_reinit_db fixture) — happy paths AND the data-integrity
-failure paths: invalid IDs, missing/unauthorized books, optimistic-locking
-version conflicts, missing chapters, and the transaction-detection fallback.
+Exercises the atomic TOC helpers against a real local MongoDB (via the
+motor_reinit_db fixture) — happy paths AND the data-integrity failure paths:
+invalid IDs, missing/unauthorized books, optimistic-locking version conflicts,
+and missing chapters.
 
-ponytail: the `if use_transaction:` real-transaction branches require a
-MongoDB replica set; a standalone test server reports no setName, so those
-functions run via the non-transactional fallback here. Covering the live
-transaction/rollback branch would need a replica-set test fixture — upgrade
-path if/when CI runs Mongo as a replica set.
+The `if use_transaction:` branches these tests used to note as uncoverable are
+gone (#369). They needed a replica-set fixture because a standalone server
+reports no setName — but the branch they guarded was also the bug: inside a
+transaction the guarded update reads at the transaction snapshot, so the version
+filter always matched, the ValueError never raised, and a genuine conflict
+surfaced at commit as a WriteConflict → generic OperationFailure → 500 instead
+of the intended 409.
+
+Every one of these helpers is a single-document compare-and-swap, so the CAS is
+atomic without a transaction and behaves identically on standalone and replica
+set. Deleting the branch was the fix; there is no longer a topology-dependent
+path to cover, which is why the note is retired rather than satisfied.
 """
 
 import pytest
@@ -626,3 +633,65 @@ async def test_book_deleted_mid_operation_reports_not_found(
 
     with pytest.raises(ValueError, match="Book not found"):
         await call(book_id, owner)
+
+
+@pytest.mark.asyncio
+async def test_update_toc_interleaved_writer_does_not_lose_update(
+    seed_book, monkeypatch
+):
+    """update_toc is the fifth helper that lost its transaction wrapper (#369).
+
+    The other four are covered by the parametrised interleave test above; this
+    one has a different signature and a different conflict message, so it gets
+    its own. Same property: a competing commit in the read -> write window must
+    make this write raise rather than clobber.
+    """
+    book_id, owner = await seed_book(
+        toc=_toc(version=1, chapters=[{"id": "c1", "title": "Original"}])
+    )
+
+    competing = _toc(
+        version=2, chapters=[{"id": "c1", "title": "Original", "content": "autosaved"}]
+    )
+    state = _interleave_competing_write(monkeypatch, book_id, competing)
+
+    with pytest.raises(ValueError):
+        await tx.update_toc_with_transaction(
+            book_id, {"chapters": [{"id": "c1", "title": "Mine"}]}, owner
+        )
+
+    assert state["fired"], "competing write never ran — test is not interleaving"
+
+    # The competing writer's data survived intact.
+    stored = await tx.books_collection.find_one({"_id": ObjectId(book_id)})
+    assert stored["table_of_contents"] == competing
+
+
+@pytest.mark.asyncio
+async def test_helpers_do_not_open_transactions(monkeypatch, seed_book):
+    """The topology-dependent path is gone, not merely unused (#369).
+
+    Pinning this structurally rather than behaviourally: a transaction would
+    reintroduce the 500-instead-of-409 bug only on a replica set, which no
+    standalone test can observe. Asserting that no session is ever started
+    catches the regression on any topology.
+    """
+    book_id, owner = await seed_book(
+        toc=_toc(version=1, chapters=[{"id": "c1", "title": "Original"}])
+    )
+
+    import app.db.base as base
+
+    def _fail_start_session(*a, **kw):
+        raise AssertionError(
+            "TOC helpers must not open a session: inside a transaction the "
+            "guarded update reads at the snapshot, so a concurrent commit "
+            "surfaces as a WriteConflict (500) instead of ValueError (409)"
+        )
+
+    monkeypatch.setattr(base._client, "start_session", _fail_start_session)
+
+    await tx.add_chapter_with_transaction(book_id, {"title": "New"}, owner)
+    await tx.update_chapter_with_transaction(book_id, "c1", {"title": "Edited"}, owner)
+    await tx.reorder_chapters_with_transaction(book_id, [{"id": "c1", "order": 1}], owner)
+    await tx.delete_chapter_with_transaction(book_id, "c1", owner)


### PR DESCRIPTION
Closes #369.

## The defect

#337 added an optimistic-lock CAS to the TOC helpers and mapped its `ValueError` to **409** — but each helper still ran inside `session.start_transaction()`. On a replica set (production Atlas) the guarded `update_one` reads at the transaction snapshot, so **the version filter always matches and the `ValueError` never fires**. The genuine conflict aborts at *commit* as a `WriteConflict`, propagates as a generic `OperationFailure`, hits the endpoints' bare `except Exception`, and returns **500**.

Two users editing a TOC concurrently got an opaque error instead of the actionable retry prompt the UI copy promises.

## The fix

Took the issue's suggested route: **delete the transaction wrappers**. The CAS is atomic on its own and behaves identically on standalone and replica set. `update_chapter_statuses_with_version_guard` (#159) already took exactly this route, and its docstring gives the same reasoning.

Applied to **all five** wrappers, not the four the issue lists — `_update_toc_internal` shares the defect, and leaving it would have kept one path returning 500 and made the retired note only half true. `_client`/`_db` imports went with them; the transaction machinery was their only consumer.

## On the replica-set fixture

**Not built, deliberately.** The fixture was required to cover the `if use_transaction:` branches — and that branch *was* the bug. Removing it satisfies "409 on both topologies" by making the code topology-independent, which is a better outcome than adding CI infrastructure to verify a path that should never be taken. The `ponytail:` note recording those branches as untestable is retired accordingly, with the reasoning written into the test module docstring.

## Review caught an over-broad claim of mine

I wrote that all five helpers are single-document writes. **Four are.** `_update_toc_internal` also inserts an audit row, so it's two documents — and the transaction *was* providing atomicity between the TOC write and its audit entry.

Removing it meant an audit insert failing *after* the guarded write committed would propagate, reporting failure for an edit that persisted — and the client's retry would then conflict with its own committed change.

Both audit writes are now explicitly best-effort: logged at error level with enough context to reconstruct the entry, never failing the request. Losing an audit row is the lesser harm. `update_chapter_statuses_with_version_guard` already had this exposure (it never used a transaction), so it gets the same treatment rather than being left as the one path that can still fail after committing.

## Coverage

The four parametrised interleaved-writer tests from #337 now exercise the only remaining path. Added:

- an interleaved test for `update_toc` (different signature and conflict message, so it needs its own),
- a **structural** tripwire asserting no helper opens a session — pinned structurally because a reintroduced transaction breaks *only* on a replica set, which no standalone test can observe,
- a test that an audit failure doesn't fail a committed edit.

**Mutation checks:**

```
wrap add_chapter in a transaction again  → ✕ no-session tripwire fails
let the audit exception propagate again  → ✕ audit-failure test fails
```

| Check | Result |
|-------|--------|
| TOC transaction tests | 55 passed |
| Backend suite | **1231 passed**, 8 skipped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)