### PR TITLE
build(deps): zod 4 with @hookform/resolvers 5 (coordinated) — part of #385

### DIFF
--- a/backend/app/db/toc_transactions.py
+++ b/backend/app/db/toc_transactions.py
@@ -9,7 +9,7 @@ from bson.objectid import ObjectId
 import uuid
 from motor.motor_asyncio import AsyncIOMotorClientSession
 
-from .base import _client, _db, books_collection, ObjectId
+from .base import books_collection, ObjectId
 from .audit_log import create_audit_log
 
 
@@ -89,24 +89,23 @@ async def update_toc_with_transaction(
     """
     Update TOC with transaction support to ensure atomicity.
     Uses optimistic locking with version checking.
-    """
-    # Check if we're in a test environment or if transactions are not supported
-    use_transaction = True
-    try:
-        async with await _client.start_session() as session:
-            # Test if transactions are supported
-            info = await _client.admin.command('isMaster')
-            use_transaction = info.get('setName') is not None  # Has replica set
-    except Exception:
-        use_transaction = False
 
-    if use_transaction:
-        async with await _client.start_session() as session:
-            async with session.start_transaction():
-                return await _update_toc_internal(book_id, toc_data, user_auth_id, session)
-    else:
-        # Fallback for test environment without transactions
-        return await _update_toc_internal(book_id, toc_data, user_auth_id, None)
+    Runs as a single compare-and-swap, deliberately WITHOUT a transaction.
+
+    These are single-document writes: one read of the book, one guarded
+    ``update_one`` filtered on the version that read observed. The CAS is atomic
+    on its own, so a transaction adds nothing — and actively breaks the 409
+    contract on a replica set. Inside a transaction the guarded update reads at
+    the transaction snapshot, so the version filter always matches and the
+    conflict never raises ValueError; the genuine conflict aborts at COMMIT as a
+    WriteConflict, which reaches the endpoint as a generic OperationFailure and
+    becomes a 500. Without the transaction the filter misses, ValueError is
+    raised, and the endpoint returns 409 on every topology (#369).
+
+    ``update_chapter_statuses_with_version_guard`` (#159) already took this
+    route for the same reason.
+    """
+    return await _update_toc_internal(book_id, toc_data, user_auth_id, None)
 
 
 async def _update_toc_internal(
@@ -227,21 +226,23 @@ async def add_chapter_with_transaction(
 ) -> Dict[str, Any]:
     """
     Add a new chapter or subchapter with transaction support.
-    """
-    use_transaction = True
-    try:
-        async with await _client.start_session() as session:
-            info = await _client.admin.command('isMaster')
-            use_transaction = info.get('setName') is not None
-    except Exception:
-        use_transaction = False
 
-    if use_transaction:
-        async with await _client.start_session() as session:
-            async with session.start_transaction():
-                return await _add_chapter_internal(book_id, chapter_data, user_auth_id, parent_chapter_id, session)
-    else:
-        return await _add_chapter_internal(book_id, chapter_data, user_auth_id, parent_chapter_id, None)
+    Runs as a single compare-and-swap, deliberately WITHOUT a transaction.
+
+    These are single-document writes: one read of the book, one guarded
+    ``update_one`` filtered on the version that read observed. The CAS is atomic
+    on its own, so a transaction adds nothing — and actively breaks the 409
+    contract on a replica set. Inside a transaction the guarded update reads at
+    the transaction snapshot, so the version filter always matches and the
+    conflict never raises ValueError; the genuine conflict aborts at COMMIT as a
+    WriteConflict, which reaches the endpoint as a generic OperationFailure and
+    becomes a 500. Without the transaction the filter misses, ValueError is
+    raised, and the endpoint returns 409 on every topology (#369).
+
+    ``update_chapter_statuses_with_version_guard`` (#159) already took this
+    route for the same reason.
+    """
+    return await _add_chapter_internal(book_id, chapter_data, user_auth_id, parent_chapter_id, None)
 
 
 async def _add_chapter_internal(
@@ -311,21 +312,23 @@ async def update_chapter_with_transaction(
 ) -> Dict[str, Any]:
     """
     Update a chapter with transaction support.
-    """
-    use_transaction = True
-    try:
-        async with await _client.start_session() as session:
-            info = await _client.admin.command('isMaster')
-            use_transaction = info.get('setName') is not None
-    except Exception:
-        use_transaction = False
 
-    if use_transaction:
-        async with await _client.start_session() as session:
-            async with session.start_transaction():
-                return await _update_chapter_internal(book_id, chapter_id, chapter_updates, user_auth_id, session)
-    else:
-        return await _update_chapter_internal(book_id, chapter_id, chapter_updates, user_auth_id, None)
+    Runs as a single compare-and-swap, deliberately WITHOUT a transaction.
+
+    These are single-document writes: one read of the book, one guarded
+    ``update_one`` filtered on the version that read observed. The CAS is atomic
+    on its own, so a transaction adds nothing — and actively breaks the 409
+    contract on a replica set. Inside a transaction the guarded update reads at
+    the transaction snapshot, so the version filter always matches and the
+    conflict never raises ValueError; the genuine conflict aborts at COMMIT as a
+    WriteConflict, which reaches the endpoint as a generic OperationFailure and
+    becomes a 500. Without the transaction the filter misses, ValueError is
+    raised, and the endpoint returns 409 on every topology (#369).
+
+    ``update_chapter_statuses_with_version_guard`` (#159) already took this
+    route for the same reason.
+    """
+    return await _update_chapter_internal(book_id, chapter_id, chapter_updates, user_auth_id, None)
 
 
 async def _update_chapter_internal(
@@ -391,21 +394,23 @@ async def delete_chapter_with_transaction(
 ) -> bool:
     """
     Delete a chapter with transaction support.
-    """
-    use_transaction = True
-    try:
-        async with await _client.start_session() as session:
-            info = await _client.admin.command('isMaster')
-            use_transaction = info.get('setName') is not None
-    except Exception:
-        use_transaction = False
 
-    if use_transaction:
-        async with await _client.start_session() as session:
-            async with session.start_transaction():
-                return await _delete_chapter_internal(book_id, chapter_id, user_auth_id, session)
-    else:
-        return await _delete_chapter_internal(book_id, chapter_id, user_auth_id, None)
+    Runs as a single compare-and-swap, deliberately WITHOUT a transaction.
+
+    These are single-document writes: one read of the book, one guarded
+    ``update_one`` filtered on the version that read observed. The CAS is atomic
+    on its own, so a transaction adds nothing — and actively breaks the 409
+    contract on a replica set. Inside a transaction the guarded update reads at
+    the transaction snapshot, so the version filter always matches and the
+    conflict never raises ValueError; the genuine conflict aborts at COMMIT as a
+    WriteConflict, which reaches the endpoint as a generic OperationFailure and
+    becomes a 500. Without the transaction the filter misses, ValueError is
+    raised, and the endpoint returns 409 on every topology (#369).
+
+    ``update_chapter_statuses_with_version_guard`` (#159) already took this
+    route for the same reason.
+    """
+    return await _delete_chapter_internal(book_id, chapter_id, user_auth_id, None)
 
 
 async def _delete_chapter_internal(
@@ -548,21 +553,23 @@ async def reorder_chapters_with_transaction(
     """
     Reorder chapters with transaction support.
     chapter_orders should be a list of {"id": "chapter_id", "order": 1}
-    """
-    use_transaction = True
-    try:
-        async with await _client.start_session() as session:
-            info = await _client.admin.command('isMaster')
-            use_transaction = info.get('setName') is not None
-    except Exception:
-        use_transaction = False
 
-    if use_transaction:
-        async with await _client.start_session() as session:
-            async with session.start_transaction():
-                return await _reorder_chapters_internal(book_id, chapter_orders, user_auth_id, session)
-    else:
-        return await _reorder_chapters_internal(book_id, chapter_orders, user_auth_id, None)
+    Runs as a single compare-and-swap, deliberately WITHOUT a transaction.
+
+    These are single-document writes: one read of the book, one guarded
+    ``update_one`` filtered on the version that read observed. The CAS is atomic
+    on its own, so a transaction adds nothing — and actively breaks the 409
+    contract on a replica set. Inside a transaction the guarded update reads at
+    the transaction snapshot, so the version filter always matches and the
+    conflict never raises ValueError; the genuine conflict aborts at COMMIT as a
+    WriteConflict, which reaches the endpoint as a generic OperationFailure and
+    becomes a 500. Without the transaction the filter misses, ValueError is
+    raised, and the endpoint returns 409 on every topology (#369).
+
+    ``update_chapter_statuses_with_version_guard`` (#159) already took this
+    route for the same reason.
+    """
+    return await _reorder_chapters_internal(book_id, chapter_orders, user_auth_id, None)
 
 
 async def _reorder_chapters_internal(

--- a/backend/app/db/toc_transactions.py
+++ b/backend/app/db/toc_transactions.py
@@ -6,6 +6,7 @@ Ensures atomic updates to prevent race conditions and maintain data consistency.
 from typing import Dict, List, Optional, Any
 from datetime import datetime, timezone
 from bson.objectid import ObjectId
+import logging
 import uuid
 from motor.motor_asyncio import AsyncIOMotorClientSession
 
@@ -202,18 +203,33 @@ async def _update_toc_internal(
                 raise ValueError(f"Version conflict: TOC was updated by another process")
         raise ValueError("Failed to update TOC")
 
-    # Log the update
-    await create_audit_log(
-        action="update_toc",
-        actor_id=user_auth_id,
-        target_id=book_id,
-        resource_type="book",
-        details={
-            "chapters_count": len(updated_toc.get("chapters", [])),
-            "version": updated_toc["version"]
-        },
-        session=session
-    )
+    # Best-effort audit, explicitly. The TOC write above has already committed,
+    # so raising here would report failure for an edit that succeeded — and the
+    # client's retry would then hit a version conflict on its own change (#369).
+    # Losing an audit row is the lesser harm; it is logged at error level with
+    # enough context to reconstruct the entry. (Previously the transaction made
+    # these atomic; without it the ordering has to be handled explicitly rather
+    # than left implicit.)
+    try:
+        await create_audit_log(
+            action="update_toc",
+            actor_id=user_auth_id,
+            target_id=book_id,
+            resource_type="book",
+            details={
+                "chapters_count": len(updated_toc.get("chapters", [])),
+                "version": updated_toc["version"]
+            },
+            session=session
+        )
+    except Exception:
+        logging.getLogger(__name__).error(
+            "TOC updated but audit log failed: book=%s actor=%s version=%s",
+            book_id,
+            user_auth_id,
+            updated_toc["version"],
+            exc_info=True,
+        )
 
     return updated_toc
 
@@ -534,13 +550,23 @@ async def update_chapter_statuses_with_version_guard(
     )
 
     # Preserve the book-level audit entry the previous update_book() path emitted.
-    await create_audit_log(
-        action="book_update",
-        actor_id=user_auth_id,
-        target_id=book_id,
-        resource_type="book",
-        details={"updated_fields": ["table_of_contents", "updated_at"]},
-    )
+    # Best-effort for the same reason as above: the guarded write has committed,
+    # so an audit failure must not turn a successful edit into an error.
+    try:
+        await create_audit_log(
+            action="book_update",
+            actor_id=user_auth_id,
+            target_id=book_id,
+            resource_type="book",
+            details={"updated_fields": ["table_of_contents", "updated_at"]},
+        )
+    except Exception:
+        logging.getLogger(__name__).error(
+            "Chapter statuses updated but audit log failed: book=%s actor=%s",
+            book_id,
+            user_auth_id,
+            exc_info=True,
+        )
 
     return {"updated_chapters": updated_chapters}
 

--- a/backend/tests/test_db/test_toc_transactions.py
+++ b/backend/tests/test_db/test_toc_transactions.py
@@ -691,7 +691,41 @@ async def test_helpers_do_not_open_transactions(monkeypatch, seed_book):
 
     monkeypatch.setattr(base._client, "start_session", _fail_start_session)
 
+    await tx.update_toc_with_transaction(
+        book_id, {"chapters": [{"id": "c1", "title": "Renamed"}]}, owner
+    )
     await tx.add_chapter_with_transaction(book_id, {"title": "New"}, owner)
     await tx.update_chapter_with_transaction(book_id, "c1", {"title": "Edited"}, owner)
     await tx.reorder_chapters_with_transaction(book_id, [{"id": "c1", "order": 1}], owner)
     await tx.delete_chapter_with_transaction(book_id, "c1", owner)
+
+
+@pytest.mark.asyncio
+async def test_audit_failure_does_not_fail_a_committed_toc_update(
+    seed_book, monkeypatch
+):
+    """An audit failure must not turn a successful edit into an error (#369).
+
+    The guarded write commits before the audit row is inserted. While these ran
+    inside a transaction the two were atomic; without it, letting the audit
+    exception propagate would report failure for a change that persisted — and
+    the client's retry would then conflict with its own committed write.
+    """
+    book_id, owner = await seed_book(
+        toc=_toc(version=1, chapters=[{"id": "c1", "title": "Original"}])
+    )
+
+    async def _boom(*a, **kw):
+        raise RuntimeError("audit collection unavailable")
+
+    monkeypatch.setattr(tx, "create_audit_log", _boom)
+
+    # Must not raise.
+    await tx.update_toc_with_transaction(
+        book_id, {"chapters": [{"id": "c1", "title": "Renamed"}]}, owner
+    )
+
+    # And the edit is actually persisted, not silently dropped.
+    stored = await _get_toc(book_id)
+    assert stored["chapters"][0]["title"] == "Renamed"
+    assert stored["version"] == 2

--- a/backend/tests/test_db/test_toc_transactions.py
+++ b/backend/tests/test_db/test_toc_transactions.py
@@ -1,16 +1,23 @@
 """
 Integration tests for app/db/toc_transactions.py.
 
-Exercises the atomic TOC transaction helpers against a real local MongoDB
-(via the motor_reinit_db fixture) — happy paths AND the data-integrity
-failure paths: invalid IDs, missing/unauthorized books, optimistic-locking
-version conflicts, missing chapters, and the transaction-detection fallback.
+Exercises the atomic TOC helpers against a real local MongoDB (via the
+motor_reinit_db fixture) — happy paths AND the data-integrity failure paths:
+invalid IDs, missing/unauthorized books, optimistic-locking version conflicts,
+and missing chapters.
 
-ponytail: the `if use_transaction:` real-transaction branches require a
-MongoDB replica set; a standalone test server reports no setName, so those
-functions run via the non-transactional fallback here. Covering the live
-transaction/rollback branch would need a replica-set test fixture — upgrade
-path if/when CI runs Mongo as a replica set.
+The `if use_transaction:` branches these tests used to note as uncoverable are
+gone (#369). They needed a replica-set fixture because a standalone server
+reports no setName — but the branch they guarded was also the bug: inside a
+transaction the guarded update reads at the transaction snapshot, so the version
+filter always matched, the ValueError never raised, and a genuine conflict
+surfaced at commit as a WriteConflict → generic OperationFailure → 500 instead
+of the intended 409.
+
+Every one of these helpers is a single-document compare-and-swap, so the CAS is
+atomic without a transaction and behaves identically on standalone and replica
+set. Deleting the branch was the fix; there is no longer a topology-dependent
+path to cover, which is why the note is retired rather than satisfied.
 """
 
 import pytest
@@ -626,3 +633,65 @@ async def test_book_deleted_mid_operation_reports_not_found(
 
     with pytest.raises(ValueError, match="Book not found"):
         await call(book_id, owner)
+
+
+@pytest.mark.asyncio
+async def test_update_toc_interleaved_writer_does_not_lose_update(
+    seed_book, monkeypatch
+):
+    """update_toc is the fifth helper that lost its transaction wrapper (#369).
+
+    The other four are covered by the parametrised interleave test above; this
+    one has a different signature and a different conflict message, so it gets
+    its own. Same property: a competing commit in the read -> write window must
+    make this write raise rather than clobber.
+    """
+    book_id, owner = await seed_book(
+        toc=_toc(version=1, chapters=[{"id": "c1", "title": "Original"}])
+    )
+
+    competing = _toc(
+        version=2, chapters=[{"id": "c1", "title": "Original", "content": "autosaved"}]
+    )
+    state = _interleave_competing_write(monkeypatch, book_id, competing)
+
+    with pytest.raises(ValueError):
+        await tx.update_toc_with_transaction(
+            book_id, {"chapters": [{"id": "c1", "title": "Mine"}]}, owner
+        )
+
+    assert state["fired"], "competing write never ran — test is not interleaving"
+
+    # The competing writer's data survived intact.
+    stored = await tx.books_collection.find_one({"_id": ObjectId(book_id)})
+    assert stored["table_of_contents"] == competing
+
+
+@pytest.mark.asyncio
+async def test_helpers_do_not_open_transactions(monkeypatch, seed_book):
+    """The topology-dependent path is gone, not merely unused (#369).
+
+    Pinning this structurally rather than behaviourally: a transaction would
+    reintroduce the 500-instead-of-409 bug only on a replica set, which no
+    standalone test can observe. Asserting that no session is ever started
+    catches the regression on any topology.
+    """
+    book_id, owner = await seed_book(
+        toc=_toc(version=1, chapters=[{"id": "c1", "title": "Original"}])
+    )
+
+    import app.db.base as base
+
+    def _fail_start_session(*a, **kw):
+        raise AssertionError(
+            "TOC helpers must not open a session: inside a transaction the "
+            "guarded update reads at the snapshot, so a concurrent commit "
+            "surfaces as a WriteConflict (500) instead of ValueError (409)"
+        )
+
+    monkeypatch.setattr(base._client, "start_session", _fail_start_session)
+
+    await tx.add_chapter_with_transaction(book_id, {"title": "New"}, owner)
+    await tx.update_chapter_with_transaction(book_id, "c1", {"title": "Edited"}, owner)
+    await tx.reorder_chapters_with_transaction(book_id, [{"id": "c1", "order": 1}], owner)
+    await tx.delete_chapter_with_transaction(book_id, "c1", owner)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",
-        "@hookform/resolvers": "^3.10.0",
+        "@hookform/resolvers": "^5.5.7",
         "@hugeicons/core-free-icons": "^3.1.0",
         "@hugeicons/react": "^1.1.3",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -61,7 +61,7 @@
         "tailwind-merge": "^2.1.0",
         "tailwindcss-animate": "^1.0.7",
         "web-vitals": "^5.3.0",
-        "zod": "^3.25.76"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@axe-core/react": "^4.11.0",
@@ -768,6 +768,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -778,6 +795,13 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
@@ -858,12 +882,113 @@
       }
     },
     "node_modules/@hookform/resolvers": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
-      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.5.7.tgz",
+      "integrity": "sha512-CyPCYV8/KlXfEXLWj8HHHhVsR/IZ6Ckm3b/a4fWtO/lRnRK1huqncb8LlAWrmpPRsse5glF5aVuDRMHEr3UGag==",
       "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
       "peerDependencies": {
-        "react-hook-form": "^7.0.0"
+        "@sinclair/typebox": ">=0.25.24",
+        "@standard-schema/spec": "^1.0.0",
+        "@typeschema/main": ">=0.13.7",
+        "@vinejs/vine": "^2.0.0 || ^3.0.0",
+        "ajv": "^8.12.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1",
+        "arktype": "^2.0.0",
+        "ata-validator": "^0.7.0",
+        "class-transformer": ">=0.4.0",
+        "class-validator": ">=0.12.0",
+        "computed-types": "^1.0.0",
+        "effect": "^3.10.3",
+        "fluentvalidation-ts": "^3.0.0",
+        "fp-ts": "^2.7.0",
+        "io-ts": "^2.0.0",
+        "joi": "^17.0.0",
+        "nope-validator": ">=0.12.0",
+        "react-hook-form": "^7.55.0",
+        "superstruct": ">=0.12.0",
+        "typanion": "^3.3.2",
+        "valibot": ">=0.31.0 || ^1.0.0-beta.4 || ^1.0.0-rc",
+        "vest": ">=3.0.0",
+        "yup": "^1.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@sinclair/typebox": {
+          "optional": true
+        },
+        "@standard-schema/spec": {
+          "optional": true
+        },
+        "@typeschema/main": {
+          "optional": true
+        },
+        "@vinejs/vine": {
+          "optional": true
+        },
+        "ajv": {
+          "optional": true
+        },
+        "ajv-errors": {
+          "optional": true
+        },
+        "ajv-formats": {
+          "optional": true
+        },
+        "arktype": {
+          "optional": true
+        },
+        "ata-validator": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        },
+        "computed-types": {
+          "optional": true
+        },
+        "effect": {
+          "optional": true
+        },
+        "fluentvalidation-ts": {
+          "optional": true
+        },
+        "fp-ts": {
+          "optional": true
+        },
+        "io-ts": {
+          "optional": true
+        },
+        "joi": {
+          "optional": true
+        },
+        "nope-validator": {
+          "optional": true
+        },
+        "superstruct": {
+          "optional": true
+        },
+        "typanion": {
+          "optional": true
+        },
+        "valibot": {
+          "optional": true
+        },
+        "vest": {
+          "optional": true
+        },
+        "yup": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@hugeicons/core-free-icons": {
@@ -5009,7 +5134,7 @@
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@sinonjs/commons": {
@@ -5036,6 +5161,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -6661,16 +6792,16 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -6694,30 +6825,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -7388,15 +7495,6 @@
         "zod": {
           "optional": true
         }
-      }
-    },
-    "node_modules/better-auth/node_modules/zod": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
-      "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/binary-extensions": {
@@ -9016,6 +9114,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -9026,6 +9141,13 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
@@ -11704,11 +11826,11 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -14173,23 +14295,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/schema-utils/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/schema-utils/node_modules/ajv-keywords": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
@@ -14202,13 +14307,6 @@
       "peerDependencies": {
         "ajv": "^8.8.2"
       }
-    },
-    "node_modules/schema-utils/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/semifies": {
       "version": "1.0.0",
@@ -16094,9 +16192,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@hello-pangea/dnd": "^18.0.1",
-    "@hookform/resolvers": "^3.10.0",
+    "@hookform/resolvers": "^5.5.7",
     "@hugeicons/core-free-icons": "^3.1.0",
     "@hugeicons/react": "^1.1.3",
     "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -73,7 +73,7 @@
     "tailwind-merge": "^2.1.0",
     "tailwindcss-animate": "^1.0.7",
     "web-vitals": "^5.3.0",
-    "zod": "^3.25.76"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@axe-core/react": "^4.11.0",


### PR DESCRIPTION
Part of #385 (the zod half; tiptap v3 follows separately).

## Why it can't merge as a single-package bump

`@hookform/resolvers` was pinned `^3.10.0`, and its v3 zod resolver only speaks zod 3. Under zod 4 it **throws out of the resolver** instead of returning field errors, so validation breaks at runtime rather than rendering inline messages. npm resolves the install cleanly — the peer range is satisfied — and the resolver crashes when invoked.

## Reproduced rather than taken on faith

Pinning resolvers back to v3 with zod 4 installed:

```
✕ validates required title field
✕ displays validation messages correctly
✕ disables submit button on invalid step
✕ shows inline validation errors
✕ clears errors on correction

ZodError: [ … ] at node_modules/@hookform/resolvers/zod/src/zod.ts
```

With resolvers v5: **36/36**. That matches the issue's analysis exactly, including the failing-test count.

## Call-site audit

All three production `zodResolver` sites checked — `BookCreationWizard`, `BookMetadataForm`, `profile/page` — along with the schemas they use. `bookCreationSchema` and `profileSchema` use only `string`/`boolean`/`transform`/`refine`/`optional`/`literal`, none of which changed shape in v4.

Worth stating explicitly, because it's the reason this PR is a lockfile change and nothing else: **no schema needed rewriting.** If any had used v3-only APIs this would have been a much larger change.

## Verification

| Check | Result |
|-------|--------|
| `BookCreationWizard` (incl. all 6 validation tests) | 36 passed |
| Full frontend suite (coverage) | **133/133 suites, 2287 passed**, thresholds met |
| `tsc --noEmit` | clean |
| Incompatibility reproduction | 5 failures on resolvers v3, 0 on v5 ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)