### PR TITLE
revert: direct-to-main commit that configured a tiptap v3 option on v2

### DIFF
--- a/frontend/src/components/chapters/ChapterEditor.tsx
+++ b/frontend/src/components/chapters/ChapterEditor.tsx
@@ -138,14 +138,7 @@ export function ChapterEditor({
 
   const editor = useEditor({
     extensions: [
-      // trailingNode is new in StarterKit v3 and ON by default: it keeps an
-      // empty paragraph at the end of the document so there is always somewhere
-      // to click below the last block. Disabled deliberately — the editor's HTML
-      // is what gets persisted and exported, so leaving it on would append a
-      // <p></p> to every chapter a user saves. That is a content change, and a
-      // dependency upgrade is the wrong place to make one; enabling it is a
-      // product decision with a migration behind it (#385).
-      StarterKit.configure({ trailingNode: false }),
+      StarterKit,
       Underline,
       Placeholder.configure({
         placeholder: 'Start writing your chapter content...',

--- a/frontend/src/jest.setup.ts
+++ b/frontend/src/jest.setup.ts
@@ -534,11 +534,7 @@ jest.mock('@tiptap/react', () => {
 
 // Mock TipTap extensions
 jest.mock('@tiptap/starter-kit', () => {
-  // v3's StarterKit is configured (trailingNode is disabled — see
-  // ChapterEditor), so the mock needs .configure like the real extension.
-  const starterKit: Record<string, unknown> = jest.fn(() => ({ name: 'starterKit' }));
-  starterKit.configure = jest.fn(() => ({ name: 'starterKit' }));
-  return starterKit;
+  return jest.fn(() => ({ name: 'starterKit' }));
 });
 
 jest.mock('@tiptap/extension-underline', () => {


### PR DESCRIPTION
Reverts `95626e2`, which I pushed **directly to `main`**, bypassing the PR workflow.

## What happened

While fixing an E2E failure on #399 (tiptap v3), I had `main` checked out — I'd switched to it after merging #398 and never went back to the feature branch. The commit and push landed on `main`.

## Why it needs reverting, beyond the process violation

`main` pins `@tiptap/starter-kit: ^2.1.13`. The commit added:

```ts
StarterKit.configure({ trailingNode: false })
```

`trailingNode` **is a v3-only option**. On `main` it configures something that doesn't exist, and the accompanying comment documents v3 behaviour in a v2 codebase. The change is only meaningful alongside the v3 bump, which lives in #399.

So this isn't merely "right change, wrong branch" — it's a change that doesn't belong on `main` at all until #399 lands.

## What I'm doing about it

1. This PR reverts it, restoring `main` to a coherent state and to the invariant that everything on it went through review.
2. The fix is re-applied on the #399 branch, where the v3 bump makes it correct and where CI can actually validate it.

## On the process failure

The repo rule is explicit — *"Never commit to `main` directly — `feature/<name>`, PR, conventional commits"* — and I broke it. The mechanical cause was not checking `git rev-parse --abbrev-ref HEAD` before committing after a branch switch; I'd been switching branches frequently while juggling two PRs.

Flagging it rather than quietly folding it into #399, because a silent direct-to-main commit is exactly the kind of thing that should be visible in the history.