### PR TITLE
chore(deps): stop Dependabot raising @types/node major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,14 @@ updates:
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 7
+    ignore:
+      # @types/node must track the Node we actually run, not the newest release.
+      # CI is on Node 20 and deploy-staging.yml pins 18, so a major bump (#422
+      # proposed 20 -> 26) types APIs the runtime doesn't have: typecheck goes
+      # green and the call fails on the server. Minor/patch still flow through.
+      # Lift this when #428 settles on one Node major across CI and deploy.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "uv"
     directory: "/backend"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13126,9 +13126,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -13856,6 +13856,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
Follow-up to the supply-chain triage of #422 (`@types/node` 20.19.27 → 26.1.1), which is being closed rather than merged.

## Why

`@types/node` ships no runtime code, so the bump had no supply-chain red flags — clean diff, no lifecycle scripts, only `undici-types` moving alongside it, a month old, all checks green. The problem was the mismatch it introduced:

| Where | Node |
|---|---|
| CI tests | 20 (`tests.yml:32,202`) |
| Staging deploy | **18** (`deploy-staging.yml:31`) |
| Proposed types | **26** |

Types ahead of the runtime remove the compile-time guardrail. #422 passed typecheck only because nothing yet reaches for a Node 26-only API — the first person who does gets a green CI run and a failure on the server. With no `engines` field in `frontend/package.json`, the `@types/node` major was the de-facto pin, so the bump was quietly removing the only thing holding the line.

## What this does

Adds an `ignore` entry to the `/frontend` npm block for `@types/node` **majors only**. Minor and patch updates keep flowing normally.

Deliberately *not* in this PR: an `engines.node` field. CI and deploy currently disagree about the target major, so writing one would encode a guess as truth. #428 (P2.12) settles that — it also tracks the real finding here, that the deploy workflows run **end-of-life Node 18**, which stopped receiving security patches in April 2025. This rule gets lifted once one major is chosen across CI and deploy.

## Verification

`.github/dependabot.yml` parses and the rule lands in the right ecosystem block:

```
$ python3 -c "import yaml; d=yaml.safe_load(open('.github/dependabot.yml')); ..."
ignore: [{'dependency-name': '@types/node', 'update-types': ['version-update:semver-major']}]
ecosystems: ['npm', 'uv', 'github-actions']
```

The first commit is config-only — no application code, no lockfile, no test surface. A second commit was added to clear a CI failure; see below.

Closes #422
Related: #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Added: nanoid security fix (unrelated to the config change)

The `Security Audit` gate failed on the first run of this branch with two advisories that **postdate main's last green run** (2026-08-07) — latent on `main`, not introduced here:

| Advisory | Issue | Fixed in |
|---|---|---|
| [GHSA-28wg-ghj8-5hjv](https://github.com/advisories/GHSA-28wg-ghj8-5hjv) (high) | non-secure generators loop indefinitely on negative size | 3.3.16 |
| [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (high) | custom generators loop indefinitely when size is zero | 3.3.17 |

`nanoid` is transitive via `postcss` (direct, and nested under `next`). 3.3.x is semver-compatible, so `npm update nanoid` lifts 3.3.11 → 3.3.18 in place with no manifest change.

**Lockfile regenerated under Node 20.19.6 / npm 10.8.2 to match CI.** Running it on the local Node 24 / npm 11 default rewrote 130 lines of `peer`/`license` metadata across the whole file; on CI's npm the diff is 7 lines. The one non-nanoid line is npm correcting a missing `"dev": true` on playwright's nested `fsevents`.

Verified locally: `nanoid` drops out of `npm audit`, and `audit_gate.py` returns `PASS — no new advisories (41 known, already in the baseline)` with exit 0. Pre-commit ran frontend lint, typecheck, unit tests, and the 85% coverage check — all green.

### Noted, not fixed here
The gate also reports 11 baselined npm advisories as **resolved** (`GHSA-22p9-wv53-3rq4`, `GHSA-2w69-qvjg-hvjx`, `GHSA-3jxr-9vmj-r5cp`, `GHSA-49rj-9fvp-4h2h`, `GHSA-8646-j5j9-6r62`, `GHSA-8v8x-cx79-35w7`, `GHSA-8x6r-g9mw-2r78`, `GHSA-chx6-hx7r-mcp5`, `GHSA-mh99-v99m-4gvg`, `GHSA-rxv8-25v2-qmq8`, `GHSA-v245-v573-v5vm`) and prunable from `security-baseline.json`. Informational only — it does not fail the gate — and pruning it is #413's territory, not this PR's.
