### PR TITLE
fix(auth): upgrade better-auth 1.4.9 → 1.6.26, clearing GHSA-p6v2-xcpg-h6xw

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -37,7 +37,7 @@
         "@tiptap/pm": "^3.29.2",
         "@tiptap/react": "^3.29.2",
         "@tiptap/starter-kit": "^3.29.2",
-        "better-auth": "^1.4.7",
+        "better-auth": "^1.6.26",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "date-fns": "^4.1.0",
@@ -158,12 +158,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -172,29 +172,29 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -220,13 +220,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -236,13 +236,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -261,36 +261,36 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -310,52 +310,52 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -613,31 +613,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -645,13 +645,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -664,16 +664,138 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@better-auth/core": {
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.26.tgz",
+      "integrity": "sha512-Ud4FqnjIJDvmeo+3bN+OsuVVAiuvFjNERbW7G8/65ictSxCox62gNgTOsJ4YXmbwXzBzyyekStzrupg2qNGEkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.39.0",
+        "@standard-schema/spec": "^1.1.0",
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1",
+        "@cloudflare/workers-types": ">=4",
+        "@opentelemetry/api": "^1.9.0",
+        "better-call": "1.3.7",
+        "jose": "^6.1.0",
+        "kysely": "^0.28.5 || ^0.29.0",
+        "nanostores": "^1.0.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/drizzle-adapter": {
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.26.tgz",
+      "integrity": "sha512-SMvAeeUqEsz0BLtWVVp+HdStAVOwcxs4vPkL/AVmFJ0e9dDKItXl881xWeB/Ze4NgBW6NYmUId9qI4LrdQu3hA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.26",
+        "@better-auth/utils": "0.4.2",
+        "drizzle-orm": "^0.45.2"
+      },
+      "peerDependenciesMeta": {
+        "drizzle-orm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/kysely-adapter": {
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.26.tgz",
+      "integrity": "sha512-Y0Kdqn8JQMR8dHMtUnbBNqq7Mk8mDf18DwTves2uhjtRfcOWByVTGxsFMDVUbedMuoM+Ab+v04bwCk94sAo8NA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.26",
+        "@better-auth/utils": "0.4.2",
+        "kysely": "^0.28.17 || ^0.29.0"
+      },
+      "peerDependenciesMeta": {
+        "kysely": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/memory-adapter": {
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.26.tgz",
+      "integrity": "sha512-kb5ahphEp9jyMleXU4T8I/xgWPa8gjOLFKKsnaVqR/BU+h7xqTOsjJwTY3evY+PFYHvjNFUlrjZ1Km8A/w1p/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.26",
+        "@better-auth/utils": "0.4.2"
+      }
+    },
+    "node_modules/@better-auth/mongo-adapter": {
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.26.tgz",
+      "integrity": "sha512-jYGhuIQqj48h69ROLPYdc8jgqDaMmRRLLFiRViZFYarNyBuYUV07DywJXvRuw8l9ADx+M1TB+BJZGnLE2nnmwQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.26",
+        "@better-auth/utils": "0.4.2",
+        "mongodb": "^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "mongodb": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/prisma-adapter": {
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.26.tgz",
+      "integrity": "sha512-ILQoYmnoYyghDP4iN1h/Gkd9Jt7Xs/vxoNAt4AuuJJbqs73u27LlQM4P1YiP7nJ+bM1iVTBI1dDF73myIAtjzQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.26",
+        "@better-auth/utils": "0.4.2",
+        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@prisma/client": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/telemetry": {
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.26.tgz",
+      "integrity": "sha512-pBs69RORUSJHRF9r5PdeY7pzLRga09YSWew8igFYrBvT2tLt7DktrbD5WjryLZpAZOuKAMZ+Xo0DlJbnvLWGpQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.26",
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1"
+      }
+    },
     "node_modules/@better-auth/utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.0.tgz",
-      "integrity": "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==",
-      "license": "MIT"
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.2.tgz",
+      "integrity": "sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1"
+      }
     },
     "node_modules/@better-fetch/fetch": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.3.1.tgz",
+      "integrity": "sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.7.1",
@@ -8502,32 +8624,38 @@
       }
     },
     "node_modules/better-auth": {
-      "version": "1.4.9",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.4.9.tgz",
-      "integrity": "sha512-usSdjuyTzZwIvM8fjF8YGhPncxV3MAg3dHUO9uPUnf0yklXUSYISiH1+imk6/Z+UBqsscyyPRnbIyjyK97p7YA==",
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.26.tgz",
+      "integrity": "sha512-nhXWrDDj+EnZsHq1j0z1c6DowOMFZWZHe6LCaXbBfLIgHHZm6dyazBQcbRspM4spUIcUt250Mc1BFOSuP7eniQ==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/core": "1.4.9",
-        "@better-auth/telemetry": "1.4.9",
-        "@better-auth/utils": "0.3.0",
-        "@better-fetch/fetch": "1.1.21",
-        "@noble/ciphers": "^2.0.0",
-        "@noble/hashes": "^2.0.0",
-        "better-call": "1.1.7",
+        "@better-auth/core": "1.6.26",
+        "@better-auth/drizzle-adapter": "1.6.26",
+        "@better-auth/kysely-adapter": "1.6.26",
+        "@better-auth/memory-adapter": "1.6.26",
+        "@better-auth/mongo-adapter": "1.6.26",
+        "@better-auth/prisma-adapter": "1.6.26",
+        "@better-auth/telemetry": "1.6.26",
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1",
+        "@noble/ciphers": "^2.1.1",
+        "@noble/hashes": "^2.0.1",
+        "better-call": "1.3.7",
         "defu": "^6.1.4",
-        "jose": "^6.1.0",
-        "kysely": "^0.28.5",
-        "nanostores": "^1.0.1",
-        "zod": "^4.1.12"
+        "jose": "^6.1.3",
+        "kysely": "^0.28.17 || ^0.29.0",
+        "nanostores": "^1.1.1",
+        "zod": "^4.3.6"
       },
       "peerDependencies": {
         "@lynx-js/react": "*",
         "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "@sveltejs/kit": "^2.0.0",
         "@tanstack/react-start": "^1.0.0",
+        "@tanstack/solid-start": "^1.0.0",
         "better-sqlite3": "^12.0.0",
         "drizzle-kit": ">=0.31.4",
-        "drizzle-orm": ">=0.41.0",
+        "drizzle-orm": "^0.45.2",
         "mongodb": "^6.0.0 || ^7.0.0",
         "mysql2": "^3.0.0",
         "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
@@ -8551,6 +8679,9 @@
           "optional": true
         },
         "@tanstack/react-start": {
+          "optional": true
+        },
+        "@tanstack/solid-start": {
           "optional": true
         },
         "better-sqlite3": {
@@ -8597,45 +8728,16 @@
         }
       }
     },
-    "node_modules/better-auth/node_modules/@better-auth/core": {
-      "version": "1.4.9",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.9.tgz",
-      "integrity": "sha512-JT2q4NDkQzN22KclUEoZ7qU6tl9HUTfK1ctg2oWlT87SEagkwJcnrUwS9VznL+u9ziOIfY27P0f7/jSnmvLcoQ==",
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "zod": "^4.1.12"
-      },
-      "peerDependencies": {
-        "@better-auth/utils": "0.3.0",
-        "@better-fetch/fetch": "1.1.21",
-        "better-call": "1.1.7",
-        "jose": "^6.1.0",
-        "kysely": "^0.28.5",
-        "nanostores": "^1.0.1"
-      }
-    },
-    "node_modules/better-auth/node_modules/@better-auth/telemetry": {
-      "version": "1.4.9",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.4.9.tgz",
-      "integrity": "sha512-Tthy1/Gmx+pYlbvRQPBTKfVei8+pJwvH1NZp+5SbhwA6K2EXIaoonx/K6N/AXYs2aKUpyR4/gzqDesDjL7zd6A==",
-      "dependencies": {
-        "@better-auth/utils": "0.3.0",
-        "@better-fetch/fetch": "1.1.21"
-      },
-      "peerDependencies": {
-        "@better-auth/core": "1.4.9"
-      }
-    },
-    "node_modules/better-auth/node_modules/better-call": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.1.7.tgz",
-      "integrity": "sha512-6gaJe1bBIEgVebQu/7q9saahVzvBsGaByEnE8aDVncZEDiJO7sdNB28ot9I6iXSbR25egGmmZ6aIURXyQHRraQ==",
+    "node_modules/better-call": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.7.tgz",
+      "integrity": "sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/utils": "^0.3.0",
-        "@better-fetch/fetch": "^1.1.4",
-        "rou3": "^0.7.10",
-        "set-cookie-parser": "^2.7.1"
+        "@better-auth/utils": "^0.4.0",
+        "@better-fetch/fetch": "^1.1.21",
+        "rou3": "^0.7.12",
+        "set-cookie-parser": "^3.0.1"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
@@ -12878,9 +12980,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -13050,9 +13152,9 @@
       }
     },
     "node_modules/kysely": {
-      "version": "0.28.9",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.9.tgz",
-      "integrity": "sha512-3BeXMoiOhpOwu62CiVpO6lxfq4eS6KMYfQdMsN/2kUCRNuF2YiEr7u0HLHaQU+O4Xu8YXE3bHVkwaQ85i72EuA==",
+      "version": "0.28.17",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.17.tgz",
+      "integrity": "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
@@ -13581,9 +13683,9 @@
       }
     },
     "node_modules/nanostores": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.1.0.tgz",
-      "integrity": "sha512-yJBmDJr18xy47dbNVlHcgdPrulSn1nhSE6Ns9vTG+Nx9VPT6iV1MD6aQFp/t52zpf82FhLLTXAXr30NuCnxvwA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.4.2.tgz",
+      "integrity": "sha512-Wxv8Roefr2nqtiRG0bnaFlpYqpIVtOEeJZHaH+4nGgOK1/7n6OHOuHCb/bhqrNQgZM8fyd0s1PqhdrJc9Ib44g==",
       "funding": [
         {
           "type": "github",
@@ -14293,6 +14395,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -15386,9 +15489,9 @@
       "license": "MIT"
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
+      "integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
       "license": "MIT"
     },
     "node_modules/set-function-length": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,7 +49,7 @@
     "@tiptap/pm": "^3.29.2",
     "@tiptap/react": "^3.29.2",
     "@tiptap/starter-kit": "^3.29.2",
-    "better-auth": "^1.4.7",
+    "better-auth": "^1.6.26",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "date-fns": "^4.1.0",
@@ -97,6 +97,7 @@
   },
   "overrides": {
     "js-yaml@^3": "3.15.1",
-    "js-yaml@^4": "4.3.1"
+    "js-yaml@^4": "4.3.1",
+    "@babel/core": "^7.29.0"
   }
 }

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -14,10 +14,66 @@ const dbName = process.env.DATABASE_NAME || "auto_author";
 const MAX_RETRY_ATTEMPTS = parseInt(process.env.MONGO_MAX_RETRY_ATTEMPTS || '3', 10);
 const BASE_RETRY_DELAY_MS = parseInt(process.env.MONGO_BASE_RETRY_DELAY_MS || '1000', 10);
 
+/**
+ * Build the better-auth instance for a connected database.
+ *
+ * Extracted from `getAuth()` so the singleton below can be typed as this
+ * function's return type. better-auth 1.6 made `Auth<TOptions>` invariant over
+ * its options, so the old `ReturnType<typeof betterAuth>` annotation — which
+ * resolves to the widened `Auth<BetterAuthOptions>` — no longer accepts the
+ * instance built from these concrete options. The `twoFactor()` plugin is what
+ * makes them concretely different: it adds `twoFactorEnabled` to the user
+ * schema, so the widened type is genuinely a different shape, not just a looser
+ * one. Naming the factory keeps the full inferred options type intact.
+ */
+function createAuthInstance(database: Db) {
+  return betterAuth({
+    appName: "Auto Author",
+    database: mongodbAdapter(database),
+    // TOTP two-factor authentication (#64). The MongoDB adapter creates the
+    // twoFactor collection on demand — no migration step required.
+    plugins: [twoFactor()],
+    emailAndPassword: {
+      enabled: true,
+      autoSignIn: true,
+      // Password reset configuration
+      sendResetPassword: async ({ user, url }) => {
+        // Send password reset email
+        // Use void to prevent timing attacks (don't reveal if email exists)
+        void (async () => {
+          try {
+            // Import email service dynamically to avoid issues during build
+            const { sendPasswordResetEmail } = await import("@/lib/email");
+            await sendPasswordResetEmail({
+              to: user.email,
+              name: user.name || "User",
+              resetUrl: url,
+            });
+            console.log(`Password reset email sent to ${user.email}`);
+          } catch (error) {
+            console.error("Failed to send password reset email:", error);
+          }
+        })();
+      },
+    },
+    session: {
+      expiresIn: 60 * 60 * 24 * 7, // 7 days
+      updateAge: 60 * 60 * 24, // Refresh every 24 hours
+      cookieCache: {
+        enabled: true,
+        maxAge: 5 * 60, // Cache for 5 minutes
+      },
+    },
+    advanced: {
+      defaultCookieAttributes: getDefaultCookieAttributes(),
+    },
+  });
+}
+
 // Lazy singleton pattern for MongoDB connection and auth instance
 let client: MongoClient | null = null;
 let db: Db | null = null;
-let authInstance: ReturnType<typeof betterAuth> | null = null;
+let authInstance: ReturnType<typeof createAuthInstance> | null = null;
 
 /**
  * Sleep for a specified duration with jitter
@@ -107,54 +163,18 @@ export async function getAuth() {
 
   // Create auth instance with connected database
   try {
-    authInstance = betterAuth({
-      appName: "Auto Author",
-      database: mongodbAdapter(db),
-      // TOTP two-factor authentication (#64). The MongoDB adapter creates the
-      // twoFactor collection on demand — no migration step required.
-      plugins: [twoFactor()],
-      emailAndPassword: {
-        enabled: true,
-        autoSignIn: true,
-        // Password reset configuration
-        sendResetPassword: async ({ user, url }) => {
-          // Send password reset email
-          // Use void to prevent timing attacks (don't reveal if email exists)
-          void (async () => {
-            try {
-              // Import email service dynamically to avoid issues during build
-              const { sendPasswordResetEmail } = await import("@/lib/email");
-              await sendPasswordResetEmail({
-                to: user.email,
-                name: user.name || "User",
-                resetUrl: url,
-              });
-              console.log(`Password reset email sent to ${user.email}`);
-            } catch (error) {
-              console.error("Failed to send password reset email:", error);
-            }
-          })();
-        },
-      },
-      session: {
-        expiresIn: 60 * 60 * 24 * 7, // 7 days
-        updateAge: 60 * 60 * 24, // Refresh every 24 hours
-        cookieCache: {
-          enabled: true,
-          maxAge: 5 * 60, // Cache for 5 minutes
-        },
-      },
-      advanced: {
-        defaultCookieAttributes: getDefaultCookieAttributes(),
-      },
-    });
+    const instance = createAuthInstance(db);
+    authInstance = instance;
+    // Return the local, not the module-level cache: the cache is declared
+    // `| null` (it has to be, to start empty), and returning it directly would
+    // widen this function's inferred return type to include null — which is
+    // what forced the null-check at the route handler.
+    return instance;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     console.error('Failed to create auth instance:', errorMessage, { error });
     throw new Error(`Auth instance creation failed: ${errorMessage}`);
   }
-
-  return authInstance;
 }
 
 /**

--- a/scripts/check-secrets.sh
+++ b/scripts/check-secrets.sh
@@ -40,10 +40,17 @@ PATTERNS=(
     # without an operator it fired on any identifier merely CONTAINING
     # "password" that happened to sit near a quoted string. The real case that
     # blocked #411: `const { sendPasswordResetEmail } = await import("@/lib/email")`
-    # matched on "Password" + ".*" + the quoted module path. Trailing
-    # [A-Za-z0-9_]* keeps compound names like `db_password_field = "..."`
-    # covered, while stopping the match from running across " } = await import(".
-    '[pP][aA][sS][sS][wW][oO][rR][dD][A-Za-z0-9_]*['\''"]?[[:space:]]*[=:][[:space:]]*['\''"][^'\''\"]{8,}['\''"]'
+    # matched on "Password" + ".*" + the quoted module path.
+    #
+    # The name-continuation class must include - and . alongside word chars:
+    # with [A-Za-z0-9_]* alone the match stopped at the hyphen and could never
+    # reach the operator, silently dropping YAML/JSON keys like
+    # `password-value: "..."` and `"password-field": "..."` that the old pattern
+    # did catch. (`db-password: "..."` was unaffected — there the hyphen precedes
+    # the word.) Bounded repetition of a restricted class still can't cross the
+    # " } = await import(" in the false positive above, because `}` and space are
+    # outside the class and the operator must follow immediately.
+    '[pP][aA][sS][sS][wW][oO][rR][dD][A-Za-z0-9_.-]*['\''"]?[[:space:]]*[=:][[:space:]]*['\''"][^'\''\"]{8,}['\''"]'
     '[tT][oO][kK][eE][nN].*['\''"][0-9a-zA-Z]{32,}['\''"]'
     # OAuth tokens
     'ghp_[0-9a-zA-Z]{36}'

--- a/scripts/check-secrets.sh
+++ b/scripts/check-secrets.sh
@@ -33,7 +33,17 @@ PATTERNS=(
     # Generic API keys and secrets
     '[aA][pP][iI][-_]?[kK][eE][yY].*['\''"][0-9a-zA-Z]{32,}['\''"]'
     '[sS][eE][cC][rR][eE][tT].*['\''"][0-9a-zA-Z]{32,}['\''"]'
-    '[pP][aA][sS][sS][wW][oO][rR][dD].*['\''"][^'\''\"]{8,}['\''"]'
+    # Require an actual assignment between the name and the quoted value, the
+    # same narrowing the NEXT_PUBLIC_ pattern below uses. This is the loosest
+    # pattern in the set — its value side accepts any 8+ characters, where the
+    # api-key/secret/token patterns demand a 32+ char alphanumeric run — so
+    # without an operator it fired on any identifier merely CONTAINING
+    # "password" that happened to sit near a quoted string. The real case that
+    # blocked #411: `const { sendPasswordResetEmail } = await import("@/lib/email")`
+    # matched on "Password" + ".*" + the quoted module path. Trailing
+    # [A-Za-z0-9_]* keeps compound names like `db_password_field = "..."`
+    # covered, while stopping the match from running across " } = await import(".
+    '[pP][aA][sS][sS][wW][oO][rR][dD][A-Za-z0-9_]*['\''"]?[[:space:]]*[=:][[:space:]]*['\''"][^'\''\"]{8,}['\''"]'
     '[tT][oO][kK][eE][nN].*['\''"][0-9a-zA-Z]{32,}['\''"]'
     # OAuth tokens
     'ghp_[0-9a-zA-Z]{36}'


### PR DESCRIPTION
Closes #411. Supersedes #405 (Dependabot's 1.6.25 bump, which could not merge — it targets the stale patch and carries none of the type work).

## Why

`better-auth` 1.4.9 is inside the vulnerable range of [GHSA-p6v2-xcpg-h6xw](https://github.com/advisories/GHSA-p6v2-xcpg-h6xw) (**high**): versions `< 1.4.17` key rate-limit buckets on individual IPv6 addresses, so the limiter is bypassable by rotating within a prefix. Rate limiting is core, not plugin-gated, so this applies as configured here.

The other 19 published advisories for this package are gated behind `oidc-provider` / `mcp` / `api-key` / `organization` / `admin` / OAuth-social, none of which this app enables — checked against `frontend/src/lib/auth.ts` (`emailAndPassword` + `twoFactor()` + `mongodbAdapter`).

Targets **1.6.26**, not the 1.6.25 in #405 — 1.6.26 is current stable (1.7.x is still RC).

## The type fix

1.6 made `Auth<TOptions>` invariant over its options, so the singleton no longer accepted its own assigned value:

```ts
let authInstance: ReturnType<typeof betterAuth> | null   // = Auth<BetterAuthOptions>, widened
authInstance = betterAuth({ ...concrete options... })    // = Auth<{ appName; plugins: [TwoFactorPlugin]; ... }>
```

`tsc` traced the mismatch to `twoFactorEnabled`: the `twoFactor()` plugin extends the user schema, so the widened type is a genuinely *different* shape, not a looser one.

Fix — extract the call into a factory and type the cache as its return:

```ts
function createAuthInstance(database: Db) { return betterAuth({ /* … */ }) }
let authInstance: ReturnType<typeof createAuthInstance> | null = null
```

**This is more than a compile fix.** The old annotation was erasing the plugin's types all along — under `Auth<BetterAuthOptions>`, `$Infer.Session.user.twoFactorEnabled` and `api.enableTwoFactor` were invisible on 1.4.9 too. The factory restores 2FA type safety that had been silently lost.

**The second reported error fixed itself.** The issue lists `route.ts:20` as a separate failure, but `Auth<BetterAuthOptions> | null is not assignable` was a *symptom* of the widened cache leaking into `getAuth()`'s return type. `src/app/api/auth/[...all]/route.ts` is unchanged. (`toNextJsHandler`'s signature is byte-identical between 1.4.9 and 1.6.26 and is structural — it only wants `{ handler }`.)

## Dependency resolution — why `overrides` and not `--legacy-peer-deps`

npm could not resolve 1.6.x at all. better-auth declares an optional peer on `@tanstack/react-start`; npm explored it into `@vitejs/plugin-react` → `@rolldown/plugin-babel`, which needs `@babel/core ^7.29` against our transitive `7.28.5`.

`--legacy-peer-deps` would have worked but disables peer checking for the entire tree. Pinning the floor in the existing `overrides` block is narrower, and matches how this repo already handles `js-yaml`.

Verified the optional-peer chain is **not** installed — `@tanstack/react-start`, `@vitejs/plugin-react` and `@rolldown/plugin-babel` are all absent from the lockfile.

Import paths are unchanged: `better-auth/adapters/mongodb` is now a one-line re-export of `@better-auth/mongo-adapter`, and `twoFactor` still ships from `better-auth/plugins`.

## Runtime verification — and why it was necessary

**Nothing in CI exercises this upgrade.** Three independent reasons:

- `jest.config.cjs` maps `better-auth/react`, `/client` and `/client/plugins` to hand-written mocks, and `lib/auth.ts` has no unit tests at all
- `tsconfig.json` excludes every test path from `tsc`
- the CI E2E job runs with `BYPASS_AUTH=true` / `E2E_ALLOW_BYPASS=1`, so it skips better-auth entirely

So a green pipeline would have proven nothing here. The following was exercised by hand against a real MongoDB and a production build, with **no auth bypass**:

| Check | Result |
|---|---|
| `POST /api/auth/sign-up/email` | 200; sets `better-auth.session_token` + separate `better-auth.session_data` |
| `POST /api/auth/sign-in/email` | 200 |
| Wrong password | 401 |
| `GET /api/auth/get-session` with signed cookie | 200 |
| `twoFactorEnabled` on returned user | present — plugin schema live |

### The backend contract was the real risk

`backend/app/core/better_auth_session.py` does **not** validate a JWT. It splits the session cookie on `.` and queries better-auth's own Mongo collection directly, hardcoding better-auth's internal storage contract. A change there would fail silently as a blanket 401 — invisible to typecheck, tests, and bypassed E2E alike.

Every assumption it makes was verified intact under 1.6.26:

| Backend assumption | Verified |
|---|---|
| Collection named `session` | exists |
| `find_one({"token": <pre-dot part>})` | **FOUND** |
| Token stored raw, byte-equal to cookie segment | true |
| Fields `token` / `userId` / `expiresAt`, camelCase | all present |

(The session token alphabet is `a-z A-Z 0-9`, so it contains no dot and `split('.')[0]` is unambiguous.)

### Cross-version login — the one that would have locked everyone out

Created an account under **1.4.9**, reinstalled **1.6.26**, rebuilt, and signed that account in:

```
sign-in HTTP 200
twoFactorEnabled backfilled on legacy user: True -> False
find_one({token}) -> FOUND
```

Legacy scrypt hashes remain valid (params are byte-identical across versions) and legacy users without the newer `twoFactor` fields read cleanly rather than being locked out.

## Also included

`scripts/check-secrets.sh` (separate commit, `d447a4d`) — the `password` pattern was rejecting an **unmodified** line, because the refactor moved it and the scanner only inspects added (`+`) lines:

```
const { sendPasswordResetEmail } = await import("@/lib/email");
```

It matched "Password" inside the identifier, then `.*`, then the quoted module path. It's the loosest pattern in the set — its value side accepts any 8+ characters, where api-key/secret/token each demand a 32+ char alphanumeric run. Narrowed to require an assignment operator, the same fix already applied to the `NEXT_PUBLIC_` pattern. Verified in both directions: 6 real-secret forms still caught, 5 false-positive forms cleared. (`--no-verify` was **not** used; the fix is in the working tree, so the corrected pattern gates its own commit.)

## Known limitations

- **Upstream regression, not introduced here and not fixed here**: 1.4.9 compared password hashes with a constant-time helper; both 1.6 implementations use a plain `===` on the derived key. This is a timing-side-channel regression in better-auth itself. Worth an upstream issue; out of scope for this PR.
- `freshAge` now derives from `createdAt` rather than `updatedAt`. It gates only `unlinkAccount`, which this app never calls, so it is inert today — but it would matter if account deletion is added later.
- The `as AuthHandlers` cast in the auth route is now unnecessary. Left in place to keep this diff scoped to the upgrade.
- Verification above was against a local Mongo, not staging. `npm run test:e2e:staging` uses real auth and should be run post-deploy — that path still can't be exercised pre-merge, since staging runs the deployed build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
