### PR TITLE
test(backend): pin the clock for TestRateLimiting to kill a boundary flake

### DIFF
--- a/backend/tests/test_api/test_dependencies.py
+++ b/backend/tests/test_api/test_dependencies.py
@@ -127,6 +127,37 @@ class TestRateLimiting:
     (`motor_reinit_db`), since the whole point is the shared persistent store.
     """
 
+    @pytest.fixture(autouse=True)
+    def _frozen_clock(self):
+        """Pin the clock for every test in this class (#442).
+
+        The limiter keys its bucket on epoch-aligned wall-clock time
+        (`dependencies.py`: ``bucket_start = int(now // window) * window``), so
+        with the usual ``window=60`` the key rolls over on every real-world
+        minute. Tests here issue several sequential calls and assert on a single
+        bucket's running count; when those calls happened to straddle a minute
+        tick, the counter restarted mid-test.
+
+        That is not hypothetical — it red-lit PR #441, an unrelated frontend-only
+        dependency bump, with ``assert [2, 2, 1] == [2, 1, 0]``: three requests
+        recorded counts 1, 1, 2 instead of 1, 2, 3. The CI log timestamped the
+        failure 76 ms past an exact minute.
+
+        `test_rate_limiter_window_reset` already patched the clock for exactly
+        this reason ("no boundary-straddle flakes on loaded CI") but only for
+        itself. Hoisting it to an autouse fixture makes the whole class
+        deterministic and, more importantly, means the next test added here
+        inherits that rather than re-discovering the flake.
+
+        The value is arbitrary but deliberately mid-bucket: 1_000_000.0 is
+        16666 * 60 + 40, i.e. 40 s into a 60 s window, so a test that advances
+        time slightly still stays inside one bucket. Tests that need to control
+        time themselves (window_reset) just patch it again — the inner
+        `patch.object` nests over this one and restores it on exit.
+        """
+        with patch.object(deps.time, "time", return_value=1_000_000.0):
+            yield
+
     async def test_two_users_do_not_share_a_bucket(
         self, motor_reinit_db, real_rate_limiter
     ):


### PR DESCRIPTION
Closes #442.

## The flake

`TestRateLimiting::test_blocks_over_limit_with_headers` fails intermittently on unrelated PRs. It red-lit **#441** — a frontend-only `@radix-ui/react-radio-group` bump that cannot touch backend rate limiting — with:

```
assert [2, 2, 1] == [2, 1, 0]
```

Three sequential requests against a `limit=3` bucket recorded counts `1, 1, 2` instead of `1, 2, 3`.

## Root cause — not what it looks like

My first read was the `motor_reinit_db` drop race (a lost write). **That was wrong**, and the correction matters because it changes the fix. The calls are sequential `await`s — there is no concurrency that could lose an increment.

The limiter keys its bucket on epoch-aligned wall-clock time:

```python
bucket_start = int(now // window) * window   # app/api/dependencies.py
```

With `window=60` that rolls over on **every real-world minute**. When a test's calls straddle a tick, the key changes mid-test and the counter restarts from 1. The CI log timestamps the failure at `19:07:00.0764220Z` — **76 ms past an exact minute**.

**This is a test bug, not a product bug.** The 2× burst across a boundary is the documented, intentional tradeoff of a fixed window (`dependencies.py:83-85` says so outright). No security implication.

## Fix

Hoist the clock patch to an autouse fixture for the whole class.

This isn't a new technique — `test_rate_limiter_window_reset` already did exactly this for itself, with a docstring naming the same cause: *"no boundary-straddle flakes on loaded CI"*. Someone found the problem and fixed one test without applying it to its siblings. Five of them were equally exposed:

- `test_two_users_do_not_share_a_bucket` (3 calls, limit=2)
- `test_bucket_shared_across_limiter_instances` (4 calls, limit=3)
- `test_blocks_over_limit_with_headers` (4 calls, limit=3) ← the observed failure
- `test_logs_warning_before_429` (2 calls, limit=1)
- `test_rate_limiter_per_endpoint` (3 calls, limit=2)

Making it autouse rather than repeating the `with patch.object(...)` five times also means the **next** test added to this class inherits determinism instead of rediscovering the flake — which is the part that stops this recurring.

Tests that drive time themselves are unaffected: `window_reset`'s inner `patch.object` nests over the fixture and restores it on exit.

## Verified by mutation, not just by passing

A test that passes proves little about a flake fix, so I checked the fixture is actually load-bearing. Replacing the pinned clock with a boundary-straddling one:

```
FAILED test_blocks_over_limit_with_headers
E   Failed: DID NOT RAISE <class 'fastapi.exceptions.HTTPException'>
```

The bucket reset, so the over-limit call came in under the limit. Restoring the pin returns all 10 to green. That's the same mechanism as the observed `[2, 2, 1]`, caught at a different point in the sequence.

Full backend suite: **1231 passed, 9 skipped, 92% coverage**.

## Why this was worth doing now

The flake lives in `Backend Tests`, a **required** check — so every occurrence blocks an unrelated PR until someone diagnoses it and re-runs. That cost recurs on every batch of dependency updates. It also quietly trains the habit of re-running to green, which is how a real regression eventually gets waved through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
