### PR TITLE
ci(backend): fail when requirements.txt drifts from uv.lock

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,6 +146,38 @@ jobs:
       # the tool itself broke, and that must not be swallowed into a false green.
       # `|| rc=$?` is load-bearing: steps run under `bash -e`, so without it the
       # expected exit-1 would abort the step before the check below runs.
+      # backend/requirements.txt is a generated export of uv.lock, not a source of
+      # truth — nothing installs from it (deploy and CI both run `uv sync`, and the
+      # pip-audit step below re-exports rather than reading the committed file).
+      # That made drift invisible, and Dependabot's uv ecosystem edits this file
+      # for TRANSITIVE deps, so #416-#421 and #430-#434 changed no installed
+      # version at all. Worse than churn: a bump that patches a real advisory
+      # would look applied while the vulnerable version stayed in uv.lock.
+      #
+      # Comparing the committed file against a fresh export turns both failure
+      # modes loud — a hand-edited export, and a requirements.txt-only Dependabot
+      # PR, now fail here instead of merging as a silent no-op. Regenerate with
+      # the command in the file's own header.
+      # Compared with the `#    uv export ... -o <path>` header line filtered out:
+      # uv writes its own output path into that comment, so a temp-file export can
+      # never be byte-identical to one written to requirements.txt. Filtering it is
+      # what makes this check possible at all; without it the step fails always.
+      - name: requirements.txt matches uv.lock
+        working-directory: backend
+        run: |
+          uv export --all-extras --no-emit-project --no-hashes \
+            --format requirements-txt > /tmp/reqs-raw.txt
+          grep -v '^#    uv export' /tmp/reqs-raw.txt > /tmp/reqs-expected.txt
+          grep -v '^#    uv export' requirements.txt > /tmp/reqs-actual.txt
+          if ! diff -u /tmp/reqs-actual.txt /tmp/reqs-expected.txt; then
+            echo "::error::backend/requirements.txt is out of sync with uv.lock."
+            echo "It is a generated file. Regenerate it rather than editing by hand:"
+            echo "  cd backend && uv export --all-extras --no-emit-project --no-hashes --format requirements-txt -o requirements.txt"
+            echo "If a dependency bump only touched requirements.txt, apply it to pyproject.toml/uv.lock instead — editing the export alone changes nothing that is installed."
+            exit 1
+          fi
+          echo "OK: requirements.txt matches uv.lock."
+
       - name: Run pip-audit
         working-directory: backend
         run: |

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,7 +15,7 @@ blinker==1.9.0
     # via flask
 boto3==1.43.56
     # via auto-author-backend
-botocore==1.43.51
+botocore==1.43.67
     # via
     #   boto3
     #   s3transfer


### PR DESCRIPTION
Closes #439. This is the follow-up c4eb4c2 (#426) asked for and that was never filed — and which recurred four more times in the meantime.

## `backend/requirements.txt` has no consumer

Verified rather than assumed:

| Claimed consumer | Reality |
|---|---|
| `deploy-staging.yml` | runs `uv sync` (line 235) — reads `uv.lock` |
| `tests.yml` pip-audit | runs its own `uv export` (line 152) — reads `uv.lock` |
| `scripts/deploy*.sh` | **no longer exist** |
| `docs/STAGING-DEPLOYMENT.md:312,429` | documents `uv pip install -r requirements.txt` — stale docs, not a live path |

It is a generated export whose own header records the command that produces it. Nothing installs from it.

## Two silent failure modes

**1. Transitive Dependabot bumps are no-ops.** The uv ecosystem edits this file for transitive dependencies, so #416–#421 and #430–#434 changed no installed version and cleared no advisory. #426 had to apply five of them to `uv.lock` by hand afterwards.

**2. It had already drifted.** #436 (boto3 1.43.40 → 1.43.56) wrote `botocore==1.43.51` while `uv.lock` resolves **1.43.67**. One line, wrong, merged, invisible.

The churn isn't the real risk. The dangerous version is a bump that *patches a real advisory* looking applied while the vulnerable version stays in `uv.lock` — you'd close the alert and ship the vulnerability.

## What this does

- **Regenerates `requirements.txt`** from `uv.lock`, fixing the botocore drift (1 line).
- **Adds a `Security Audit` step** diffing the committed file against a fresh export. A `requirements.txt`-only Dependabot PR now **fails CI** instead of merging as a no-op, and the error message points at the real fix — apply the bump to `pyproject.toml`/`uv.lock`.

`Security Audit` became a required check in #444, so this genuinely blocks.

## A bug I hit while building the check

The first version compared against `uv export -o /tmp/reqs-expected.txt` — which **fails permanently**, because uv writes its own output path into the header comment:

```
-#    uv export ... -o requirements.txt
+#    uv export ... -o /tmp/reqs-expected.txt
```

So the check filters that header line. Worth flagging because it made my first verification run look like it "correctly caught the drift" when it was really just catching its own temp path. Caught while verifying rather than in review — and it's the reason the step redirects stdout instead of using `-o`.

## Verification

| Scenario | Result |
|---|---|
| Current tree (post-regeneration) | **PASS** |
| #436's `botocore==1.43.51` drift reintroduced | **FAIL** — correctly blocks |
| Restored | **PASS** |

`tests.yml` parses; the step is ordered before `Run pip-audit`.

## Note on the issue's option (a)

#439 offered deleting the file as an alternative. I didn't take it: `docs/STAGING-DEPLOYMENT.md` still references it and I can't rule out external tooling reading it. Enforcing sync solves the actual failure mode without needing that judgement, and the issue itself said option (b) is "worth doing regardless". Deleting remains available later if the docs are updated and nothing turns out to depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
