### PR TITLE
feat(docker): add container build foundation for the deploy migration (part 1 of #427)

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,14 @@
+.venv
+__pycache__
+**/__pycache__
+*.pyc
+.pytest_cache
+htmlcov
+.coverage
+coverage.xml
+tests
+.env*
+!.env.example
+.git
+Dockerfile
+.dockerignore

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1
+#
+# FastAPI backend image (#427).
+#
+# Multi-stage: build the virtualenv with uv, then copy just the venv and app into
+# a clean runtime layer. uv is not present at runtime.
+#
+# pyproject.toml requires >=3.13.
+
+ARG PYTHON_VERSION=3.13-slim
+
+# ---- build: resolve from uv.lock only
+FROM python:${PYTHON_VERSION} AS build
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+WORKDIR /app
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PROJECT_ENVIRONMENT=/app/.venv
+
+# Dependencies first, without the project, so this layer survives app-code edits.
+COPY pyproject.toml uv.lock ./
+# --frozen fails rather than silently re-resolving if uv.lock is stale, which is
+# the same guarantee the requirements.txt drift check gives in CI (#439).
+# No --extra test: the test extra exists to keep production installs lean.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project --no-dev
+
+COPY . .
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev
+
+# ---- runtime
+FROM python:${PYTHON_VERSION} AS runtime
+WORKDIR /app
+
+# Non-root. python:slim has no unprivileged user of its own, so create one.
+RUN useradd --create-home --uid 1000 appuser
+
+COPY --from=build --chown=appuser:appuser /app/.venv /app/.venv
+COPY --from=build --chown=appuser:appuser /app/app /app/app
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+USER appuser
+EXPOSE 8000
+
+# app.main:app — note backend/main.py is an unrelated stub (`print("Hello from
+# backend!")`), not the server entrypoint.
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,19 @@
+# Build overlay (#427). Used by CI and for local image builds:
+#   docker compose -f docker-compose.yml -f docker-compose.build.yml build
+#
+# Kept separate from the base file so a deploy on the VPS has no build definition
+# to fall back on if an image pull fails — it errors instead of quietly compiling
+# on the box, which is the behaviour this migration exists to remove.
+services:
+  backend:
+    build:
+      context: ./backend
+  frontend:
+    build:
+      context: ./frontend
+      args:
+        # NEXT_PUBLIC_* is inlined into the client bundle at build time, so these
+        # are build args rather than runtime env. Changing one needs a rebuild,
+        # not a restart.
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-https://api.dev.autoauthor.app/api/v1}
+        NEXT_PUBLIC_BETTER_AUTH_URL: ${NEXT_PUBLIC_BETTER_AUTH_URL:-https://dev.autoauthor.app}

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,13 @@
+# Staging overlay (#427). Used as:
+#   docker compose -f docker-compose.yml -f docker-compose.staging.yml up -d
+#
+# Pins both images to an immutable SHA tag. That is the rollback mechanism:
+# re-run with the previous SHA rather than hoping an old release directory's
+# node_modules still match, which is what the PM2/symlink deploy required.
+#
+# No `build:` reset is needed because the base file carries none.
+services:
+  backend:
+    image: ghcr.io/frankbria/auto-author-backend:${IMAGE_TAG:?IMAGE_TAG is required (e.g. sha-abc1234)}
+  frontend:
+    image: ghcr.io/frankbria/auto-author-frontend:${IMAGE_TAG:?IMAGE_TAG is required (e.g. sha-abc1234)}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,57 @@
+# Container deploy for auto-author (#427).
+#
+# Base definitions. The staging box uses this together with
+# docker-compose.staging.yml, which pins image tags and points at the host's env
+# file. There is no Mongo service: Mongo is Atlas, and adding a local one here
+# would quietly give a deploy a second, empty database to talk to.
+#
+# There is deliberately no `build:` here — see docker-compose.build.yml. Keeping
+# build definitions out of the base file means a deploy on the box physically
+# cannot rebuild an image, which is the point of the migration: no npm ci or
+# uv sync on the shared VPS.
+#
+# Ports match what nginx already fronts (backend 8000, frontend 3002) so no
+# upstream config changes. The box is shared with other apps — check the ports
+# are still free before the first deploy.
+
+services:
+  backend:
+    image: ${BACKEND_IMAGE:-ghcr.io/frankbria/auto-author-backend:staging}
+    restart: unless-stopped
+    # Bound to loopback: nginx proxies from the same host, so there is no reason
+    # to publish these on the shared box's public interface.
+    ports:
+      - "127.0.0.1:8000:8000"
+    environment:
+      # Secrets come from the host env file, never baked into the image.
+      MONGODB_URI: ${MONGODB_URI:?MONGODB_URI is required}
+      DATABASE_NAME: ${DATABASE_NAME:?DATABASE_NAME is required}
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET is required}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:?OPENAI_API_KEY is required}
+      ENVIRONMENT: ${ENVIRONMENT:-staging}
+      CORS_ORIGINS: ${CORS_ORIGINS:-}
+      SENTRY_DSN: ${SENTRY_DSN:-}
+    healthcheck:
+      # The same /health endpoint the existing deploy smoke-checks (#341 made it
+      # do real dependency checks rather than returning a static ok).
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/api/v1/health', timeout=5).status==200 else 1)\""]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 40s
+
+  frontend:
+    image: ${FRONTEND_IMAGE:-ghcr.io/frankbria/auto-author-frontend:staging}
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:3002:3002"
+    environment:
+      # Server-side only. The frontend talks to Mongo directly for better-auth.
+      DATABASE_URL: ${MONGODB_URI:?MONGODB_URI is required}
+      DATABASE_NAME: ${DATABASE_NAME:?DATABASE_NAME is required}
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET is required}
+      BETTER_AUTH_URL: ${BETTER_AUTH_URL:-https://dev.autoauthor.app}
+      NODE_ENV: production
+    depends_on:
+      backend:
+        condition: service_healthy

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+.next
+coverage
+playwright-report
+test-results
+.env*
+!.env.example
+**/__tests__
+**/*.test.ts
+**/*.test.tsx
+tests
+src/e2e
+.git
+Dockerfile
+.dockerignore

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,58 @@
+# syntax=docker/dockerfile:1
+#
+# Next.js frontend image (#427).
+#
+# Multi-stage: deps -> build -> runtime. The runtime stage carries only the
+# standalone server bundle, so it does not need npm or the full node_modules.
+#
+# Requires `output: "standalone"` in next.config.ts, which also pins
+# outputFileTracingRoot to the frontend directory. Without that pin Next roots the
+# trace at the nearest lockfile ancestor — the repo root has its own package.json
+# (a PM2 shell), so it walked up to the home directory and emitted the entrypoint
+# at .next/standalone/projects/auto-author/frontend/server.js instead of
+# .next/standalone/server.js. The COPY paths below assume the pinned layout.
+
+ARG NODE_VERSION=24-alpine
+
+# ---- deps: install with the lockfile only, so this layer caches on lock changes
+FROM node:${NODE_VERSION} AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# ---- build
+FROM node:${NODE_VERSION} AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+# Next inlines NEXT_PUBLIC_* into the client bundle at build time, so anything the
+# browser needs must be present here rather than only at runtime.
+ARG NEXT_PUBLIC_API_URL
+ARG NEXT_PUBLIC_BETTER_AUTH_URL
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL} \
+    NEXT_PUBLIC_BETTER_AUTH_URL=${NEXT_PUBLIC_BETTER_AUTH_URL} \
+    NEXT_TELEMETRY_DISABLED=1
+RUN npm run build
+
+# ---- runtime
+FROM node:${NODE_VERSION} AS runtime
+WORKDIR /app
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3002 \
+    HOSTNAME=0.0.0.0
+
+# Non-root. node:alpine already ships a `node` user (uid 1000); reuse it rather
+# than creating another.
+USER node
+
+# The standalone bundle excludes static assets and public/ by design — they are
+# served from disk, so they must be copied alongside it or every asset 404s.
+COPY --from=build --chown=node:node /app/.next/standalone ./
+COPY --from=build --chown=node:node /app/.next/static ./.next/static
+COPY --from=build --chown=node:node /app/public ./public
+
+EXPOSE 3002
+
+# Published on the host port nginx already fronts (3002), so upstreams are unchanged.
+CMD ["node", "server.js"]

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,19 @@
 import type { NextConfig } from "next";
+import path from "node:path";
 
 const nextConfig: NextConfig = {
+  // Emit a self-contained server bundle at .next/standalone for container images
+  // (#427). This is additive: `next build` still produces the normal .next output,
+  // so `next start` — which the current PM2 deploy uses — keeps working unchanged.
+  output: "standalone",
+  // Pin the trace root to this directory. The repo root carries its own
+  // package.json (a PM2 shell), so Next walked further up and rooted the trace at
+  // the home directory — emitting the server at
+  // .next/standalone/projects/auto-author/frontend/server.js and sweeping ~/.nvm
+  // into a 197 MB bundle. Pinning it puts the entrypoint at the documented
+  // .next/standalone/server.js, which is what the Dockerfile COPYs.
+  outputFileTracingRoot: path.join(__dirname),
+
   // Enable SWC minification and optimization
   // swcMinify: true,
 


### PR DESCRIPTION
Part 1 of #427 — the **additive** half. Refs #427; deliberately does not close it.

Nothing here touches `deploy-staging.yml`, PM2, or nginx. The current deploy path is unchanged and keeps working, matching the issue's own sequencing: *"Keep the old PM2 path runnable until the container deploy is proven; cutover, then delete."*

| Scope item | Status |
|---|---|
| 1. `backend/Dockerfile` | done |
| 2. `frontend/Dockerfile` | done |
| 3. `docker-compose.yml` + staging override | done (+ a build overlay) |
| 4. `.dockerignore` both apps | done |
| 5. Rewrite `deploy-staging.yml` | **not here** — needs the VPS |
| 6. Port `deploy-production.yml.disabled` | **not here** |
| 7. Docs + mark PM2 historical | **not here** |

## Two findings that would have produced a broken image

Both were caught by building and running rather than by writing Dockerfiles from the docs.

**1. `output: "standalone"` alone was not enough.** The repo root carries its own `package.json` (the PM2 shell), so Next walked past it and rooted the file trace at the **home directory** — emitting the entrypoint at

```
.next/standalone/projects/auto-author/frontend/server.js
```

instead of `.next/standalone/server.js`, and sweeping `~/.nvm` into a **197 MB** bundle. A Dockerfile written against the documented path would have `COPY`d a tree with no server in it. Pinning `outputFileTracingRoot` to the frontend directory fixes the path and drops the bundle to **104 MB**.

**2. The standalone bundle excludes `.next/static` and `public/` by design.** Both are copied explicitly. Without that, pages render but every asset 404s — a failure that looks like a CDN problem, not a build problem.

## The open risk from my issue assessment is now settled

I flagged that adding `output: "standalone"` could break the current PM2 deploy, since it runs `next start`. That's resolved by test, not argument:

- `next start` with standalone enabled → **HTTP 200** (the PM2 path, unchanged)
- standalone `node server.js` → **HTTP 200** (the container path)

## Verified end to end

| Check | Result |
|---|---|
| Both images build | clean |
| Frontend container | **HTTP 200**, runs as `node`, 268 MB |
| Backend container vs real `mongo:7` | `/api/v1/health` → **200** `{"status":"healthy","checks":{"mongodb":"ok","config":"ok"}}`, runs as `appuser`, 252 MB |
| `docker compose config` | valid for base, base+build, and base+staging |
| Staging overlay | resolves `ghcr.io/frankbria/auto-author-{backend,frontend}:sha-abc1234` |

Both containers run **non-root**, and no secrets are baked into either image — everything comes from the host env file, as today.

## A design note

`build:` lives in its own `docker-compose.build.yml` rather than the base file. That means a deploy on the box has no build definition to fall back on if an image pull fails — it errors instead of quietly compiling on the shared VPS, which is precisely the behaviour this migration exists to remove. It also sidesteps Compose's `!reset` tag, which the repo's `check-yaml` hook cannot parse.

## What still needs you (part 2)

The remaining ACs can only be satisfied against the real box: deploying to dev.autoauthor.app, confirming `/health`, checking port and Docker-daemon state on a VPS shared with other apps, proving rollback once, and running staging E2E against the containerized deploy. Happy to drive that with you when you're ready.

## Incidental finding

The backend reads `MONGODB_URI` (`config.py:46`, preferred over `DATABASE_URL`), but `tests.yml:107` passes **`MONGODB_URL`** — which nothing reads. Backend tests in CI have been running on the `DATABASE_URL` default. Harmless today, since that default is `mongodb://localhost:27017` and CI's mongo service listens there, but the env var is doing nothing. Left alone to keep this diff additive; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
