### PR TITLE
ci(docker): build and publish container images to GHCR (#427 AC 1)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,137 @@
+name: Build Images
+
+# Builds and publishes the backend and frontend container images (#427, AC 1).
+#
+# This does NOT deploy. It only produces immutable artifacts, so it can land and
+# be exercised while the PM2 deploy keeps running untouched — matching the
+# issue's sequencing: keep the old path runnable until the container deploy is
+# proven, then cut over.
+#
+# Once the cutover happens, the deploy step becomes `docker compose pull && up -d`
+# against the sha-<short> tag this workflow already publishes, and rollback is the
+# same command pinned to an earlier SHA.
+
+on:
+  push:
+    branches: [main]
+    # Only rebuild when something that lands in an image changes. Docs- or
+    # test-only pushes don't produce a different artifact.
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'docker-compose*.yml'
+      - '.github/workflows/build-images.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'docker-compose*.yml'
+      - '.github/workflows/build-images.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    name: Build ${{ matrix.app }} image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - app: backend
+            context: ./backend
+          - app: frontend
+            context: ./frontend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Pull requests from forks get a read-only token, and pushing an image from
+      # an unreviewed PR would be a supply-chain hole regardless. Build to verify
+      # the Dockerfile still works, publish only from main.
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/auto-author-${{ matrix.app }}
+          tags: |
+            type=sha,format=short,prefix=sha-
+            type=raw,value=staging,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.app }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.app }}
+          # NEXT_PUBLIC_* is inlined into the client bundle at build time, so the
+          # frontend image is environment-specific and these must be present here
+          # rather than injected at run time. Harmless no-ops for the backend.
+          build-args: |
+            NEXT_PUBLIC_API_URL=${{ vars.NEXT_PUBLIC_API_URL || 'https://api.dev.autoauthor.app/api/v1' }}
+            NEXT_PUBLIC_BETTER_AUTH_URL=${{ vars.NEXT_PUBLIC_BETTER_AUTH_URL || 'https://dev.autoauthor.app' }}
+
+      # A built image that cannot start is worse than a failed build: it publishes
+      # a tag the deploy would happily pull. Boot each image before it is trusted.
+      - name: Smoke test the built image
+        if: github.event_name != 'pull_request'
+        run: |
+          TAG=$(echo '${{ steps.meta.outputs.tags }}' | head -n1)
+          echo "Booting $TAG"
+          if [ "${{ matrix.app }}" = "backend" ]; then
+            docker network create smoke-net
+            docker run -d --name smoke-mongo --network smoke-net mongo:7
+            docker run -d --name smoke --network smoke-net -p 8000:8000 \
+              -e MONGODB_URI=mongodb://smoke-mongo:27017 \
+              -e DATABASE_NAME=smoke \
+              -e BETTER_AUTH_SECRET=test-secret-for-ci-minimum-32-characters-long-safe-for-testing \
+              -e OPENAI_API_KEY=sk-smoke-test \
+              "$TAG"
+            URL=http://localhost:8000/api/v1/health
+          else
+            docker run -d --name smoke -p 3002:3002 \
+              -e DATABASE_URL=mongodb://127.0.0.1:27017/smoke \
+              -e DATABASE_NAME=smoke \
+              -e BETTER_AUTH_SECRET=test-secret-for-ci-minimum-32-characters-long-safe-for-testing \
+              "$TAG"
+            # The frontend only reaches Mongo on an auth request; the root route
+            # renders without it, which is enough to prove the image boots.
+            URL=http://localhost:3002/
+          fi
+          for i in $(seq 1 30); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "$URL" || true)
+            [ "$code" = "200" ] && echo "OK: $URL -> 200" && exit 0
+            sleep 4
+          done
+          echo "::error::${{ matrix.app }} image failed to serve $URL"
+          docker logs smoke 2>&1 | tail -40
+          exit 1
+
+      - name: Report published tags
+        if: github.event_name != 'pull_request'
+        run: |
+          { echo "## ${{ matrix.app }} image"; echo '```'; echo '${{ steps.meta.outputs.tags }}'; echo '```'; } >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Part 2 of #427's non-cutover work. Satisfies **AC 1** — *"Both images build in CI and push to GHCR tagged `sha-<short>` + `staging`"* — with no VPS access required. Refs #427; does not close it.

## Still not a deploy

This only produces immutable artifacts. The PM2 deploy keeps running untouched, per the issue's sequencing. What it sets up:

- **AC 3 (rollback)** becomes mechanical once cutover happens — `docker compose -f docker-compose.yml -f docker-compose.staging.yml up -d` with `IMAGE_TAG=sha-<previous>`, against tags this workflow already publishes.
- **AC 4 (no `npm ci`/`uv sync` on the VPS)** is satisfied by construction: the box pulls a built image.

## Design notes

- **PRs build but do not push.** Fork PRs get a read-only token, and publishing an image from unreviewed code is a supply-chain hole. The build still runs, so a broken Dockerfile fails the PR.
- **Each image is booted before it's trusted.** A built-but-unstartable image is worse than a failed build — it publishes a tag a deploy would happily pull. Backend is verified against a real `mongo:7` on a shared network via `/api/v1/health`; frontend on its root route, which renders without Mongo. This mirrors exactly what I ran locally in #459.
- **`NEXT_PUBLIC_*` are build args, not runtime env.** Next inlines them into the client bundle, so the frontend image is environment-specific by construction. Defaults target staging; override with repo variables.
- **Path filters** keep docs- and test-only pushes from rebuilding byte-identical artifacts.

## Remaining on #427 — all genuinely need the box

| AC | Blocker |
|---|---|
| 2. Push to main deploys to dev.autoauthor.app | live deploy |
| 3. Rollback tried once | live deploy |
| 6. nginx keeps working unchanged | live nginx config |
| 7. Staging E2E against the containerized deploy | live deploy |
| 8. PM2 removed after two green runs | live deploy |

Plus the issue's own warning — *"Shared box — check for port conflicts and any existing Docker daemon/containers"* — which is a check against a machine running other people's apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)