### PR TITLE
fix(security): upgrade starlette to 1.x, clearing six advisories

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -221,7 +221,7 @@ six==1.17.0
     #   python-dateutil
 sniffio==1.3.1
     # via openai
-starlette==0.47.2
+starlette==1.6.0
     # via fastapi
 stripe==15.3.0
     # via auto-author-backend

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1416,14 +1416,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.47.2"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/57/d062573f391d062710d4088fa1369428c38d51460ab6fedff920efef932e/starlette-0.47.2.tar.gz", hash = "sha256:6ae9aa5db235e4846decc1e7b79c4f346adf41e9777aebeb49dfd09bbd7023d8", size = 2583948, upload-time = "2025-07-20T17:31:58.522Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/1f/b876b1f83aef204198a42dc101613fefccb32258e5428b5f9259677864b4/starlette-0.47.2-py3-none-any.whl", hash = "sha256:c5847e96134e5c5371ee9fac6fdf1a67336d5815e09eb2a01fdb57a351ef915b", size = 72984, upload-time = "2025-07-20T17:31:56.738Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
 ]
 
 [[package]]

--- a/security-baseline.json
+++ b/security-baseline.json
@@ -1,14 +1,8 @@
 {
   "_comment": "Known-and-accepted advisories as of #342. CI fails on anything NOT listed here, so this file is the repo's dependency-debt ledger, not an ignore-list to grow casually. Shrink it: each entry names its package and fix version. Regenerate wholesale with: python scripts/audit_gate.py --pip-audit <json> --npm-audit <json> --baseline security-baseline.json --write-baseline",
   "pypi": {
-    "PYSEC-2026-161": "starlette; fix: 1.0.1",
-    "PYSEC-2026-1942": "starlette; fix: 0.49.1",
     "PYSEC-2026-2132": "click; fix: 8.3.3",
-    "PYSEC-2026-2270": "python-dotenv; fix: 1.2.2",
-    "PYSEC-2026-2280": "starlette; fix: 1.1.0",
-    "PYSEC-2026-2281": "starlette; fix: 1.1.0",
-    "PYSEC-2026-248": "starlette; fix: 1.3.0",
-    "PYSEC-2026-249": "starlette; fix: 1.3.1"
+    "PYSEC-2026-2270": "python-dotenv; fix: 1.2.2"
   },
   "npm": {
     "GHSA-23c5-xmqv-rm74": "minimatch; fix: yes",


### PR DESCRIPTION
Supersedes #472 — the third batch today of the requirements.txt-only no-op pattern, correctly failing the drift check from #450.

Applied to `uv.lock` instead, where it takes effect. uv resolves to **1.6.0** (latest satisfying), not the 1.3.1 the PR named.

## A bigger security win than the PR advertised

#472 surfaced no advisory IDs in its body. It clears **six** baselined starlette advisories:

| Advisory | Fixed in | | Advisory | Fixed in |
|---|---|---|---|---|
| PYSEC-2026-161 | 1.0.1 | | PYSEC-2026-2280 | 1.1.0 |
| PYSEC-2026-1942 | 0.49.1 | | PYSEC-2026-2281 | 1.1.0 |
| PYSEC-2026-248 | 1.3.0 | | PYSEC-2026-249 | 1.3.1 |

**The pypi baseline is now 2 entries, down from 34 at the start of today.**

## Verified, not assumed

A major on FastAPI's core dependency deserves more than a peer-range check. `fastapi 0.139.0` declares only `starlette>=0.46.0` — no upper bound — so it *resolves*, but resolving isn't compatibility.

Ran the suite: **1231 passed, 9 skipped** — unchanged from before the upgrade.

## Known follow-up

starlette 1.x deprecates `HTTP_422_UNPROCESSABLE_ENTITY` in favour of `HTTP_422_UNPROCESSABLE_CONTENT`, taking the backend from 14 warnings to 73. Nothing breaks — the old name still works — but it needs a sweep before starlette removes it. Not done here to keep this diff to the upgrade.

## Verification

- Backend suite: **1231 passed**, 9 skipped
- Audit gate: **PASS**, exit 0, no stale list
- `scripts/test_audit_gate.py`: 29 passed
- `requirements.txt` regenerated, so the drift check stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
