### PR TITLE
feat(deploy): author the container deploy workflow (disabled) and document cutover

### DIFF
--- a/.github/workflows/deploy-staging-containers.yml.disabled
+++ b/.github/workflows/deploy-staging-containers.yml.disabled
@@ -1,0 +1,133 @@
+name: Deploy Staging (Containers)
+
+# Container deploy for staging (#427, items 5-6). DISABLED until the first
+# cutover is done with a human present — see the checklist in
+# docs/STAGING-DEPLOYMENT.md. Enable by renaming to
+# deploy-staging-containers.yml and disabling the PM2 workflow
+# (deploy-staging.yml -> .disabled), not before.
+#
+# The .disabled suffix follows this repo's existing convention
+# (deploy-production.yml.disabled). GitHub only loads .yml/.yaml, so this file
+# is inert as-is.
+#
+# What changes vs the PM2 deploy it replaces:
+#   - no npm ci / uv sync on the VPS; images are built in CI (build-images.yml)
+#     and pulled by tag
+#   - no releases/<id> symlink dance; the image tag IS the release identifier
+#   - rollback is this same workflow re-run with an older IMAGE_TAG, rather than
+#     hoping a previous release directory's node_modules still match
+#
+# Prerequisites on the box, all one-time and all human-verified before first run:
+#   1. Docker + compose plugin installed, daemon running
+#   2. /opt/auto-author/ containing docker-compose.yml, docker-compose.staging.yml
+#      and a .env file with the secrets listed in docker-compose.yml
+#   3. Ports 8000 and 3002 free — this is a SHARED box, check before assuming
+#   4. `docker login ghcr.io` (or a pull secret) if the packages are private
+#   5. nginx upstreams already point at 127.0.0.1:8000 / :3002 — unchanged from
+#      the PM2 setup, which is why those ports were kept
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Image tag to deploy (e.g. sha-3931169). Use an older tag to roll back.'
+        required: true
+        type: string
+
+# Least privilege: this only reads the repo and pulls published images.
+permissions:
+  contents: read
+
+concurrency:
+  # Never let two deploys race on one box.
+  group: deploy-staging
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy containers to staging
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: staging
+      url: https://dev.autoauthor.app
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_KEY }}" > ~/.ssh/staging_key
+          chmod 600 ~/.ssh/staging_key
+          # No `nc` preflight or ssh-keyscan: those open connections that close
+          # before authenticating, which the box's fail2ban (aggressive,
+          # maxretry=4) counts as attacks and bans the runner for (#162). The
+          # steps below authenticate on first contact via accept-new.
+
+      - name: Ship compose files
+        run: |
+          # Retry with a cool-down: first SSH contact opens several short-lived
+          # preauth connections during host-key discovery, which on this shared
+          # box intermittently gets the follow-up dropped (#162 again).
+          for attempt in 1 2 3; do
+            if scp -i ~/.ssh/staging_key \
+                 -o StrictHostKeyChecking=accept-new -o ConnectTimeout=30 \
+                 docker-compose.yml docker-compose.staging.yml \
+                 ${{ secrets.USER }}@${{ secrets.HOST }}:/opt/auto-author/; then
+              exit 0
+            fi
+            echo "Upload attempt $attempt failed; retrying in 60s..."
+            sleep 60
+          done
+          echo "::error::Failed to ship compose files after 3 attempts"
+          exit 1
+
+      - name: Pull and start
+        run: |
+          ssh -i ~/.ssh/staging_key -o StrictHostKeyChecking=accept-new -o ConnectTimeout=30 \
+            ${{ secrets.USER }}@${{ secrets.HOST }} \
+            "set -euo pipefail
+             cd /opt/auto-author
+             export IMAGE_TAG='${{ inputs.image_tag }}'
+             # --pull always so a re-run of the same tag still fetches a rebuilt
+             # image; compose would otherwise reuse a stale local layer.
+             docker compose -f docker-compose.yml -f docker-compose.staging.yml pull
+             docker compose -f docker-compose.yml -f docker-compose.staging.yml up -d --remove-orphans"
+
+      - name: Health check
+        run: |
+          ssh -i ~/.ssh/staging_key -o StrictHostKeyChecking=accept-new -o ConnectTimeout=30 \
+            ${{ secrets.USER }}@${{ secrets.HOST }} \
+            "set -euo pipefail
+             for i in \$(seq 1 30); do
+               be=\$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://127.0.0.1:8000/api/v1/health || true)
+               fe=\$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://127.0.0.1:3002/ || true)
+               if [ \"\$be\" = '200' ] && [ \"\$fe\" = '200' ]; then
+                 echo 'Both services healthy'; exit 0
+               fi
+               sleep 5
+             done
+             echo 'Health check failed; recent logs:'
+             cd /opt/auto-author
+             docker compose -f docker-compose.yml -f docker-compose.staging.yml logs --tail=60
+             exit 1"
+
+      # Deliberately last and deliberately conservative: pruning before the
+      # health check would delete the image a rollback needs.
+      - name: Prune old images
+        if: success()
+        run: |
+          ssh -i ~/.ssh/staging_key -o StrictHostKeyChecking=accept-new -o ConnectTimeout=30 \
+            ${{ secrets.USER }}@${{ secrets.HOST }} \
+            "docker image prune -f --filter 'until=336h'"
+
+      - name: Summary
+        if: always()
+        run: |
+          { echo '## Staging container deploy';
+            echo "- tag: \`${{ inputs.image_tag }}\`";
+            echo "- result: ${{ job.status }}";
+            echo '- rollback: re-run this workflow with an earlier `sha-` tag';
+          } >> $GITHUB_STEP_SUMMARY

--- a/docs/STAGING-DEPLOYMENT.md
+++ b/docs/STAGING-DEPLOYMENT.md
@@ -1,5 +1,14 @@
 # Staging Server Deployment Guide
 
+> **Status note (#427):** the container deploy is being introduced alongside the
+> PM2 path documented below. Images are already built and published on every
+> push to `main` (`.github/workflows/build-images.yml`), and the deploy workflow
+> is written but **disabled** pending a first supervised cutover. See
+> [Container deploy (#427)](#container-deploy-427) at the end of this document.
+>
+> Until that cutover happens the PM2 instructions below are still the live path
+> and remain correct. Do not follow both.
+
 **Last Updated**: 2025-10-19
 **Target Server**: frankbria-inspiron-7586
 **Purpose**: Stable sprint demo and integration testing environment
@@ -680,3 +689,103 @@ For deployment issues:
 **Maintained By**: Development Team
 **Review Frequency**: Before each major release
 **Last Review**: 2025-10-19
+
+
+---
+
+## Container deploy (#427)
+
+The PM2/rsync path above builds on the VPS: `npm ci` and `uv sync` run on a box
+shared with other applications, a `releases/<id>` directory is symlinked to
+`current`, and PM2 is stopped and restarted. That makes deploys depend on the
+box's toolchain versions and disk, and makes rollback a matter of hoping an old
+release directory's `node_modules` still match.
+
+The container path replaces that with immutable images.
+
+### What already exists
+
+| Piece | Where | State |
+|---|---|---|
+| Backend image | `backend/Dockerfile` | multi-stage, non-root `appuser`, uvicorn on 8000 |
+| Frontend image | `frontend/Dockerfile` | multi-stage Next standalone, non-root `node`, 3002 |
+| Compose base | `docker-compose.yml` | both services on 127.0.0.1:8000 / :3002 — the ports nginx already fronts |
+| Build overlay | `docker-compose.build.yml` | build contexts, used by CI and locally |
+| Staging overlay | `docker-compose.staging.yml` | pins both images to `${IMAGE_TAG}` |
+| Image publishing | `.github/workflows/build-images.yml` | **live** — publishes `sha-<short>` and `staging` on every push to `main` |
+| Deploy workflow | `.github/workflows/deploy-staging-containers.yml.disabled` | **written, disabled** |
+
+`build:` deliberately lives in its own overlay rather than the base file, so a
+deploy that cannot pull an image **errors** instead of quietly compiling on the
+shared box — which is the behaviour this migration exists to remove.
+
+### One-time setup on the box, before the first deploy
+
+This is a **shared machine**. Every step is a check, not an assumption.
+
+1. **Ports.** Confirm 8000 and 3002 are free, or that only this app holds them:
+   `sudo ss -ltnp | grep -E ':(8000|3002)'`
+2. **Docker.** Confirm the daemon is installed and running, and note any
+   containers already there that belong to other applications:
+   `docker ps -a`
+3. **Directory.** `mkdir -p /opt/auto-author` and place `docker-compose.yml`,
+   `docker-compose.staging.yml`, and a `.env` carrying the variables listed in
+   `docker-compose.yml` (`MONGODB_URI`, `DATABASE_NAME`, `BETTER_AUTH_SECRET`,
+   `OPENAI_API_KEY`, …). Secrets live only in that file — never in an image.
+4. **Registry access.** If the GHCR packages are private,
+   `docker login ghcr.io` with a token that has `read:packages`.
+5. **nginx.** Confirm the upstreams still point at `127.0.0.1:8000` and
+   `127.0.0.1:3002`. They should need no change — that is why those ports were
+   kept.
+
+### First cutover
+
+Do this with a person watching, not from an automatic trigger.
+
+1. Pick a tag published by `build-images.yml`, e.g. `sha-3931169`.
+2. Stop the PM2 processes for this app only:
+   `pm2 stop auto-author-backend auto-author-frontend`
+   (`pm2 list` first — other applications may be under the same PM2.)
+3. Bring the containers up:
+   ```bash
+   cd /opt/auto-author
+   IMAGE_TAG=sha-3931169 docker compose \
+     -f docker-compose.yml -f docker-compose.staging.yml up -d
+   ```
+4. Verify locally, then through nginx:
+   ```bash
+   curl -s http://127.0.0.1:8000/api/v1/health   # {"status":"healthy",...}
+   curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3002/
+   curl -s -o /dev/null -w '%{http_code}\n' https://dev.autoauthor.app/
+   ```
+5. Run the staging E2E suite (`npm run test:e2e:staging`) — it uses real auth,
+   so it is the check that actually exercises the deployed stack.
+6. If anything is wrong, roll back immediately: `docker compose … down` and
+   `pm2 start auto-author-backend auto-author-frontend`. The PM2 release
+   directory is untouched by any of the above.
+
+### Rollback
+
+Re-run the deploy with an earlier tag. That is the whole procedure:
+
+```bash
+cd /opt/auto-author
+IMAGE_TAG=sha-<previous> docker compose \
+  -f docker-compose.yml -f docker-compose.staging.yml up -d
+```
+
+The image-prune step in the deploy workflow keeps 14 days of images and runs
+only after a successful health check, so the previous tag is still present when
+you need it.
+
+### Enabling the automated deploy
+
+Only after the manual cutover has been done and verified **twice**:
+
+1. Rename `deploy-staging-containers.yml.disabled` →
+   `deploy-staging-containers.yml`
+2. Rename `deploy-staging.yml` → `deploy-staging.yml.disabled`
+3. Trigger it via workflow dispatch with an explicit `image_tag` before wiring
+   any automatic trigger
+
+Only then remove the PM2 ecosystem template and the PM2 steps (#427 AC 8).


### PR DESCRIPTION
#427 items 5–7, taken as far as they go without the box. **Refs #427; deliberately does not close it** — ACs 2, 3, 7 and 8 all require a real deploy to the shared VPS.

## The deploy workflow, written but inert

`.github/workflows/deploy-staging-containers.yml.disabled` follows this repo's existing convention (`deploy-production.yml.disabled`). GitHub only loads `.yml`/`.yaml`, so it cannot fire by accident.

The point is that the cutover becomes *"rename two files and dispatch"* with a person present, rather than authoring a deploy under time pressure at cutover time.

Design choices worth calling out:

| Choice | Why |
|---|---|
| `workflow_dispatch` with explicit `image_tag`, no auto trigger | The first container deploy should be deliberate. It also makes **rollback the same workflow with an older tag** — that's AC 3. |
| `concurrency: deploy-staging`, `cancel-in-progress: false` | Two deploys racing on one box is the failure this prevents; cancelling mid-deploy is worse than queueing. |
| SSH setup copied verbatim from `deploy-staging.yml`, comments included | Not styling. The box runs fail2ban in aggressive mode, and a `keyscan`/`nc` preflight burst **bans the runner** (#162). The retry-with-cooldown on first contact exists for the same reason. |
| Health check polls both services, dumps compose logs on failure | A deploy that silently half-starts is the thing worth catching. |
| Image prune last, only on success, 14-day window | Pruning before the health check would delete the image a rollback needs. |

## Docs

`docs/STAGING-DEPLOYMENT.md` gains a status banner and a **Container deploy (#427)** section covering:

- what already exists and what is still disabled
- **one-time setup on the box, framed as checks rather than assumptions** — free ports, existing containers belonging to other apps, registry access, nginx upstreams. It's a shared machine.
- the supervised first cutover, with the PM2 path left untouched throughout so fallback is one command
- the rollback procedure
- the exact conditions for enabling automation: only after two verified manual cutovers

The existing PM2 instructions are left correct and explicitly marked as still-live, because they are.

## Where #427 now stands

| AC | Status |
|---|---|
| 1. Images build in CI → GHCR | **done** (#460, verified publishing `sha-3931169`) |
| 4. No `npm ci`/`uv sync` on the VPS | **done by construction** |
| 5. Non-root, no baked secrets | **done** (#459) |
| 6. nginx unchanged | **designed for**; confirm on the box |
| 2. Push deploys to dev.autoauthor.app | needs the box |
| 3. Rollback tried once | mechanism ready; needs the box |
| 7. Staging E2E against containers | needs the box |
| 8. PM2 removed after two green runs | needs the box |

Everything authorable is now authored. What remains is the supervised cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
