### PR TITLE
fix(security): apply flask and pygments to uv.lock

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -70,7 +70,7 @@ fastapi==0.139.0
     # via
     #   auto-author-backend
     #   sentry-sdk
-flask==3.1.1
+flask==3.1.3
     # via
     #   flask-cors
     #   flask-login
@@ -159,7 +159,7 @@ pydantic-core==2.46.4
     # via pydantic
 pydantic-settings==2.10.1
     # via auto-author-backend
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
 pymongo==4.13.2
     # via

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -412,7 +412,7 @@ wheels = [
 
 [[package]]
 name = "flask"
-version = "3.1.1"
+version = "3.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blinker" },
@@ -422,9 +422,9 @@ dependencies = [
     { name = "markupsafe" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/de/e47735752347f4128bcf354e0da07ef311a78244eba9e3dc1d4a5ab21a98/flask-3.1.1.tar.gz", hash = "sha256:284c7b8f2f58cb737f0cf1c30fd7eaf0ccfcde196099d24ecede3fc2005aa59e", size = 753440, upload-time = "2025-05-13T15:01:17.447Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/68/9d4508e893976286d2ead7f8f571314af6c2037af34853a30fd769c02e9d/flask-3.1.1-py3-none-any.whl", hash = "sha256:07aae2bb5eaf77993ef57e357491839f5fd9f4dc281593a81a9e4d79a24f295c", size = 103305, upload-time = "2025-05-13T15:01:15.591Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
 ]
 
 [[package]]
@@ -1113,11 +1113,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fourth batch of the requirements.txt-only pattern. Supersedes #474 (flask, **GHSA-68rp-wp8r-4726**) and #476 (pygments), both of which fail the drift check from #450 rather than merging as no-ops.

| Package | Bump | Advisory | Via |
|---|---|---|---|
| flask | 3.1.1 → 3.1.3 | **GHSA-68rp-wp8r-4726** | locust |
| pygments | 2.19.2 → 2.20.0 | none | pytest |

Both transitive, applied with `uv lock --upgrade-package`. `pip-audit` against the regenerated export confirms neither carries a remaining vuln.

**#475 (python-dotenv) is deliberately left alone** — it's a direct dependency, so Dependabot correctly updated `pyproject.toml`, `uv.lock` and the export together. It passes the drift check and can merge on its own.

Verified: backend suite **1231 passed**, 9 skipped; audit gate **PASS** exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)