### PR TITLE
fix(security): apply werkzeug 3.1.3 → 3.1.8 to uv.lock

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -254,7 +254,7 @@ uvicorn==0.49.0
     # via auto-author-backend
 websocket-client==1.8.0
     # via python-socketio
-werkzeug==3.1.3
+werkzeug==3.1.8
     # via
     #   flask
     #   flask-cors

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1514,14 +1514,14 @@ wheels = [
 
 [[package]]
 name = "werkzeug"
-version = "3.1.3"
+version = "3.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925, upload-time = "2024-11-08T15:52:18.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498, upload-time = "2024-11-08T15:52:16.132Z" },
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fifth batch of the requirements.txt-only pattern. Supersedes #479, which carries **two advisories** (GHSA-29vq-49wr-vm6x, GHSA-87hc-h4r5-73f7) and touches only the generated export — so it fails the drift check from #450 rather than merging as a no-op.

werkzeug is transitive via flask/locust, so applied with `uv lock --upgrade-package` where it takes effect.

Verified: backend suite **1231 passed**, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)