### PR TITLE
refactor(backend): use HTTP_422_UNPROCESSABLE_CONTENT

### DIFF
--- a/backend/app/api/endpoints/books.py
+++ b/backend/app/api/endpoints/books.py
@@ -2609,7 +2609,7 @@ async def generate_chapter_draft(
             # and carries the actionable message through (#352).
             if result.get("error_code") == "DRAFT_TRUNCATED":
                 raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                     detail={
                         "message": result.get("error"),
                         "error_code": "DRAFT_TRUNCATED",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -190,7 +190,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     error_details = "; ".join(errors)
     logger.error(f"Validation error: {error_details}", exc_info=True)
     return JSONResponse(
-        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
         content={
             "detail": f"Validation error",
             "errors": exc.errors(),
@@ -204,7 +204,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 async def pydantic_validation_exception_handler(request: Request, exc: ValidationError):
     logger.error(f"Pydantic validation error: {exc}", exc_info=True)
     return JSONResponse(
-        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
         content={"detail": "Validation error"},
     )
 

--- a/backend/app/utils/error_handlers.py
+++ b/backend/app/utils/error_handlers.py
@@ -145,7 +145,7 @@ def handle_validation_error(
     error_response = create_error_response(
         error_code=ErrorCode.VALIDATION_FAILED,
         message="Request validation failed",
-        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
         details=details,
         request_id=request_id
     )
@@ -153,7 +153,7 @@ def handle_validation_error(
     logger.info(f"Validation error: field={field}, value={value} [request_id={request_id}]")
 
     return HTTPException(
-        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
         detail=error_response.model_dump(mode='json')
     )
 

--- a/backend/tests/test_error_handlers.py
+++ b/backend/tests/test_error_handlers.py
@@ -136,7 +136,7 @@ class TestValidationErrorHandler:
                 value=100,
             )
 
-        assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     def test_includes_field_in_details(self):
         """Test that error response includes field name"""
@@ -260,7 +260,7 @@ class TestResponseSaveErrorHandler:
                 user_id="user-456",
             )
 
-        assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     def test_handles_generic_error(self):
         """Test handling generic errors"""
@@ -289,7 +289,7 @@ class TestRatingSaveErrorHandler:
                 rating_value=10,
             )
 
-        assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     def test_includes_rating_value(self):
         """Test that error includes the invalid rating value"""


### PR DESCRIPTION
Follow-up to the starlette 1.x upgrade (#473), where I flagged this and left it out to keep that diff to the upgrade.

starlette 1.x deprecates `HTTP_422_UNPROCESSABLE_ENTITY` in favour of `HTTP_422_UNPROCESSABLE_CONTENT`, matching the RFC 9110 rename. The old name still resolves, so nothing was broken — but it emitted a `StarletteDeprecationWarning` on every reference (**backend went 14 → 73 warnings**), and it stops working whenever starlette drops the alias.

Eight occurrences across four files: `app/main.py` (2), `app/utils/error_handlers.py` (2), `app/api/endpoints/books.py` (1), `tests/test_error_handlers.py` (3).

**Purely a rename.** Both constants are `422`, and all eight sites import via `fastapi.status`, which re-exports the new name. No behaviour change, no response-code change, no API contract change.

Verified: backend suite **1231 passed**, 9 skipped, and warnings drop **73 → 15** (the remainder are unrelated and pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)