### PR TITLE
fix(deploy): request the OAuth client's full tag set, not a subset

### DIFF
--- a/.github/workflows/deploy-staging-containers.yml
+++ b/.github/workflows/deploy-staging-containers.yml
@@ -69,7 +69,19 @@ jobs:
         with:
           oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_AUTH_SECRET }}
-          tags: tag:ci
+          # BOTH tags, deliberately. Tailscale requires the requested tags to
+          # match the OAuth client's FULL tag set, not a subset: this client
+          # (kDnQDnzTAK…) carries tag:ci and tag:staging-server, and asking for
+          # either one alone is rejected with
+          #   400 "requested tags [tag:ci] are invalid or not permitted"
+          # which reads like a permissions problem but is an exact-match rule.
+          # Verified against the API: [tag:ci] 400, [tag:staging-server] 400,
+          # [tag:ci,tag:staging-server] SUCCESS.
+          #
+          # codeframe gets away with `tags: tag:ci` only because its client
+          # carries that single tag, so its request is already the full set.
+          # If this client's tags change, this line must change with them.
+          tags: tag:ci,tag:staging-server
 
       - name: Setup SSH
         run: |


### PR DESCRIPTION
Closes #486. One line, but it took three disproven hypotheses to find.

## The error is misleading

```
400 "requested tags [tag:ci] are invalid or not permitted"
```

That reads like the OAuth client lacks `tag:ci`. **It doesn't** — client `kDnQDnzTAK…` carries both `tag:ci` and `tag:staging-server`, with `auth_keys` and `oauth_keys` scopes.

Tailscale requires the tags in a key-creation request to match the client's **full** tag set, not a subset.

## Verified against the API

Same credentials, `POST /api/v2/tailnet/-/keys`:

| Requested | Result |
|---|---|
| `[tag:ci]` | 400 invalid or not permitted |
| `[tag:staging-server]` | 400 invalid or not permitted |
| `[tag:ci, tag:staging-server]` | **SUCCESS** |

Either tag alone is rejected. Both together succeed.

## Why copying codeframe didn't work

codeframe uses `tags: tag:ci` and deploys fine — because *its* client carries only that one tag, so its request already **is** the full set. Ours carries two, so the same line is a subset request and gets rejected.

## What was ruled out first

- **Missing tag on the client** — disproven: both granted tags failed identically
- **Wrong credential type / swapped secrets** — disproven: secret is `tskey-client-…` and its embedded client ID matches `TS_CLIENT_ID`
- **Missing `auth_keys` scope** — disproven: scopes are `auth_keys, oauth_keys`, and OAuth token exchange returns 200

The workflow, the secrets, and the Tailscale setup were all correct throughout.

## Note

If the client's tag list changes, this line must change with it. That coupling is commented in the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
