### PR TITLE
fix(books): show newest books first on the dashboard

### DIFF
--- a/backend/app/db/book.py
+++ b/backend/app/db/book.py
@@ -121,6 +121,20 @@ async def get_books_by_user(
     """
     cursor = (
         books_collection.find({"owner_id": user_auth_id}, CONTENT_EXCLUDING_PROJECTION)
+        # Newest first. Without an explicit sort Mongo returns natural (roughly
+        # insertion) order, so once a user passes the endpoint's 100-row page size
+        # the dashboard shows their OLDEST 100 forever and a newly created book is
+        # never visible — it sits past the end of page one. On staging (#488) that
+        # account had 2,649 books and the dashboard's newest card was months old.
+        #
+        # Sort on updated_at ALONE, deliberately. The collection already carries
+        # owner_updated_idx (owner_id, updated_at DESC), and this exact shape uses
+        # it: explain() reports LIMIT -> FETCH -> IXSCAN. Adding an _id tiebreaker
+        # for tie determinism looks harmless but measured as
+        # SORT -> FETCH -> IXSCAN — a blocking in-memory sort on every dashboard
+        # load, which is what hits Mongo's 32MB sort cap as a library grows.
+        # Ties within one second are rare and not worth that.
+        .sort("updated_at", -1)
         .skip(skip)
         .limit(limit)
     )

--- a/backend/tests/test_db/test_n1_and_projection.py
+++ b/backend/tests/test_db/test_n1_and_projection.py
@@ -12,6 +12,7 @@ Two independent changes folded into the dead-code removal:
 """
 
 import pytest
+from datetime import datetime, timezone
 from unittest.mock import patch
 from bson import ObjectId
 import motor.motor_asyncio
@@ -286,3 +287,59 @@ async def test_get_book_metadata_by_id_excludes_chapter_html(motor_reinit_db):
 async def test_get_book_metadata_by_id_returns_none_for_missing_and_malformed_ids(motor_reinit_db):
     assert await get_book_metadata_by_id(str(ObjectId())) is None
     assert await get_book_metadata_by_id("not-an-object-id") is None
+
+
+async def test_get_books_by_user_returns_newest_first(motor_reinit_db):
+    """The dashboard must show a user's most recent books, not their oldest.
+
+    `get_books_by_user` applies .skip()/.limit() with no .sort(), so Mongo returns
+    natural (roughly insertion) order. Once a user passes the 100-book page size,
+    the endpoint hands back their OLDEST 100 forever and a newly created book is
+    never visible on the dashboard — it sits past the end of the page.
+
+    Found on staging (#488): the account had 2,649 books, the dashboard rendered
+    73 cards whose newest was months old, and the "book creation succeeds and
+    persists" E2E regression failed on its final visibility assertion even though
+    the POST returned 201.
+    """
+    books = await get_collection("books")
+    # Insert oldest-first so natural order is the opposite of what we want back.
+    for i in range(5):
+        await books.insert_one({
+            "owner_id": USER,
+            "title": f"Book {i}",
+            "created_at": datetime(2026, 1, i + 1, tzinfo=timezone.utc),
+            "updated_at": datetime(2026, 1, i + 1, tzinfo=timezone.utc),
+        })
+
+    # A page smaller than the collection is what exposes the ordering bug.
+    result = await get_books_by_user(USER, limit=3)
+
+    assert [b["title"] for b in result] == ["Book 4", "Book 3", "Book 2"]
+
+
+async def test_get_books_by_user_pagination_is_stable_across_pages(motor_reinit_db):
+    """Consecutive pages must not repeat or drop rows.
+
+    Without an explicit sort the order is not guaranteed stable between queries,
+    so skip/limit paging can show the same book twice and hide another entirely.
+
+    Distinct timestamps here on purpose: the production sort is updated_at alone
+    (see get_books_by_user for why an _id tiebreaker was measured and rejected),
+    so this pins page boundaries rather than tie-order.
+    """
+    books = await get_collection("books")
+    for i in range(6):
+        await books.insert_one({
+            "owner_id": USER,
+            "title": f"Book {i}",
+            "created_at": datetime(2026, 2, i + 1, tzinfo=timezone.utc),
+            "updated_at": datetime(2026, 2, i + 1, tzinfo=timezone.utc),
+        })
+
+    page1 = [b["title"] for b in await get_books_by_user(USER, skip=0, limit=3)]
+    page2 = [b["title"] for b in await get_books_by_user(USER, skip=3, limit=3)]
+
+    assert page1 == ["Book 5", "Book 4", "Book 3"]
+    assert page2 == ["Book 2", "Book 1", "Book 0"]
+    assert not set(page1) & set(page2), "pages must not overlap"


### PR DESCRIPTION
Refs #488. A real user-facing bug, found by an E2E test that was right all along.

## The bug

`get_books_by_user` applied `.skip()`/`.limit()` with **no `.sort()`**:

```python
books_collection.find({"owner_id": user_auth_id}, ...).skip(skip).limit(limit)
```

Mongo returns natural (roughly insertion) order, so past the endpoint's 100-row page size a user sees their **oldest 100 books forever** and a newly created book never appears — it sits past the end of page one.

On staging: 2,649 books, dashboard rendered 73 cards whose newest was **months old**.

## It explains three E2E failures, not one

All three failing specs share the same shape — create a book, `goto('/dashboard')`, assert the title is visible:

| Spec | |
|---|---|
| `regressions.spec.ts:69` | ObjectId conversion: book creation succeeds and persists |
| `edge-cases.spec.ts:132` | Unicode metadata preserved in dashboard rendering |
| `edge-cases.spec.ts:140` | XSS-like metadata rendered as inert text |

The POST returned **201** every time. The dashboard just never showed the book.

**Worth flagging on the XSS one:** it was failing at the *visibility* assertion, before reaching its `window.__marker` check — so the security assertion has never actually executed. It'll finally run once this lands.

## Sort on `updated_at` alone — measured, not assumed

My first version added an `_id` tiebreaker for tie determinism. That looks free. It isn't. `explain()` against the real staging collection:

| Sort | Plan |
|---|---|
| `updated_at` | `LIMIT → FETCH → IXSCAN` ✅ |
| `updated_at, _id` | `SORT → FETCH → IXSCAN` ❌ blocking in-memory sort |

The collection **already carries `owner_updated_idx (owner_id, updated_at DESC)`** — the index for this query existed; the code simply never used it. The tiebreaker defeats it and adds a blocking sort to every dashboard load, which is what hits Mongo's 32MB sort cap as a library grows. Same-second ties are rare and not worth that.

## TDD

Both tests written first and failing (`'Book 0' != 'Book 5'`):

- `returns_newest_first` — 5 books inserted oldest-first, `limit=3`, asserts the three newest return
- `pagination_is_stable_across_pages` — consecutive pages must not overlap or drop rows

Backend suite: **1233 passed**, 9 skipped.

## Verification plan

Staging E2E is the real proof, and it needs this deployed. After merge I'll deploy via the (now working) container workflow and re-run the suite — expecting those three specs to go green, and the two remaining failures (`complete-user-journey`, 50-chapter TOC) to be triaged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
