### PR TITLE
test(e2e): fix three staging specs that were failing for non-product reasons

### DIFF
--- a/frontend/tests/e2e/staging/edge-cases.spec.ts
+++ b/frontend/tests/e2e/staging/edge-cases.spec.ts
@@ -31,11 +31,23 @@ async function updateToc(page: Page, bookId: string, chapterCount: number): Prom
     structure_notes: 'Staging edge-case large TOC smoke data',
   };
 
+  // The endpoint reads data.get("toc"), so the payload must be wrapped. Sent flat,
+  // it resolves to {} -> chapters [] -> an empty TOC saved with a 200, which is why
+  // this test asserted a successful PUT and then found 0 chapters on the edit
+  // screen. The endpoint accepting that silently is tracked separately.
   const response = await page.request.put(`${API_BASE_URL}/books/${bookId}/toc`, {
-    data: toc,
+    data: { toc },
   });
 
   expect(response.status(), await response.text()).toBeLessThan(400);
+
+  // A 200 is not proof of persistence here — verify the chapters actually landed.
+  const saved = await page.request.get(`${API_BASE_URL}/books/${bookId}/toc`);
+  expect(saved.status(), await saved.text()).toBeLessThan(400);
+  const savedBody = await saved.json();
+  const savedChapters =
+    savedBody?.toc?.chapters ?? savedBody?.table_of_contents?.chapters ?? savedBody?.chapters ?? [];
+  expect(savedChapters, 'TOC PUT returned 2xx but persisted no chapters').toHaveLength(chapterCount);
 }
 
 async function expectAuthenticatedDashboard(page: Page): Promise<void> {

--- a/frontend/tests/e2e/staging/fixtures/journey.helpers.ts
+++ b/frontend/tests/e2e/staging/fixtures/journey.helpers.ts
@@ -190,5 +190,15 @@ export async function readFirstChapterAnswer(page: Page): Promise<string> {
   await page.getByRole('tab', { name: /interview questions/i }).click();
   const responseBox = page.getByPlaceholder(/type your response here/i);
   await expect(responseBox).toBeVisible({ timeout: 30_000 });
+
+  // Visibility is not readiness. After a reload the textarea mounts empty and is
+  // populated once the saved response arrives, so reading inputValue() the moment
+  // it becomes visible races the fetch and returns "" — which then reads as an
+  // Issue #54 persistence regression when the answer is in fact saved (verified
+  // directly in the question_responses collection).
+  //
+  // Wait for the box to hold something before reading. The caller still asserts
+  // WHICH text it holds, so this removes the race without weakening the check.
+  await expect(responseBox).not.toHaveValue('', { timeout: 30_000 });
   return responseBox.inputValue();
 }

--- a/frontend/tests/e2e/staging/regressions.spec.ts
+++ b/frontend/tests/e2e/staging/regressions.spec.ts
@@ -98,7 +98,14 @@ test.describe('Issue #83 regressions', () => {
 
     // The created book must be queryable after a full reload (owner_id correct).
     await page.goto('/dashboard');
-    await expect(page.getByText(bookTitle)).toBeVisible({ timeout: 15000 });
+    // 20s to match the sibling dashboard-visibility specs in edge-cases.spec.ts.
+    // This one was the outlier at 15s and was the only one failing late in a full
+    // suite run: the failure snapshot showed ZERO book cards rendered, i.e. the
+    // whole list had not loaded yet — not that this book was missing. The account
+    // carries ~2,700 books and the dashboard renders a 100-row page (~195 KB) with
+    // no pagination UI, so first paint is slow. Tracked separately; the assertion
+    // itself is unchanged.
+    await expect(page.getByText(bookTitle)).toBeVisible({ timeout: 20_000 });
   });
 
   /**


### PR DESCRIPTION
Closes #488. Follow-up to #491 (dashboard ordering), which took the suite from 6 failed / 5 passed to 4 failed. These three take it to **10 passed**.

Each was a defect in the test, confirmed against the database rather than inferred from the symptom.

## 1. Read-after-visible race — reported as data loss, wasn't

`readFirstChapterAnswer` waited for the textarea to be **visible**, then immediately read `inputValue()`. After a reload the box mounts empty and is populated when the saved response arrives, so it returned `""` and the test reported:

```
Error: Answer was lost after refresh (Issue #54 regression)
```

**The answer was never lost.** `question_responses` holds 120 `Persistence check` rows, including the one from the failing run. The PUT had returned `< 400` and genuinely persisted.

Now waits for a non-empty value before reading. The caller still asserts *which* text it contains, so the check is not weakened. This also fixed `complete-user-journey`, which shares the helper.

## 2. Wrong TOC payload shape, masked by a 200

The endpoint reads `data.get("toc")`, so a flat `{chapters: [...]}` body resolves to `{}` → `chapters: []` → an **empty TOC saved with a 200**. The test asserted only `status < 400`, so it passed the PUT and then found 0 chapters on the edit screen.

Verified in Mongo — for the book it had just "saved" 50 chapters to:

```
table_of_contents chapters: 0
toc_items: 0
```

Fixed by wrapping as `{ toc }`, **and** adding a read-back assertion so a 2xx can no longer stand in for persistence.

The endpoint accepting that shape silently is a genuine product defect — filed as **#492**.

## 3. Timeout outlier, 15s → 20s

The ObjectId spec was the only dashboard-visibility test at 15 s (siblings use 20 s) and the only one failing late in a full run. Its failure snapshot showed **zero book cards rendered** — the whole list hadn't loaded, not that this book was missing.

The account carries ~2,700 books and the dashboard renders a 100-row page (~195 KB) with no pagination UI. The assertion is unchanged; the slow first paint is filed as **#493**.

## Result

| | |
|---|---|
| Start of #488 | 6 failed / 5 passed |
| After #491 (dashboard ordering) | 4 failed / 7 passed |
| After this | **10 passed**, 1 transient |

The one transient was `never return 401`, which passed on re-run in 2.9 s with **zero 401s** in the backend logs across the whole window.

Every change was verified against real staging, not a local mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
