### PR TITLE
chore(deps): bump docker/setup-buildx-action from 3 to 4

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Pull requests from forks get a read-only token, and pushing an image from
       # an unreviewed PR would be a supply-chain hole regardless. Build to verify


### PR DESCRIPTION
## What

Bumps `docker/setup-buildx-action` from `v3` to `v4` in `.github/workflows/build-images.yml`. One line.

## Why this is a hand-written PR and not a Dependabot one

This recreates **#504**, which **Dependabot closed itself** at 18:40 UTC with:

> Looks like docker/setup-buildx-action is up-to-date now, so this is no longer needed.

That was incorrect — `main` still pinned `@v3` at the time and right up until this PR. The most likely cause is Dependabot getting confused by the rebase storm while four PRs touching `build-images.yml` (#498, #501, #504, #506) landed in quick succession. It deleted the branch on close, so `gh pr reopen 504` fails with `Could not open the pull request`, leaving no way to revive the original.

Without this, the repo would silently sit on `setup-buildx-action@v3` until Dependabot's next scheduled run happened to notice again.

## Supply-chain triage

Carried over from the triage posted on #504, which concluded **Merge now**:

- **Update type:** high-impact core — a CI action that executes during build/deploy.
- **Security urgency:** Low. No CVE, no GHSA, no `security` label. Not a security update.
- **Supply-chain risk:** Low. Official `docker` org; no maintainer, ownership, or namespace change. No lifecycle scripts. No new dependencies.
- **Version age:** `v4.0.0` first published **2026-03-04**, ~5.5 months of ecosystem exposure — well past any reasonable cooldown window.
- **Verification:** `Build backend image` and `Build frontend image` both passed on #504, so the action was actually exercised rather than merely parsed. The same two jobs gate this PR.

## Note on tag pinning

These actions are referenced by floating major tag (`@v4`), which is mutable and could in principle be repointed upstream. That is the repo's existing convention across every action in this workflow and is unchanged by this PR — flagging it as a possible follow-up (pin by commit SHA with Dependabot configured to update the pinned SHAs), not as a defect introduced here.

Part of the 2026-08-25 Dependabot supply-chain sweep. See also #512, #513, #514.
