### PR TITLE
feat(ci): sync MONGODB_URI from the staging secret to the box (#537)

### DIFF
--- a/.github/workflows/sync-staging-env.yml
+++ b/.github/workflows/sync-staging-env.yml
@@ -1,0 +1,175 @@
+name: Sync Staging Env
+
+# Makes the `staging` environment secret MONGODB_URI actually authoritative.
+#
+# Why this exists (#537): application secrets live in /opt/auto-author/.env on the
+# box, and until now NO workflow wrote that file. Updating the GitHub secret
+# therefore changed nothing that runs — a trap that cost a real outage its first
+# hour of debugging, because the secret's `updated_at` says the credential was
+# refreshed while the box still holds the old one. Either the secret is wired to
+# something or it should not exist; this wires it.
+#
+# Scope is deliberately ONE key. The box's .env holds 26 keys and only a subset
+# have GitHub secrets at all (AWS_*, CLOUDINARY_*, SENTRY_DSN and others exist
+# only on the box), so a whole-file render would silently delete working config.
+# Worse, a broad sync would let a *stale* GitHub secret overwrite a newer value on
+# the box — turning this workflow into an outage source. One key, updated in
+# place, everything else untouched. Add keys here only when a specific need shows
+# up, and only after checking the box's value is not the newer one.
+#
+# This does not replace deploy-staging-containers.yml. That ships images; this
+# ships one credential.
+
+on:
+  workflow_dispatch:
+    inputs:
+      recreate:
+        description: 'Recreate containers so the new value takes effect (compose injects env at container CREATION, so a plain restart keeps the old value)'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  # Shared with the deploy workflow on purpose: both mutate /opt/auto-author and
+  # both bounce containers. Never let them interleave on one box.
+  group: deploy-staging
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync MONGODB_URI to the staging box
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: staging
+      url: https://dev.autoauthor.app
+
+    steps:
+      # Same access path as the deploy: the box firewalls :22 off the public
+      # internet except from the owner's home subnet, and the runner reaches it
+      # over Tailscale. Both tags are required — Tailscale matches the OAuth
+      # client's FULL tag set, not a subset. See deploy-staging-containers.yml.
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
+        with:
+          oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_AUTH_SECRET }}
+          tags: tag:ci,tag:staging-server
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_KEY }}" > ~/.ssh/staging_key
+          chmod 600 ~/.ssh/staging_key
+
+      - name: Refuse to run on an empty secret
+        env:
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+        run: |
+          # Without this, an unset or cleared secret would happily write
+          # MONGODB_URI= to the box and take staging down on the next recreate.
+          # docker-compose.yml's `${MONGODB_URI:?...}` would then block startup.
+          if [ -z "${MONGODB_URI}" ]; then
+            echo "::error::The staging MONGODB_URI secret is empty or unset. Refusing to write it."
+            exit 1
+          fi
+          case "${MONGODB_URI}" in
+            mongodb://*|mongodb+srv://*) ;;
+            *) echo "::error::MONGODB_URI does not look like a MongoDB connection string. Refusing."; exit 1 ;;
+          esac
+          # The value crosses to the box as one line and is read back with a single
+          # `read -r`. A secret containing a newline would therefore be silently
+          # TRUNCATED at the first one and written as a valid-looking but wrong
+          # credential — the worst failure mode available here. Refuse instead.
+          if [ "$(printf '%s' "${MONGODB_URI}" | wc -l)" -ne 0 ]; then
+            echo "::error::MONGODB_URI contains a newline. Refusing rather than writing a truncated value."
+            exit 1
+          fi
+          echo "Secret present and well-formed (value not printed)."
+
+      - name: Write MONGODB_URI into /opt/auto-author/.env
+        env:
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+        run: |
+          # The value travels on STDIN, never in argv: the remote script is the ssh
+          # command argument, so the credential never appears in the box's process
+          # list. GitHub masks it in logs; this covers `ps` on a SHARED box, which
+          # masking does not.
+          printf '%s\n' "${MONGODB_URI}" | ssh -i ~/.ssh/staging_key \
+            -o StrictHostKeyChecking=accept-new -o ConnectTimeout=30 \
+            ${{ secrets.USER }}@${{ secrets.STAGING_TS_HOST || secrets.HOST }} '
+              set -euo pipefail
+              IFS= read -r VALUE
+              [ -n "$VALUE" ] || { echo "empty value reached the box"; exit 1; }
+              cd /opt/auto-author
+
+              # Timestamped backup, kept. Rolling this back by hand at 2am should
+              # not require reconstructing a 26-key file from memory.
+              cp -a .env ".env.bak.$(date -u +%Y%m%dT%H%M%SZ)"
+
+              # Targeted single-key update. Every other key is carried through
+              # byte-for-byte. The rewritten key moves to the end of the file,
+              # which compose does not care about.
+              tmp=$(mktemp)
+              grep -v "^MONGODB_URI=" .env > "$tmp" || true
+              printf "MONGODB_URI=%s\n" "$VALUE" >> "$tmp"
+              chmod 600 "$tmp"
+              mv "$tmp" .env
+
+              # Each backup is a credential-bearing file on a box shared with six
+              # other apps. Keep enough to roll back, not an unbounded archive.
+              ls -1t .env.bak.* 2>/dev/null | tail -n +6 | xargs -r rm -f
+
+              echo "Wrote MONGODB_URI. .env now has $(grep -c . .env) non-empty lines."
+            '
+
+      - name: Recreate containers
+        if: ${{ inputs.recreate }}
+        run: |
+          ssh -i ~/.ssh/staging_key -o StrictHostKeyChecking=accept-new -o ConnectTimeout=30 \
+            ${{ secrets.USER }}@${{ secrets.STAGING_TS_HOST || secrets.HOST }} \
+            "set -euo pipefail
+             cd /opt/auto-author
+             # --force-recreate because compose injects env at container CREATION.
+             # Without it a container started before the .env edit keeps the old
+             # credential and this workflow appears to do nothing — the exact
+             # class of bug it was written to kill.
+             docker compose -f docker-compose.yml -f docker-compose.staging.yml up -d --force-recreate"
+
+      - name: Verify the credential actually works
+        if: ${{ inputs.recreate }}
+        run: |
+          # Outcome evidence, not 'the file was written'. Ask MongoDB directly from
+          # inside the running backend, then confirm the app's own readiness probe
+          # agrees. /health returns only an exception type, so the ping is what
+          # gives a diagnosable message.
+          ssh -i ~/.ssh/staging_key -o StrictHostKeyChecking=accept-new -o ConnectTimeout=30 \
+            ${{ secrets.USER }}@${{ secrets.STAGING_TS_HOST || secrets.HOST }} bash -s <<'REMOTE'
+          set -euo pipefail
+          echo '--- direct MongoDB ping from the backend container ---'
+          docker exec auto-author-backend-1 python -c "import os, pymongo; pymongo.MongoClient(os.environ['MONGODB_URI'], serverSelectionTimeoutMS=8000).admin.command('ping'); print('PING OK')"
+          echo '--- readiness probe ---'
+          body=''
+          for i in $(seq 1 24); do
+            body=$(curl -s --max-time 5 http://127.0.0.1:8000/api/v1/health || true)
+            case "$body" in
+              *'"status":"healthy"'*) echo "$body"; exit 0 ;;
+            esac
+            sleep 5
+          done
+          echo "::error::Backend never reported healthy; last body: $body"
+          exit 1
+          REMOTE
+
+      - name: Summary
+        if: always()
+        run: |
+          { echo '## Staging env sync';
+            echo '- key: `MONGODB_URI` (value never printed)';
+            echo "- containers recreated: ${{ inputs.recreate }}";
+            echo "- result: ${{ job.status }}";
+            echo '- a timestamped `.env.bak.*` was left on the box before the write';
+          } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sync-staging-env.yml
+++ b/.github/workflows/sync-staging-env.yml
@@ -90,6 +90,30 @@ jobs:
           fi
           echo "Secret present and well-formed (value not printed)."
 
+      - name: Pre-flight — prove the NEW credential works before touching anything
+        env:
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+        run: |
+          # Order matters here, and getting it wrong is an outage.
+          #
+          # docker-compose.yml makes the frontend `depends_on: backend:
+          # condition: service_healthy`. So if this value is also bad, a
+          # write-then-recreate would leave compose waiting on a backend that can
+          # never pass its healthcheck, abort, and take the FRONTEND down with it —
+          # converting "login broken, site up" into "site down". Worse than the
+          # state we came to fix.
+          #
+          # So: test the new credential against the live cluster first, using the
+          # container that already exists, without writing anything. A bad secret
+          # then costs one failed workflow run and changes nothing.
+          #
+          # -i plus stdin, not `docker exec -e`, so the candidate credential stays
+          # out of argv on this shared box.
+          printf '%s\n' "${MONGODB_URI}" | ssh -i ~/.ssh/staging_key \
+            -o StrictHostKeyChecking=accept-new -o ConnectTimeout=30 \
+            ${{ secrets.USER }}@${{ secrets.STAGING_TS_HOST || secrets.HOST }} \
+            'set -euo pipefail; docker exec -i auto-author-backend-1 python -c "import sys, pymongo; uri = sys.stdin.readline().strip(); pymongo.MongoClient(uri, serverSelectionTimeoutMS=8000).admin.command(\"ping\"); print(\"PRE-FLIGHT PING OK\")"'
+
       - name: Write MONGODB_URI into /opt/auto-author/.env
         env:
           MONGODB_URI: ${{ secrets.MONGODB_URI }}
@@ -133,6 +157,19 @@ jobs:
             ${{ secrets.USER }}@${{ secrets.STAGING_TS_HOST || secrets.HOST }} \
             "set -euo pipefail
              cd /opt/auto-author
+             # docker-compose.staging.yml pins both images to
+             # \${IMAGE_TAG:?IMAGE_TAG is required}, and the deploy workflow only
+             # exports it for the duration of its own SSH session — nothing on the
+             # box persists it. Without this, compose aborts before recreating
+             # anything and the freshly written credential is never applied.
+             #
+             # Derive it from what is ALREADY running, never from main. This
+             # workflow ships a credential, not a release: it must not quietly
+             # move staging onto a different build as a side effect.
+             IMAGE_TAG=\$(docker inspect --format '{{.Config.Image}}' auto-author-backend-1 | sed 's/.*://')
+             [ -n \"\$IMAGE_TAG\" ] || { echo 'could not determine the running image tag'; exit 1; }
+             export IMAGE_TAG
+             echo \"recreating on the running tag: \$IMAGE_TAG\"
              # --force-recreate because compose injects env at container CREATION.
              # Without it a container started before the .env edit keeps the old
              # credential and this workflow appears to do nothing — the exact

--- a/docs/references/quality-standards.md
+++ b/docs/references/quality-standards.md
@@ -145,6 +145,34 @@ git fetch origin main && git show origin/main:<file> | grep <dependency>
 Anything closed-but-not-merged whose version is still old on `main` was lost. Recreate it
 as a fresh PR — the original branch is gone.
 
+## Staging secrets
+
+Application secrets live in `/opt/auto-author/.env` **on the box**, not in GitHub.
+
+**One exception, and it is the one that matters:** `MONGODB_URI` is synced from the
+`staging` environment secret by `.github/workflows/sync-staging-env.yml`
+(`workflow_dispatch`). Update the GitHub secret, dispatch that workflow, and it writes
+the key, recreates the containers and verifies the credential end-to-end.
+
+Every **other** key in that file — `AWS_*`, `CLOUDINARY_*`, `SENTRY_DSN`, and the rest of
+the 26 — exists only on the box. Nothing in CI writes them. Editing a GitHub secret with
+one of those names changes nothing that runs.
+
+That asymmetry is deliberate. A whole-file render from GitHub secrets would delete the
+keys that have no secret, and would let a *stale* secret overwrite a newer value on the
+box — turning the sync into an outage source. Add a key to the workflow only when there
+is a specific need, and only after confirming the box's value is not the newer one.
+
+### Why this exists
+
+Before #537, no workflow wrote that file at all. A rotated `MONGODB_URI` was pushed to
+the GitHub secret, the secret's `updated_at` duly changed, and the running containers
+kept the old credential — indistinguishable, from the outside, from a rotation that had
+simply not worked. Staging was down for six days.
+
+**Compose injects env at container *creation*.** A `restart` keeps the old values; only
+`up -d --force-recreate` picks up an edited `.env`. The workflow does this for you.
+
 ## Backend Dependency Updates
 
 `backend/requirements.txt` is a **generated export** of `uv.lock`. Nothing that ships


### PR DESCRIPTION
Part of #537.

## Problem

Application secrets live in `/opt/auto-author/.env` **on the box**, and until now **no workflow wrote that file**. So when the rotated `MONGODB_URI` was pushed to the `staging` environment secret, GitHub dutifully updated the secret's `updated_at` — and the running containers kept the old, rejected credential.

From the outside those two states are identical. That is what made #537 expensive: the natural next thought after updating a secret is "the credential is fixed", and nothing contradicts it. Staging had been down six days.

Either the secret is wired to something, or it should not exist. This wires it.

## What it does

`workflow_dispatch` → connect over Tailscale (same pinned action and tag pair as the deploy) → write the key → `up -d --force-recreate` → **verify against MongoDB for real**.

Verification is a live `ping` from inside the running backend container plus the readiness probe — not "the file was written". `/health` returns only an exception type, so the ping is what yields a diagnosable message.

## Scope is one key, deliberately

The box's `.env` holds **26** keys; only a subset have GitHub secrets at all (`AWS_*`, `CLOUDINARY_*`, `SENTRY_DSN` and others exist only on the box). Two failure modes ruled out the obvious "render the whole file from secrets" design:

1. It would **silently delete** every key with no corresponding secret.
2. It would let a **stale** GitHub secret overwrite a newer value on the box — turning this workflow into an outage source rather than a fix for one.

So: one key, updated in place, everything else carried through byte-for-byte.

## Credential handling

- **stdin, never argv.** The remote script is the `ssh` command argument and the value arrives on stdin, so it never appears in the process list. GitHub masks secrets in logs; masking does nothing about `ps` on a box shared with six other apps.
- **Refuses rather than guesses** — empty/unset, not a `mongodb://`/`mongodb+srv://` string, or *containing a newline*. That last one matters: the remote `read -r` takes one line, so a multi-line secret would be silently truncated into a valid-looking wrong credential. Worst available failure mode; now impossible.
- **Timestamped mode-600 backup** before the write, pruned to the five most recent so credential-bearing files don't accumulate on a shared box.

## Verification

Guards, all five cases:

| input | result |
|---|---|
| empty | REFUSED |
| `hunter2` | REFUSED: not a connection string |
| multi-line | REFUSED: contains newline |
| valid `mongodb+srv://…` | ACCEPTED |
| valid `mongodb://…` | ACCEPTED |

The write logic, run against a realistic 10-key `.env` with awkward values:

- key set unchanged ✅
- every other key byte-identical ✅
- value containing `@ / ? & =` written **exactly** ✅
- mode 600 preserved on `.env` and the backup ✅

`shellcheck` on both embedded remote scripts: two info/style notes (`ls` on our own fixed-format filenames; an unused loop counter), no defects.

## Note for #520

#520 proposes **retiring** the dead `MONGODB_URI`/`DATABASE_NAME` secrets. This takes the opposite resolution to the same problem — making `MONGODB_URI` live rather than deleting it. If this merges, #520 should be re-scoped to the `.disabled` workflow cleanup and `DATABASE_NAME` alone. Flagging rather than silently invalidating it.

## Known limitations

- **Not yet run.** It needs a `workflow_dispatch` against live staging, which will change the credential on the box. Happy to dispatch it on request — that is also the fastest route to closing #537.
- **`DATABASE_NAME` is not synced.** It has not changed since 2025-11-22 and altering it would point the app at a different database. Risk without need.
- **The `staging` environment secret remains the source of truth only for this one key.** Documented in `quality-standards.md` so the asymmetry is discoverable rather than folklore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
