### PR TITLE
fix(security): scrub live staging identifiers from tracked docs (#544)

### DIFF
--- a/.github/DEPLOYMENT.md
+++ b/.github/DEPLOYMENT.md
@@ -53,7 +53,7 @@ same name feeds only the disabled PM2 path.
 | `SSH_KEY` | Private SSH key for server access | `-----BEGIN OPENSSH PRIVATE KEY-----…` |
 | `USER` | SSH username | `root` |
 | `STAGING_TS_HOST` | Tailscale hostname for the box; preferred over `HOST` | `staging-vps` |
-| `HOST` | Public hostname or IP — fallback when `STAGING_TS_HOST` is unset | `195.35.14.177` |
+| `HOST` | Public hostname or IP — fallback when `STAGING_TS_HOST` is unset | `<staging-host>` |
 | `TS_CLIENT_ID` | Tailscale OAuth client id — the deploy runs over Tailscale (#485, #489) | — |
 | `TS_AUTH_SECRET` | Tailscale OAuth client secret; needs the client's full tag set (#490) | — |
 

--- a/docs/BACKEND_TEST_FAILURE_ANALYSIS.md
+++ b/docs/BACKEND_TEST_FAILURE_ANALYSIS.md
@@ -21,7 +21,7 @@
 ### Error Pattern
 ```
 pymongo.errors.ServerSelectionTimeoutError: SSL handshake failed:
-ac-gdkptel-shard-00-XX.oxzhocn.mongodb.net:27017: [Errno 104] Connection reset by peer
+<cluster-host>:27017: [Errno 104] Connection reset by peer
 ```
 
 ### Affected Tests (12 in session service + 2 question generation)

--- a/docs/STAGING_VERIFICATION_RESULTS.md
+++ b/docs/STAGING_VERIFICATION_RESULTS.md
@@ -48,7 +48,7 @@ All critical infrastructure verified and operational:
 
 **MongoDB Connection**: Atlas (Cloud)
 ```bash
-DATABASE_URL=mongodb+srv://frankbria:***@briastrategygroup.oxzhocn.mongodb.net/
+DATABASE_URL=mongodb+srv://<db-user>:<redacted>@<cluster-host>/
 DATABASE_NAME=auto_author-staging
 ```
 

--- a/docs/demos/2026-07-10-issue-189-loopback-bind.md
+++ b/docs/demos/2026-07-10-issue-189-loopback-bind.md
@@ -17,7 +17,7 @@ LISTEN 0      511                              *:3002             *:*
 The host firewall (ufw, default-deny) already drops external 8000/3002 — the AC "OR" branch — but nothing in the repo documented it. From an off-box machine, direct port access times out while the nginx-proxied HTTPS endpoints serve normally:
 
 ```bash
-curl -sm 5 http://195.35.14.177:8000/api/v1/health -o /dev/null -w "direct 8000: %{http_code}\n" || echo "direct 8000: TIMEOUT/UNREACHABLE"; curl -sm 5 http://195.35.14.177:3002 -o /dev/null -w "direct 3002: %{http_code}\n" || echo "direct 3002: TIMEOUT/UNREACHABLE"; curl -sm 10 https://api.dev.autoauthor.app/api/v1/health -o /dev/null -w "via nginx api: %{http_code}\n"; curl -sm 10 https://dev.autoauthor.app -o /dev/null -w "via nginx app: %{http_code}\n"
+curl -sm 5 http://<staging-host>:8000/api/v1/health -o /dev/null -w "direct 8000: %{http_code}\n" || echo "direct 8000: TIMEOUT/UNREACHABLE"; curl -sm 5 http://<staging-host>:3002 -o /dev/null -w "direct 3002: %{http_code}\n" || echo "direct 3002: TIMEOUT/UNREACHABLE"; curl -sm 10 https://api.dev.autoauthor.app/api/v1/health -o /dev/null -w "via nginx api: %{http_code}\n"; curl -sm 10 https://dev.autoauthor.app -o /dev/null -w "via nginx app: %{http_code}\n"
 ```
 
 ```output
@@ -72,7 +72,7 @@ LISTEN 0      2048                     127.0.0.1:8000       0.0.0.0:*
 The app still works end-to-end through nginx (TLS + real response bodies), deploy health checks on localhost keep working, and direct external port access remains dead:
 
 ```bash
-echo "--- via nginx (off-box) ---"; curl -sm 10 https://api.dev.autoauthor.app/api/v1/health; echo; curl -sm 15 https://dev.autoauthor.app -o /dev/null -w "frontend via nginx: %{http_code}\n"; echo "--- deploy health checks (on-box, localhost) ---"; ssh staging 'curl -sf http://localhost:8000/api/v1/health >/dev/null && echo "localhost:8000 health OK"; curl -sf http://localhost:3002 -o /dev/null && echo "localhost:3002 OK"'; echo "--- direct external (must stay unreachable) ---"; curl -sm 5 http://195.35.14.177:8000/api/v1/health -o /dev/null -w "direct 8000: %{http_code}\n" || echo "direct 8000: TIMEOUT/UNREACHABLE"; curl -sm 5 http://195.35.14.177:3002 -o /dev/null -w "direct 3002: %{http_code}\n" || echo "direct 3002: TIMEOUT/UNREACHABLE"
+echo "--- via nginx (off-box) ---"; curl -sm 10 https://api.dev.autoauthor.app/api/v1/health; echo; curl -sm 15 https://dev.autoauthor.app -o /dev/null -w "frontend via nginx: %{http_code}\n"; echo "--- deploy health checks (on-box, localhost) ---"; ssh staging 'curl -sf http://localhost:8000/api/v1/health >/dev/null && echo "localhost:8000 health OK"; curl -sf http://localhost:3002 -o /dev/null && echo "localhost:3002 OK"'; echo "--- direct external (must stay unreachable) ---"; curl -sm 5 http://<staging-host>:8000/api/v1/health -o /dev/null -w "direct 8000: %{http_code}\n" || echo "direct 8000: TIMEOUT/UNREACHABLE"; curl -sm 5 http://<staging-host>:3002 -o /dev/null -w "direct 3002: %{http_code}\n" || echo "direct 3002: TIMEOUT/UNREACHABLE"
 ```
 
 ```output

--- a/scripts/test_no_staging_identifiers.py
+++ b/scripts/test_no_staging_identifiers.py
@@ -36,7 +36,13 @@ ALLOWED_HOSTS = {
 }
 
 ATLAS = re.compile(r"\b[a-z0-9][a-z0-9-]*\.[a-z0-9-]+\.mongodb\.net\b", re.I)
-SKIP_PREFIXES = ("frontend/playwright-report/", "frontend/tests/e2e/staging/playwright-report-staging/")
+SELF = "scripts/test_no_staging_identifiers.py"
+
+# No path is skipped. An earlier draft skipped the Playwright report directories
+# as "noise", but both are gitignored with zero tracked files, so the skip
+# excluded nothing while creating a blind spot in the one artifact type most
+# likely to leak a connection string: a report HTML can embed a backend error
+# body verbatim. If such a report is ever force-added, it gets scanned.
 
 
 def _tracked_text_files():
@@ -44,7 +50,7 @@ def _tracked_text_files():
         ["git", "ls-files"], cwd=REPO, capture_output=True, text=True, check=True
     ).stdout.split("\n")
     for rel in out:
-        if not rel or rel.startswith(SKIP_PREFIXES) or rel == "scripts/test_no_staging_identifiers.py":
+        if not rel or rel == SELF:
             continue
         p = REPO / rel
         if not p.is_file() or p.stat().st_size > 2_000_000:
@@ -80,7 +86,18 @@ def test_allowlisted_hosts_are_still_referenced(host):
     It would silently permit that exact hostname forever. If this fails, the
     example moved or was deleted -- drop the entry rather than keeping it.
     """
+    # `:!<path>` excludes this file. Without it the search matches the
+    # ALLOWED_HOSTS literal directly above and the test can never fail — it
+    # passed for exactly as long as this file was untracked, which is why the
+    # bug survived its own first run.
     hits = subprocess.run(
-        ["git", "grep", "-lF", host], cwd=REPO, capture_output=True, text=True
+        ["git", "grep", "-lF", host, "--", ":!" + SELF],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
     ).stdout.strip()
-    assert hits, f"ALLOWED_HOSTS entry {host!r} matches no tracked file; remove it."
+    assert hits, (
+        f"ALLOWED_HOSTS entry {host!r} matches no tracked file outside this "
+        "guard; the example it allowed is gone, so the entry now only widens "
+        "what may pass. Remove it."
+    )

--- a/scripts/test_no_staging_identifiers.py
+++ b/scripts/test_no_staging_identifiers.py
@@ -1,0 +1,86 @@
+"""Guard: no live staging infrastructure identifiers in tracked files (#544).
+
+This repository is PUBLIC. #544 found a database username sitting in one string
+with its managed-cluster hostname — no password (that was masked), but half a
+credential plus the name of a specific principal to attack, with the discovery
+step removed. Scrubbing the working tree does not remove it from history, so the
+value of this guard is preventing the NEXT one, not undoing that one.
+
+Deliberately narrow, because a noisy rule gets deleted: this repo already removed
+`detect-private-key` from pre-commit for false positives. So the pattern is a
+managed-cluster hostname (`*.mongodb.net`), which has no legitimate reason to be
+literal in a public repo, and every known documentation example is allowlisted
+below by its exact value rather than by a fuzzy "looks like a placeholder" rule.
+
+The staging host's *IP* is deliberately NOT matched. #544 calibrated it as close
+to zero marginal risk (`dev.autoauthor.app` resolves to it), and a public-IPv4
+rule would fire on version strings, RFC 5737 test addresses and the 88 tracked
+references to the previous provider's now-dead host — the exact noise that gets a
+check switched off.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Documentation examples that are allowed to contain a mongodb.net hostname.
+# Exact hostnames, so a REAL cluster appearing in these same files still fails.
+ALLOWED_HOSTS = {
+    # The #211 test-db-guard fixture and its demo. Obviously synthetic, and the
+    # fixture's whole job is to be a remote srv URI the guard must refuse.
+    "cluster0.abcde.mongodb.net",
+}
+
+ATLAS = re.compile(r"\b[a-z0-9][a-z0-9-]*\.[a-z0-9-]+\.mongodb\.net\b", re.I)
+SKIP_PREFIXES = ("frontend/playwright-report/", "frontend/tests/e2e/staging/playwright-report-staging/")
+
+
+def _tracked_text_files():
+    out = subprocess.run(
+        ["git", "ls-files"], cwd=REPO, capture_output=True, text=True, check=True
+    ).stdout.split("\n")
+    for rel in out:
+        if not rel or rel.startswith(SKIP_PREFIXES) or rel == "scripts/test_no_staging_identifiers.py":
+            continue
+        p = REPO / rel
+        if not p.is_file() or p.stat().st_size > 2_000_000:
+            continue
+        yield rel, p
+
+
+def test_no_live_cluster_hostname_in_tracked_files():
+    offenders = []
+    for rel, path in _tracked_text_files():
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), 1):
+            for host in ATLAS.findall(line):
+                if host.lower() not in ALLOWED_HOSTS:
+                    offenders.append(f"{rel}:{lineno} -> {host}")
+    assert not offenders, (
+        "A managed-cluster hostname is present in a tracked file of a PUBLIC repo.\n"
+        + "\n".join(offenders)
+        + "\n\nReplace it with `<cluster-host>` (and any username with `<db-user>`). "
+        "If it is genuinely a documentation example, add the exact hostname to "
+        "ALLOWED_HOSTS above with a comment saying which file it serves. Do not "
+        "widen the pattern -- the point is that a real cluster name cannot pass."
+    )
+
+
+@pytest.mark.parametrize("host", sorted(ALLOWED_HOSTS))
+def test_allowlisted_hosts_are_still_referenced(host):
+    """An allowlist entry that no longer matches anything is a latent hole.
+
+    It would silently permit that exact hostname forever. If this fails, the
+    example moved or was deleted -- drop the entry rather than keeping it.
+    """
+    hits = subprocess.run(
+        ["git", "grep", "-lF", host], cwd=REPO, capture_output=True, text=True
+    ).stdout.strip()
+    assert hits, f"ALLOWED_HOSTS entry {host!r} matches no tracked file; remove it."

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -203,3 +203,27 @@ guard that watched it — the CI sync gate, `exclude-paths`, and the test pinnin
 exclusion. Nothing would have noticed the file returning, and the `uv export` command is
 still quoted in older CHANGELOG entries. **When a removal takes all existing checks with
 it, leave exactly one tripwire behind, and mutation-check it.**
+
+## #553 — a repo-scanning guard matches its own literal (2026-08-27)
+
+**Pattern:** added `scripts/test_no_staging_identifiers.py` with a second test asserting
+every `ALLOWED_HOSTS` entry still matches a real file, so a stale entry cannot silently
+whitelist a hostname forever. `git grep -lF "$HOST"` matches the `ALLOWED_HOSTS` literal
+in the guard file itself, so it could never fail.
+
+**Why it survived review-by-me:** it *did* fail on first run, catching two allowlist
+entries I had guessed at — because the file was still **untracked**, so `git grep` could
+not see it. The moment it was committed it became vacuous. I then wrote in the PR body
+that it "earned its keep immediately", crediting it for work it structurally could not do.
+
+**Rules:**
+1. Any guard that scans the repo must exclude itself: `git grep ... -- ":!$SELF"`.
+2. Mutation-check a new guard **after `git add`**, not before — tracked/untracked changes
+   what `git grep`, `git ls-files` and `git diff --cached` can see.
+3. Mutation-check **both directions**. The forbid-direction ("add the bad thing → RED")
+   passed. Only the require-direction ("remove the required thing → RED") was broken, and
+   I never tested it.
+
+**Also, again:** `git checkout <file>` to revert a mutation probe reverted an *uncommitted*
+scrub in the same file. Same trap as `commit-before-mutation-checks`. Use a backup copy
+(`cp` to scratch, `cp` back) when the working tree has uncommitted work.


### PR DESCRIPTION
Addresses #544 (AC2 + a guard). **AC1 and AC3 need Atlas console access and are left open** — see below.

## What was scrubbed

All four locations the issue named, replaced with `<staging-host>`, `<db-user>`, `<cluster-host>`:

| file | disclosed |
|---|---|
| `.github/DEPLOYMENT.md` | staging host address |
| `docs/demos/2026-07-10-issue-189-loopback-bind.md` | staging host address ×4 |
| `docs/STAGING_VERIFICATION_RESULTS.md` | db username **and** managed-cluster hostname, in one string |
| `docs/BACKEND_TEST_FAILURE_ANALYSIS.md` | cluster shard hostname |

Every substitution keeps the surrounding command or table readable.

## I swept the whole tracked tree rather than trusting the list — and the list was right

Worth recording so nobody re-runs it. The raw sweep flagged ~99 tracked lines, which looks alarming and isn't:

- **88 of them are the *previous* provider's now-dead IP** (retired in the #537 move), across `archive/`, `claudedocs/`, `frontend/claudedocs/`, `docs/` and `.beads/issues.jsonl`. A dead host's address is not a disclosure. (Distribution corrected after review — the note exists so nobody re-runs the sweep, so a wrong inventory defeats its own purpose.)
- **The current host appears in exactly the two files above** — 5 occurrences.
- **Two apparent "username + hostname" hits were documentation placeholders**: `staging_user:pa%24%24word@` in `docs/DATABASE_CONNECTION_STANDARD.md`, and an uppercase `USER:REDACTED@cluster0.abcde.mongodb.net` in the #211 demo.
- **`backend/.env` is untracked, gitignored, and has never been committed** (`git log --all -- backend/.env` → 0 commits). I checked this first, because a committed `.env` would have been a different and much worse issue.

So #544's triage was better than my sweep's first pass. The one thing the sweep adds is the dead-IP count, which is a reason *not* to widen the scrub, not a reason to.

## The guard

`scripts/test_no_staging_identifiers.py`, in the suite CI already runs (`pytest scripts/`). Mutation-checked: RED when a real cluster hostname is reintroduced, GREEN when it is not.

Deliberately narrow, because a noisy rule gets deleted — this repo already dropped `detect-private-key` from pre-commit for false positives:

- **Matches `*.mongodb.net` hostnames**, which have no legitimate reason to appear literally in a public repo. Known examples are allowlisted **by exact value**, so a real cluster appearing in those same files still fails.
- **A second test fails if an allowlist entry stops matching anything**, so a stale entry cannot sit there silently permitting one hostname forever. This shipped **broken** in the first commit — `git grep` matched the `ALLOWED_HOSTS` literal in the guard file itself, so it could never fail. It passed for exactly as long as the file was untracked, which is why the bug survived its own first run. Caught by the cross-family review, which proved it by deleting the hostname from both referencing files; fixed in `625bd72` and mutation-checked in both directions.
- **Does NOT match public IPv4.** #544 itself calibrated the host IP as close to zero marginal risk (`dev.autoauthor.app` resolves to it), and such a rule would fire on version strings, RFC 5737 test addresses, and those 88 dead-host lines.

### One attempt reverted

I first added a `check-secrets.sh` pattern matching Mongo URIs whose userinfo isn't a placeholder. It false-positived on **both** of the repo's own documented examples (case-sensitivity missed `USER:`, and `staging_user` isn't a form the regex knew). That is exactly how the previous hook got removed, so I reverted it rather than tuning a fragile regex.

## Remediation path — Option 1, "rotate and accept"

Per the issue's own framing. These values are in git history; scrubbing the working tree stops it getting worse but does not retract them. History rewriting is **not** done here — the issue says not to without the maintainer explicitly asking, and on a public repo the values may already be mirrored or indexed.

## Also found, filed separately

The review surfaced operator-**network** identifiers in three docs — a home dynamic IP named alongside the ISP, and a `/24` granted SSH in a `ufw` rule. Different category from #544's staging infrastructure, and lower severity (stale, dynamic, no credential value), so filed as **#554** rather than widened into this PR.

## Left open — needs Atlas console access

- [ ] **AC1** — was the 2026-08-26 credential rotation routine, or a response to something? The issue is explicit that nobody should assume the benign answer. This gates whether #544 stays P2 hygiene or escalates.
- [ ] **AC3** — confirm the cluster's network access list still restricts connections to the expected sources.

I can't reach the Atlas console, so **#544 should stay open after this merges** until those two are answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
