### PR TITLE
[#576] fix(ci): retry npm audit when the registry returns a malformed body

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -181,12 +181,29 @@ jobs:
           echo "OK: frontend/package-lock.json is the only npm lockfile."
 
       # npm audit resolves straight from the lockfile — no `npm ci` needed.
+      #
+      # The registry's audit endpoint fails intermittently, and npm reports that
+      # failure as exit 1 — the same code it uses for "vulnerabilities found" — so
+      # the exit status alone cannot tell the two apart. A registry error therefore
+      # slips through and hands audit_gate.py a truncated document, which it
+      # correctly rejects, turning a required check red for no real reason.
+      # Treat "output has no `vulnerabilities` key" as the retry signal instead.
       - name: Run npm audit
         working-directory: frontend
         run: |
-          rc=0
-          npm audit --json > /tmp/npm-audit.json || rc=$?
-          if [ "$rc" -gt 1 ]; then echo "::error::npm audit failed with exit $rc"; exit "$rc"; fi
+          for attempt in 1 2 3; do
+            rc=0
+            npm audit --json > /tmp/npm-audit.json || rc=$?
+            if [ "$rc" -gt 1 ]; then echo "::error::npm audit failed with exit $rc"; exit "$rc"; fi
+            if jq -e 'has("vulnerabilities")' /tmp/npm-audit.json >/dev/null 2>&1; then
+              echo "npm audit returned well-formed output on attempt $attempt"
+              exit 0
+            fi
+            echo "::warning::npm audit output has no 'vulnerabilities' key on attempt $attempt (registry audit endpoint erroring); retrying"
+            sleep $((attempt * 10))
+          done
+          echo "::error::npm audit returned malformed output on 3 consecutive attempts — the registry audit endpoint is failing, not this repo"
+          exit 1
 
       - name: Check advisories against the baseline
         run: |


### PR DESCRIPTION
Closes #576.

## Problem

`npm audit --json` exits **1** for "vulnerabilities found" — the normal, expected outcome — and *also* exits 1 when the registry's audit endpoint errors. The existing guard only caught `rc > 1`:

```bash
rc=0
npm audit --json > /tmp/npm-audit.json || rc=$?
if [ "$rc" -gt 1 ]; then echo "::error::npm audit failed with exit $rc"; exit "$rc"; fi
```

So a registry failure slipped through and handed `scripts/audit_gate.py` an `{"error": ...}` document with no `vulnerabilities` key:

```
npm error audit endpoint returned an error
FAIL — could not read audit output: /tmp/npm-audit.json:
  missing expected key 'vulnerabilities' — audit output looks truncated
```

Hit twice in ~20 minutes on 2026-09-04 while clearing the Dependabot queue (#570, then #563). `Security Audit` is a required check and branch protection is `strict: true`, so a flake there freezes every merge — and reads as "this PR introduced an advisory" when the PR is not involved at all.

## Fix

Retry on the real signal — a response body with no `vulnerabilities` key — instead of on exit status. Three attempts, linear backoff (10s, 20s), then fail loudly naming the registry as the cause.

`audit_gate.py` is **unchanged**. Refusing to report "no vulnerabilities" from a document it could not parse is exactly the right behavior; the defect was the workflow never retrying the network call.

## Verification

The loop logic was exercised directly against a stubbed `npm`, covering all three paths:

| Scenario | Expected | Result |
|---|---|---|
| Registry errors twice, then returns a well-formed body | retries, succeeds on attempt 3 | ✅ exit 0 |
| Registry errors on all 3 attempts | fails, blames the registry | ✅ exit 1 |
| `exit 1` with a well-formed body (ordinary "vulnerabilities found") | treated as success by the step, passed to the gate | ✅ exit 0 |

That last row is the one that matters for not weakening the gate: a real advisory still reaches `audit_gate.py` and still fails the check if it is absent from `security-baseline.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCi3n6oq14mPc24bvHYXDC
