### PR TITLE
ci: guard the two silent-failure modes in reusable-workflow calls

### DIFF
--- a/.github/workflows/check-workflow-calls.yml
+++ b/.github/workflows/check-workflow-calls.yml
@@ -27,8 +27,19 @@ on:
   pull_request:
     paths:
       - ".github/workflows/**"
-  # Also runnable on demand: the PR trigger cannot catch an upstream callee
-  # changing its declared permissions, since no PR here would touch that.
+  # Also on direct pushes to main. A PR-only trigger leaves the gap open: a
+  # workflow edit landing straight on main is never checked, and no later PR
+  # re-checks it unless that PR happens to touch .github/workflows/** — so a
+  # backwards re-pin would be a silent startup_failure on every subsequent PR
+  # with the guard installed and never running. Reports after the fact rather
+  # than blocking, which is still the difference between silence and a red mark.
+  # (Found by the reviewer on the sibling PR, narrative-modeling-app#592.)
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+  # Also runnable on demand: neither trigger catches an upstream callee changing
+  # its declared permissions, since no push or PR here would touch that.
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/check-workflow-calls.yml
+++ b/.github/workflows/check-workflow-calls.yml
@@ -1,0 +1,52 @@
+name: Check workflow calls
+
+# Guards the two ways a reusable-workflow call can be misconfigured such that it
+# never runs and never says so (frankbria/glm-review#9):
+#
+#   1. A calling job granting LESS than the called workflow declares. GitHub
+#      refuses the run before any job exists, so it surfaces as a
+#      `startup_failure` with no log and no annotation naming the missing scope.
+#      Listing a `permissions:` block sets every scope you did NOT list to
+#      `none`, so the denial never appears in the caller's own text.
+#
+#   2. A caller `concurrency:` group that can expand to the same string as the
+#      callee's. The callee joins that group while its parent still holds it and
+#      cancels the parent on queue — a sibling repo had a run end in 2 seconds
+#      having started no jobs at all. The colliding groups there were not
+#      identical text; they merely expanded the same, which is why the checker
+#      compares possible expansions rather than strings.
+#
+# This repo has not hit either — its GLM Review caller is correct today. The
+# guard is here so a future re-pin or an added concurrency block cannot break it
+# silently, which is the failure mode that cost the sibling repo 266 runs.
+#
+# It cannot be a job inside review.yml: in both failures that workflow never
+# starts, so a guard inside it would never run either.
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  # Also runnable on demand: the PR trigger cannot catch an upstream callee
+  # changing its declared permissions, since no PR here would touch that.
+  workflow_dispatch:
+
+jobs:
+  check:
+    uses: frankbria/glm-review/.github/workflows/check-workflow-calls.yml@f3dbf009689671f82e7ccfaabcde112d61b5fd1c # 2026-09-08 (main; no tags upstream)
+    with:
+      # Both extensions, deliberately. GitHub runs `.yml` and `.yaml` alike, so
+      # globbing only `.yml` would leave a silent bypass — a future workflow
+      # named `.yaml` would execute with this repo's credentials while passing a
+      # check that never looked at it. Same reasoning, and the same wording, as
+      # scripts/test_actions_are_sha_pinned.py, which globs both for exactly
+      # this reason. The upstream default covers only `.yml`; overridden here
+      # until that is fixed.
+      paths: .github/workflows/*.yml .github/workflows/*.yaml
+      # Pinned to the same commit as the workflow above: the reusable workflow
+      # and the checker script it runs live in one repo, and leaving the script
+      # tracking `main` while the workflow is pinned reintroduces exactly the
+      # pin-vs-content drift this guard exists to catch.
+      guard_ref: f3dbf009689671f82e7ccfaabcde112d61b5fd1c
+    permissions:
+      contents: read


### PR DESCRIPTION
Installs [frankbria/glm-review](https://github.com/frankbria/glm-review)'s workflow-call guard, merged upstream as `f3dbf00`.

**This repo has not hit either failure** — its GLM Review caller is correct today. This is preventive: a future re-pin or an added `concurrency:` block should not be able to break the reviewer *silently*, which is how sibling repo `narrative-modeling-app` lost **266 consecutive runs** over two months while looking configured the whole time.

## The two invariants

**1. A calling job granting less than the called workflow declares.** GitHub refuses the run *before any job exists*, so it is a `startup_failure` with no log and no annotation naming the missing scope. The reason it stays hidden: **listing a `permissions:` block sets every scope you did not list to `none`**, so the denial never appears in the caller's own text.

**2. A caller `concurrency:` group that can expand to the same string as the callee's.** The callee joins that group while its parent still holds it and cancels the parent on queue — the sibling repo had a run end in **2 seconds** having started no jobs at all. The colliding groups were not identical text:

```
caller:  glm-review-${{ github.event.pull_request.number }}
callee:  glm-review-${{ github.event.pull_request.number || github.ref }}
```

They merely expand the same, because `||` yields its first truthy operand. The checker compares the sets of strings each group can expand to, not the strings themselves.

## Two configuration choices worth reading

**`paths` overrides the upstream default to cover both `.yml` and `.yaml`** — and the reasoning is this repo's own, borrowed. `scripts/test_actions_are_sha_pinned.py` globs both extensions with the comment that globbing one leaves *"a silent bypass: a future workflow named `.yaml` executes with the repo's credentials while passing a check that never looked at it."* That argument applies verbatim to this guard. The upstream default currently covers only `.yml`, which is a real gap I found by reading that script; I am overriding it here rather than blocking this on an upstream fix, and will fix the default separately.

**`guard_ref` is pinned to the same commit as the workflow.** The reusable workflow and the checker script it runs live in one repo; leaving the script tracking `main` while the workflow is pinned reintroduces exactly the pin-vs-content drift this guard exists to catch.

## Verification

- **This repo's own pinning policy passes.** `scripts/test_actions_are_sha_pinned.py` — 22 tests — accepts the new pin and its version comment. The comment format is not cosmetic here: that check requires `#\s*v?\d`, so `# 2026-09-08 (main; no tags upstream)` matches where a `# main @ …` form would have failed.
- **The checker reports this repo clean**, all seven active workflow files, with every callee resolved rather than skipped:

  ```
  OK: 7 file(s) checked — every reusable-workflow call grants the scopes its
  callee declares, and no concurrency group can collide with its callee's.
  ```

  That `OK` is meaningful rather than vacuous — the checker refuses to print it when any call went unverified, and reports the count instead.

- **The guard workflow is already proven in a live run.** Its first real execution was on [narrative-modeling-app#592](https://github.com/frankbria/narrative-modeling-app/pull/592): green in 10 seconds, with the log confirming it enumerated every workflow file and resolved both reusable-workflow calls at their pinned refs over the network — not a silent no-op.

## One behaviour worth knowing

A private callee the token cannot read now **fails** the guard rather than passing silently, since a call the checker could not verify must not be reported as OK. Every callee here is public, so it does not bite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdSq9dMfiLL12RHcmcPER7

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdSq9dMfiLL12RHcmcPER7)_