### PR TITLE
chore(security): prune 42 resolved advisories from the audit baseline (#647)

### DIFF
--- a/security-baseline.json
+++ b/security-baseline.json
@@ -1,50 +1,7 @@
 {
-  "_comment": "Known-and-accepted advisories as of #342. CI fails on anything NOT listed here, so this file is the repo's dependency-debt ledger, not an ignore-list to grow casually. Shrink it: each entry names its package and fix version. Regenerate wholesale with: python scripts/audit_gate.py --pip-audit <json> --npm-audit <json> --baseline security-baseline.json --write-baseline",
+  "_comment": "Known-and-accepted advisories. CI fails on anything NOT listed here, so this file is the repo's dependency-debt ledger, not an ignore-list to grow casually. Shrink it: each entry names its package and fix version. Started at 91 entries (#342); pruned to 1 in #647 once the tree caught up — a fixed advisory left ledgered here silently absorbs the NEXT advisory on the same package, so prune whatever the gate reports under 'Resolved'. Regenerate wholesale with: python scripts/audit_gate.py --pip-audit <json> --npm-audit <json> --baseline security-baseline.json --write-baseline",
   "pypi": {
-    "PYSEC-2026-2132": "click; fix: 8.3.3",
-    "PYSEC-2026-2270": "python-dotenv; fix: 1.2.2"
+    "PYSEC-2026-2132": "click; fix: 8.3.3"
   },
-  "npm": {
-    "GHSA-23c5-xmqv-rm74": "minimatch; fix: yes",
-    "GHSA-25h7-pfq9-p65f": "flatted; fix: yes",
-    "GHSA-267c-6grr-h53f": "next; fix: yes",
-    "GHSA-26hh-7cqf-hhc6": "next; fix: yes",
-    "GHSA-2w6w-674q-4c4q": "handlebars; fix: yes",
-    "GHSA-36qx-fr4f-26g5": "next; fix: yes",
-    "GHSA-392p-2q2v-4372": "better-auth; fix: yes",
-    "GHSA-3mfm-83xf-c92r": "handlebars; fix: yes",
-    "GHSA-3ppc-4f35-3m26": "minimatch; fix: yes",
-    "GHSA-492v-c6pp-mqqv": "next; fix: yes",
-    "GHSA-6g55-p6wh-862q": "postcss; fix: yes",
-    "GHSA-737v-mqg7-c878": "defu; fix: yes",
-    "GHSA-7r86-cg39-jmmj": "minimatch; fix: yes",
-    "GHSA-7w99-5wm4-3g79": "better-auth; fix: yes",
-    "GHSA-86j7-9j95-vpqj": "better-auth; fix: yes",
-    "GHSA-89xv-2m56-2m9x": "next; fix: yes",
-    "GHSA-8cpq-38p9-67gx": "kysely; fix: yes",
-    "GHSA-8h8q-6873-q5fj": "next; fix: yes",
-    "GHSA-96hv-2xvq-fx4p": "ws; fix: yes",
-    "GHSA-9cx6-37pm-9jff": "handlebars; fix: yes",
-    "GHSA-9h47-pqcx-hjr4": "better-auth; fix: yes",
-    "GHSA-c2c7-rcm5-vvqj": "picomatch; fix: yes",
-    "GHSA-c4j6-fc7j-m34r": "next; fix: yes",
-    "GHSA-f88m-g3jw-g9cj": "sharp; fix: yes",
-    "GHSA-fmh4-wcc4-5jm3": "better-auth; fix: yes",
-    "GHSA-g38m-r43w-p2q7": "better-auth; fix: yes",
-    "GHSA-h25m-26qc-wcjf": "next; fix: yes",
-    "GHSA-hmw2-7cc7-3qxx": "form-data; fix: yes",
-    "GHSA-m99w-x7hq-7vfj": "next; fix: yes",
-    "GHSA-mg66-mrh9-m8jx": "next; fix: yes",
-    "GHSA-p6v2-xcpg-h6xw": "better-auth; fix: yes",
-    "GHSA-p9j2-gv94-2wf4": "next; fix: yes",
-    "GHSA-pv5w-4p9q-p3v2": "kysely; fix: yes",
-    "GHSA-pw9m-5jxm-xr6h": "better-auth; fix: yes",
-    "GHSA-q4gf-8mx6-v5v3": "next; fix: yes",
-    "GHSA-qq9h-g4jm-xgf3": "better-auth; fix: yes",
-    "GHSA-r28c-9q8g-f849": "postcss; fix: yes",
-    "GHSA-rf6f-7fwh-wjgh": "flatted; fix: yes",
-    "GHSA-wmrf-hv6w-mr66": "kysely; fix: yes",
-    "GHSA-xhpv-hc6g-r9c6": "handlebars; fix: yes",
-    "GHSA-xjpj-3mr7-gcpf": "handlebars; fix: yes"
-  }
+  "npm": {}
 }


### PR DESCRIPTION
Closes #647.

## What

Prunes **42 of 43** entries from `security-baseline.json`. All 41 npm entries and one pypi entry ledger advisories the tree no longer carries. Only `PYSEC-2026-2132` (click, fix: 8.3.3) is still live.

## Why a stale entry is worse than no entry

The baseline is an allowlist: `scripts/audit_gate.py` fails CI on any advisory **not** listed. An entry for an advisory that is already fixed suppresses nothing today — which is exactly why it is easy to leave in place, and exactly what makes it a trap. It stays armed to absorb the **next** occurrence of that advisory ID instead of failing the build.

`GHSA-c2c7-rcm5-vvqj` (picomatch) is the case that surfaced this. #648 patched every vulnerable copy in the tree; the baseline entry stayed behind. Had picomatch regressed — a lockfile revert, a resolution change, a transitive pulling an old copy back — CI would have gone green on a live high-severity ReDoS advisory.

## Evidence, measured not assumed

`npm audit` in `frontend/` (same invocation CI uses — from the lockfile, no `--omit=dev`, 1102 deps resolved):

```
{'info': 0, 'low': 0, 'moderate': 0, 'high': 0, 'critical': 0, 'total': 0}
```

`pip-audit` on the `--no-dev` export, as CI runs it: one live advisory, `PYSEC-2026-2132` (click). `PYSEC-2026-2270` (python-dotenv) is fixed.

The gate itself had been reporting all 42 under its own **"Resolved — prune these from the baseline"** heading. This PR acts on that output; it adds no new machinery. Notably, that reporting path exists because a #342 test anticipated precisely this day — it pins that `evaluate()` must take scanned ecosystems explicitly, since inferring them "would strand 53 dead entries on the happy day an ecosystem goes fully clean."

## Mutation verification

The point of this PR is that the gate still has teeth afterwards, so both directions were run rather than asserted:

| | Lockfile | Baseline | Gate | Meaning |
|---|---|---|---|---|
| **A** | picomatch reverted to 2.3.1 / 4.0.3 | **pruned (this PR)** | **exit 1**, names `GHSA-c2c7-rcm5-vvqj  picomatch  severity=high` | the gate catches the regression |
| **B** | same vulnerable lockfile | **old (main)** | **exit 0**, "no new advisories" | the stale entry *was* suppressing a live high advisory |

B is the one that matters: it is a working demonstration of the trap, not a hypothesis about it. Same tree, same advisory, opposite verdicts — the only variable is the line this PR deletes.

The mutation was reverted with `git checkout HEAD --` and the revert asserted with `git diff --quiet HEAD --` (a stale `.git/index.lock` silently no-ops checkouts and lets mutations accumulate unnoticed; checked for one first — none present). Working tree verified clean afterwards.

## Also answered: does the gate see moderate advisories?

#647 flagged that `GHSA-3v7f-55p6-f55p` (moderate, picomatch) was never baselined yet the gate passed while it was live — raising whether the gate silently skips moderates.

It does, **by design**: `--min-severity` defaults to `high` and the workflow does not override it. That is documented in the script and deliberate, not a hole — so no follow-up issue. Worth knowing explicitly, though: **a moderate advisory will never fail this gate**, whatever the baseline says.

## Not in scope

- **click `PYSEC-2026-2132` is retained and still live** — a fix exists (8.3.3). Bumping it is a backend dependency change with its own test surface, deliberately not widened into a baseline-hygiene PR.
- `pip-audit` runs `--no-dev`, so advisories in test/dev extras never reach the gate. Pre-existing, tracked in #522.

## Verification

- `python scripts/audit_gate.py --pip-audit … --npm-audit … --baseline security-baseline.json` → `PASS — no new advisories (1 known, already in the baseline)`, and the "Resolved" section is now empty
- `uvx --with pytest --with pyyaml pytest scripts/ -q` → **77 passed, 4 skipped** (the gate's own 29-test suite runs inside the audit job, so the guard is itself guarded)
- Both mutations above
- Required checks on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTVWYAbSGs8j2Bimzw74Yo
