### PR TITLE
chore(claude): quartermaster workspace config — live-rules, seeded permissions

### DIFF
--- a/.claude/live-rules/manifest.json
+++ b/.claude/live-rules/manifest.json
@@ -1,0 +1,60 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "path": "rules/reuse-first.md",
+      "hash": "c8db2b1620b1f74e5060bcd3b1987e2b5e722c67313c2c972dcf1025019ba0f7",
+      "description": "Reuse-first implementation",
+      "globs": [],
+      "dirs": [],
+      "prompt": [],
+      "priority": 90,
+      "enabled": true,
+      "include": []
+    },
+    {
+      "path": "rules/self-improvement.md",
+      "hash": "736a16a05138c67f1863053e00dce33742475102580779da4846fb27996cd2f6",
+      "description": "Self-improvement: build the capability that makes the next goal cheaper",
+      "globs": [],
+      "dirs": [],
+      "prompt": [],
+      "priority": 40,
+      "enabled": true,
+      "include": []
+    },
+    {
+      "path": "rules/static-guard-invariants.md",
+      "hash": "01d35644cb8838761a2488935269dd831a1b2d0d865cdcda4fc424a479230ca9",
+      "description": "Static theme/contrast guards \u2014 what makes one real instead of decorative",
+      "globs": [
+        "frontend/src/__tests__/theme/**",
+        "frontend/*baseline*.json",
+        "frontend/src/app/globals.css",
+        "frontend/tailwind.config.js"
+      ],
+      "dirs": [],
+      "prompt": [],
+      "priority": 65,
+      "enabled": true,
+      "include": []
+    },
+    {
+      "path": "rules/verified-reverts.md",
+      "hash": "78738d0e1a97c3afb104636614957feef34f24767454ef99b75c888e6d739425",
+      "description": "Mutation checks and reverts that actually revert",
+      "globs": [],
+      "dirs": [],
+      "prompt": [
+        "mutation",
+        "mutate",
+        "revert",
+        "verify the guard",
+        "mutation-check"
+      ],
+      "priority": 70,
+      "enabled": true,
+      "include": []
+    }
+  ]
+}

--- a/.claude/live-rules/rules/reuse-first.md
+++ b/.claude/live-rules/rules/reuse-first.md
@@ -1,0 +1,21 @@
+---
+description: Reuse-first implementation
+priority: 90
+---
+This repo is a Next.js frontend and a FastAPI backend over MongoDB, with a large existing surface of
+guards, helpers and idioms. Before adding anything, trace how the existing pieces already cover the
+case: a helper in `frontend/src/__tests__/theme/helpers/`, an established class idiom, an existing
+DAO in `backend/app/db/`, a ledger file, or a skill already in the workflow.
+
+Prefer deleting or tightening over adding. Fix the smallest shared root cause rather than patching
+each call site. Keep input validation at trust boundaries and the auth, ownership and data-loss
+safeguards regardless of how small the change looks.
+
+Two repo-specific traps worth naming, both of which have shipped bugs here:
+- A new guard that duplicates an existing sweep will disagree with it, and the file that falls into
+  the gap is the one that ships the defect. Extend the existing guard or share its helper.
+- Removing a thing also removes its tripwire. Before deleting a file because "script X reads it",
+  run X.
+
+Files under 500 lines. Never hardcode secrets, host IPs, SSH users or cluster hostnames anywhere in
+the repo, an issue, a PR or a commit — several of these repos are public.

--- a/.claude/live-rules/rules/self-improvement.md
+++ b/.claude/live-rules/rules/self-improvement.md
@@ -1,0 +1,19 @@
+---
+description: 'Self-improvement: build the capability that makes the next goal cheaper'
+priority: 40
+---
+At a natural pause, assess whether a concrete weakness earns an improvement. Keep what works; do not
+change the workspace for novelty. The orchestrator decides the benefit, approach, and boundaries before
+implementation. Focused research may return facts or bounded alternatives when an unknown could change that
+decision; do not investigate unrequested optimizations by default. First check whether the
+existing project, standard library, native platform, installed plugins, skills, rules, or instruments
+already cover it. Improve the installed capability before proposing a parallel one. Offer
+`/quartermaster:resupply` only with current or standing user approval; every recommended change still
+needs its own approval unless that exact class is covered by standing permission.
+- **A claim you couldn't check** (is it correct? fast enough? complete?) may need a measurement.
+  First check whether an existing instrument can answer it or can be improved. Build a new measurement
+  only when it is the smallest durable missing capability.
+- **A multi-step task you did by hand** may belong in a skill (build it with skill-creator).
+- **Something you re-derived or re-explored** may belong in a codebase map doc or a CLAUDE.md line.
+- **A convention you had to be told** may belong in a tightly-scoped live rule.
+Keep it to one evidenced improvement. If existing capabilities hold up, say so explicitly.

--- a/.claude/live-rules/rules/static-guard-invariants.md
+++ b/.claude/live-rules/rules/static-guard-invariants.md
@@ -1,0 +1,41 @@
+---
+description: Static theme/contrast guards — what makes one real instead of decorative
+globs: ["frontend/src/__tests__/theme/**", "frontend/*baseline*.json", "frontend/src/app/globals.css", "frontend/tailwind.config.js"]
+priority: 65
+---
+Every rule here is a defect this repo actually shipped, not a style preference.
+
+**Build the sweep first and let it produce the count.** Never trust a count from an issue body or a
+hand-written list. #632's issue title said 19, its own table summed to 14, the sweep found 18;
+#637's said 27, the sweep found 30. The misses are systematic: a hand-written grep for an
+"unprefixed" class cannot match `group-[.toast]:` or `hover:`, and an import walk silently omits the
+file nobody registered.
+
+**Measure the ratio; never quote one.** A contrast figure without the surface it was taken against is
+not a measurement. Re-derive it from `globals.css` tokens and the palette using
+`__tests__/theme/helpers/contrast.ts`. Two wrong numbers shipped by copying them out of an issue.
+
+**Confirm which declaration the utility actually resolves to.** `text-primary` is `tailwind.config.js`'s
+brand indigo plus a `.dark .text-primary` override in `globals.css` — not the `--primary` token, which
+feeds only the v4-only `@theme` block that v3 ignores. #634 published 16.39/1.15 for a colour that
+never renders. Check `tailwind.config.js` and any `@layer utilities` before pricing a class.
+
+**Ledger per distinct value, never a per-file total.** A single total lets a net-zero swap through:
+drop one `text-gray-500`, add one `text-gray-300`, count unchanged. Pair it with a stale-row assertion
+so a burned-down row fails instead of silently pre-authorising the class, and an explicit vacuity
+assertion on the sweep's input set (`sources.length > 150`).
+
+**A guard scans the tree, and must exclude itself.** Once tracked, a repo-scanning guard matches the
+pattern literal in its own doc comment — passing its first run while untracked, then going vacuous.
+
+**Mutation-check in both directions.** A guard that only fails when broken proves nothing about what it
+accepts. Show it failing on the regression *and* passing on the correct idiom. Scope the predicate to
+the smallest unit that can't pool: same property, same hue, same state, same class run — asking "is
+there *a* dark class nearby?" instead of "does one replace *this* one, where it paints" produced three
+separate false greens in #637 alone.
+
+**axe is not evidence here.** Its `color-contrast` rule does not evaluate non-text elements at all, so
+icons, rings, dots and borders come back clean while failing 1.4.11.
+
+`npm run typecheck` never sees any of this — `tsconfig` excludes `**/__tests__/**` and `**/e2e/**`.
+Run `tsc` directly on a test file before citing it as green (#625).

--- a/.claude/live-rules/rules/verified-reverts.md
+++ b/.claude/live-rules/rules/verified-reverts.md
@@ -1,0 +1,34 @@
+---
+description: Mutation checks and reverts that actually revert
+priority: 70
+prompt: ["mutation", "mutate", "revert", "verify the guard", "mutation-check"]
+---
+Commit before mutating. A `git checkout` revert discards uncommitted work, so an unstaged change made
+just before a mutation check is gone. A **brand-new file has nothing to revert to** — `git checkout HEAD --`
+on it silently does nothing and the mutation persists into the next check.
+
+Before any `git reset --hard`, `git checkout --` or `git clean`, read `git status` as a list of things
+about to be lost, not as noise. The likeliest casualty is a file changed hours ago for an unrelated
+reason, because it has stopped registering as work in progress. Fix a branch mix-up with the narrowest
+tool — `git branch <name>` and switch away — rather than resetting a tree that may be carrying
+something else.
+
+Check for a stale `.git/index.lock` first, and assert every revert:
+
+```sh
+[ -e .git/index.lock ] && rm -f .git/index.lock   # only when no git process is actually running
+git checkout HEAD -- <paths>
+git diff --quiet HEAD -- <paths> || { echo "REVERT FAILED"; exit 1; }
+```
+
+A leftover lock silently no-ops every `checkout` and `commit`: reverts stop reverting, mutations pile
+up on each other, and the results of every later check become meaningless. It is not hypothetical —
+it has occurred repeatedly in this repo, and only the assertion caught it. Confirm no git process is
+genuinely running before removing a lock (a 0-byte lock with no `git` in `ps` is stale).
+
+For a group PR or any branch cut from a main that has since had commits squash-merged, rebasing will
+try to replay the pre-squash commits. Rebuild the branch from `origin/main` and cherry-pick your own
+commits instead of fighting the conflicts.
+
+State mutation results honestly: "guard PASSED under mutation" is a finding about the guard, not a
+step to retry until it goes green.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,33 +1,52 @@
 {
-  "env": {
-    "CLAUDE_FLOW_AUTO_COMMIT": "false",
-    "CLAUDE_FLOW_AUTO_PUSH": "false",
-    "CLAUDE_FLOW_HOOKS_ENABLED": "true",
-    "CLAUDE_FLOW_TELEMETRY_ENABLED": "true",
-    "CLAUDE_FLOW_REMOTE_EXECUTION": "true",
-    "CLAUDE_FLOW_CHECKPOINTS_ENABLED": "true"
-  },
   "permissions": {
     "allow": [
-      "Bash(npm run lint)",
-      "Bash(npm run test:*)",
-      "Bash(npm test :*)",
-      "Bash(git status)",
-      "Bash(git diff :*)",
-      "Bash(git log :*)",
+      "Bash(cat:*)",
+      "Bash(comm:*)",
+      "Bash(diff:*)",
+      "Bash(find:*)",
+      "Bash(gh api /advisories*)",
+      "Bash(gh api /repos/*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run view:*)",
       "Bash(git add :*)",
-      "Bash(git commit :*)",
-      "Bash(git push)",
-      "Bash(git config :*)",
-      "Bash(git tag :*)",
       "Bash(git branch :*)",
       "Bash(git checkout :*)",
+      "Bash(git commit :*)",
+      "Bash(git config :*)",
+      "Bash(git diff :*)",
+      "Bash(git log :*)",
+      "Bash(git push)",
       "Bash(git stash :*)",
+      "Bash(git status)",
+      "Bash(git tag :*)",
+      "Bash(grep:*)",
+      "Bash(head:*)",
       "Bash(jq :*)",
+      "Bash(ls :*)",
       "Bash(node :*)",
-      "Bash(which :*)",
+      "Bash(npm run lint)",
+      "Bash(npm run lint:*)",
+      "Bash(npm run test:*)",
+      "Bash(npm run typecheck:*)",
+      "Bash(npm test :*)",
+      "Bash(npx eslint:*)",
+      "Bash(npx jest:*)",
+      "Bash(npx tsc:*)",
       "Bash(pwd)",
-      "Bash(ls :*)"
+      "Bash(sed -n:*)",
+      "Bash(tail:*)",
+      "Bash(uv export:*)",
+      "Bash(uv run pytest:*)",
+      "Bash(uv run ruff:*)",
+      "Bash(wc:*)",
+      "Bash(which :*)"
     ],
     "deny": [
       "Bash(rm -rf /)",
@@ -35,5 +54,7 @@
     ]
   },
   "includeCoAuthoredBy": true,
-  "enabledMcpjsonServers": ["ruv-swarm"]
+  "enabledPlugins": {
+    "live-rules@eigenwise-toolshed": true
+  }
 }


### PR DESCRIPTION
From `/quartermaster:setup` earlier in this session.

**Committed rather than left in the working tree** because I destroyed it twice with `git reset --hard` while tidying branches — the second time from a cleanup line baked into a rebase helper I reused, so it fired without my reconsidering it. Leaving workspace config pending review in a tree I keep running destructive git commands against was the wrong call; a PR is reviewable *and* durable.

## What's here

`live-rules@eigenwise-toolshed` at project scope, with four rules:

| rule | scope | why |
|---|---|---|
| `static-guard-invariants` | globs on `__tests__/theme/**`, `*baseline*.json`, `globals.css`, `tailwind.config.js` | Eight invariants, **every one a defect this repo shipped** — build the sweep rather than trust a count (#620/#632/#637), never quote an unmeasured ratio, confirm which declaration a utility resolves to (#634), ledger per distinct value, guards must exclude themselves, mutate both directions, axe cannot see non-text, run `tsc` directly (#625) |
| `verified-reverts` | prompt-triggered | Commit before mutating; a new file has nothing to revert to; read `git status` before any `reset --hard` as a list of things about to be lost. Strengthened after it caught me three times — and then I broke it twice more |
| `reuse-first` | global | Adapted to this stack |
| `self-improvement` | global | The standard loop |

**27 permissions seeded** from measured command frequency across 45 days — `gh pr/issue/run` read subcommands, `uv run pytest/ruff`, text tools. Deliberately **excludes** `gh pr merge`, `gh api -X DELETE/POST/PUT` and all `ssh`/`scp`: the only genuine permission denials in that window were `gh api -X D...` and staging SSH, both correctly gated. (That exclusion proved itself later — the gate refused my `DATABASE_NAME` secret deletion in #520.)

**Removed**: six `CLAUDE_FLOW_*` env vars and the `ruv-swarm` MCP enablement. Zero MCP attribution across 25 projects in 45 days, and no claude-flow usage anywhere in the mining.

## Not verified

Needs `/reload-plugins` before live-rules actually injects. I have confirmed the files are written and their manifest hashes match, nothing more — "installed" is not "working", and I am not claiming the latter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTVWYAbSGs8j2Bimzw74Yo